### PR TITLE
copy-paste ninja fix to missing end line problem

### DIFF
--- a/bytecode/bytecode_015d36d.cpp
+++ b/bytecode/bytecode_015d36d.cpp
@@ -612,6 +612,13 @@ Error GDScriptDecomp_015d36d::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_054a2ac.cpp
+++ b/bytecode/bytecode_054a2ac.cpp
@@ -623,6 +623,13 @@ Error GDScriptDecomp_054a2ac::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_0b806ee.cpp
+++ b/bytecode/bytecode_0b806ee.cpp
@@ -523,6 +523,13 @@ Error GDScriptDecomp_0b806ee::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_1a36141.cpp
+++ b/bytecode/bytecode_1a36141.cpp
@@ -648,6 +648,13 @@ Error GDScriptDecomp_1a36141::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_1add52b.cpp
+++ b/bytecode/bytecode_1add52b.cpp
@@ -579,6 +579,13 @@ Error GDScriptDecomp_1add52b::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_1ca61a3.cpp
+++ b/bytecode/bytecode_1ca61a3.cpp
@@ -660,6 +660,13 @@ Error GDScriptDecomp_1ca61a3::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_216a8aa.cpp
+++ b/bytecode/bytecode_216a8aa.cpp
@@ -617,6 +617,13 @@ Error GDScriptDecomp_216a8aa::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_2185c01.cpp
+++ b/bytecode/bytecode_2185c01.cpp
@@ -540,6 +540,13 @@ Error GDScriptDecomp_2185c01::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_23381a5.cpp
+++ b/bytecode/bytecode_23381a5.cpp
@@ -585,6 +585,13 @@ Error GDScriptDecomp_23381a5::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_23441ec.cpp
+++ b/bytecode/bytecode_23441ec.cpp
@@ -562,6 +562,13 @@ Error GDScriptDecomp_23441ec::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_30c1229.cpp
+++ b/bytecode/bytecode_30c1229.cpp
@@ -551,6 +551,13 @@ Error GDScriptDecomp_30c1229::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_31ce3c5.cpp
+++ b/bytecode/bytecode_31ce3c5.cpp
@@ -525,6 +525,13 @@ Error GDScriptDecomp_31ce3c5::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_3ea6d9f.cpp
+++ b/bytecode/bytecode_3ea6d9f.cpp
@@ -626,6 +626,13 @@ Error GDScriptDecomp_3ea6d9f::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_48f1d02.cpp
+++ b/bytecode/bytecode_48f1d02.cpp
@@ -547,6 +547,13 @@ Error GDScriptDecomp_48f1d02::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_4ee82a2.cpp
+++ b/bytecode/bytecode_4ee82a2.cpp
@@ -583,6 +583,13 @@ Error GDScriptDecomp_4ee82a2::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_513c026.cpp
+++ b/bytecode/bytecode_513c026.cpp
@@ -584,6 +584,13 @@ Error GDScriptDecomp_513c026::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_514a3fb.cpp
+++ b/bytecode/bytecode_514a3fb.cpp
@@ -649,6 +649,13 @@ Error GDScriptDecomp_514a3fb::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_5e938f0.cpp
+++ b/bytecode/bytecode_5e938f0.cpp
@@ -608,6 +608,13 @@ Error GDScriptDecomp_5e938f0::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_6174585.cpp
+++ b/bytecode/bytecode_6174585.cpp
@@ -560,6 +560,13 @@ Error GDScriptDecomp_6174585::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_620ec47.cpp
+++ b/bytecode/bytecode_620ec47.cpp
@@ -652,6 +652,13 @@ Error GDScriptDecomp_620ec47::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_62273e5.cpp
+++ b/bytecode/bytecode_62273e5.cpp
@@ -592,6 +592,13 @@ Error GDScriptDecomp_62273e5::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_64872ca.cpp
+++ b/bytecode/bytecode_64872ca.cpp
@@ -556,6 +556,13 @@ Error GDScriptDecomp_64872ca::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_65d48d6.cpp
+++ b/bytecode/bytecode_65d48d6.cpp
@@ -543,6 +543,13 @@ Error GDScriptDecomp_65d48d6::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_703004f.cpp
+++ b/bytecode/bytecode_703004f.cpp
@@ -526,6 +526,13 @@ Error GDScriptDecomp_703004f::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_7124599.cpp
+++ b/bytecode/bytecode_7124599.cpp
@@ -563,6 +563,13 @@ Error GDScriptDecomp_7124599::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_7d2d144.cpp
+++ b/bytecode/bytecode_7d2d144.cpp
@@ -555,6 +555,13 @@ Error GDScriptDecomp_7d2d144::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_7f7d97f.cpp
+++ b/bytecode/bytecode_7f7d97f.cpp
@@ -651,6 +651,13 @@ Error GDScriptDecomp_7f7d97f::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_85585c7.cpp
+++ b/bytecode/bytecode_85585c7.cpp
@@ -564,6 +564,13 @@ Error GDScriptDecomp_85585c7::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_8aab9a0.cpp
+++ b/bytecode/bytecode_8aab9a0.cpp
@@ -654,6 +654,13 @@ Error GDScriptDecomp_8aab9a0::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_8b912d1.cpp
+++ b/bytecode/bytecode_8b912d1.cpp
@@ -589,6 +589,13 @@ Error GDScriptDecomp_8b912d1::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_8c1731b.cpp
+++ b/bytecode/bytecode_8c1731b.cpp
@@ -524,6 +524,13 @@ Error GDScriptDecomp_8c1731b::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_8cab401.cpp
+++ b/bytecode/bytecode_8cab401.cpp
@@ -530,6 +530,13 @@ Error GDScriptDecomp_8cab401::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_8e35d93.cpp
+++ b/bytecode/bytecode_8e35d93.cpp
@@ -638,6 +638,13 @@ Error GDScriptDecomp_8e35d93::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_91ca725.cpp
+++ b/bytecode/bytecode_91ca725.cpp
@@ -621,6 +621,13 @@ Error GDScriptDecomp_91ca725::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_97f34a1.cpp
+++ b/bytecode/bytecode_97f34a1.cpp
@@ -542,6 +542,13 @@ Error GDScriptDecomp_97f34a1::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_a3f1ee5.cpp
+++ b/bytecode/bytecode_a3f1ee5.cpp
@@ -642,6 +642,13 @@ Error GDScriptDecomp_a3f1ee5::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_a56d6ff.cpp
+++ b/bytecode/bytecode_a56d6ff.cpp
@@ -625,6 +625,13 @@ Error GDScriptDecomp_a56d6ff::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_be46be7.cpp
+++ b/bytecode/bytecode_be46be7.cpp
@@ -542,6 +542,13 @@ Error GDScriptDecomp_be46be7::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_c24c739.cpp
+++ b/bytecode/bytecode_c24c739.cpp
@@ -600,6 +600,13 @@ Error GDScriptDecomp_c24c739::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_c6120e7.cpp
+++ b/bytecode/bytecode_c6120e7.cpp
@@ -613,6 +613,13 @@ Error GDScriptDecomp_c6120e7::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_d28da86.cpp
+++ b/bytecode/bytecode_d28da86.cpp
@@ -615,6 +615,13 @@ Error GDScriptDecomp_d28da86::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_d6b31da.cpp
+++ b/bytecode/bytecode_d6b31da.cpp
@@ -658,6 +658,13 @@ Error GDScriptDecomp_d6b31da::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_e82dc40.cpp
+++ b/bytecode/bytecode_e82dc40.cpp
@@ -534,6 +534,13 @@ Error GDScriptDecomp_e82dc40::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_ed80f45.cpp
+++ b/bytecode/bytecode_ed80f45.cpp
@@ -568,6 +568,13 @@ Error GDScriptDecomp_ed80f45::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_f8a7c46.cpp
+++ b/bytecode/bytecode_f8a7c46.cpp
@@ -596,6 +596,13 @@ Error GDScriptDecomp_f8a7c46::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;

--- a/bytecode/bytecode_ff1e7cf.cpp
+++ b/bytecode/bytecode_ff1e7cf.cpp
@@ -624,6 +624,13 @@ Error GDScriptDecomp_ff1e7cf::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
+	if (!line.empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
 	if (script_text == String()) {
 		error_message = RTR("Invalid token");
 		return ERR_INVALID_DATA;


### PR DESCRIPTION
Sorry, this fix is questionable quality. On other hand it seems to fix last line problem could be found in some scripts. 

At first I was thinking of adding NEWLINE token to the end of the token vector, but it seems that this newline could be different between versions and it's requiring moving enum to header. 