### PR TITLE
call _ensure_space before "is " token

### DIFF
--- a/bytecode/bytecode_015d36d.cpp
+++ b/bytecode/bytecode_015d36d.cpp
@@ -486,6 +486,7 @@ Error GDScriptDecomp_015d36d::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_054a2ac.cpp
+++ b/bytecode/bytecode_054a2ac.cpp
@@ -494,6 +494,7 @@ Error GDScriptDecomp_054a2ac::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_1a36141.cpp
+++ b/bytecode/bytecode_1a36141.cpp
@@ -498,6 +498,7 @@ Error GDScriptDecomp_1a36141::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_1ca61a3.cpp
+++ b/bytecode/bytecode_1ca61a3.cpp
@@ -510,6 +510,7 @@ Error GDScriptDecomp_1ca61a3::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_216a8aa.cpp
+++ b/bytecode/bytecode_216a8aa.cpp
@@ -491,6 +491,7 @@ Error GDScriptDecomp_216a8aa::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_3ea6d9f.cpp
+++ b/bytecode/bytecode_3ea6d9f.cpp
@@ -497,6 +497,7 @@ Error GDScriptDecomp_3ea6d9f::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_514a3fb.cpp
+++ b/bytecode/bytecode_514a3fb.cpp
@@ -499,6 +499,7 @@ Error GDScriptDecomp_514a3fb::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_620ec47.cpp
+++ b/bytecode/bytecode_620ec47.cpp
@@ -502,6 +502,7 @@ Error GDScriptDecomp_620ec47::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_7f7d97f.cpp
+++ b/bytecode/bytecode_7f7d97f.cpp
@@ -501,6 +501,7 @@ Error GDScriptDecomp_7f7d97f::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_8aab9a0.cpp
+++ b/bytecode/bytecode_8aab9a0.cpp
@@ -507,6 +507,7 @@ Error GDScriptDecomp_8aab9a0::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_8e35d93.cpp
+++ b/bytecode/bytecode_8e35d93.cpp
@@ -500,6 +500,7 @@ Error GDScriptDecomp_8e35d93::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_91ca725.cpp
+++ b/bytecode/bytecode_91ca725.cpp
@@ -492,6 +492,7 @@ Error GDScriptDecomp_91ca725::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_a3f1ee5.cpp
+++ b/bytecode/bytecode_a3f1ee5.cpp
@@ -504,6 +504,7 @@ Error GDScriptDecomp_a3f1ee5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_a56d6ff.cpp
+++ b/bytecode/bytecode_a56d6ff.cpp
@@ -496,6 +496,7 @@ Error GDScriptDecomp_a56d6ff::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_c6120e7.cpp
+++ b/bytecode/bytecode_c6120e7.cpp
@@ -487,6 +487,7 @@ Error GDScriptDecomp_c6120e7::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_d28da86.cpp
+++ b/bytecode/bytecode_d28da86.cpp
@@ -489,6 +489,7 @@ Error GDScriptDecomp_d28da86::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_d6b31da.cpp
+++ b/bytecode/bytecode_d6b31da.cpp
@@ -508,6 +508,7 @@ Error GDScriptDecomp_d6b31da::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_ff1e7cf.cpp
+++ b/bytecode/bytecode_ff1e7cf.cpp
@@ -495,6 +495,7 @@ Error GDScriptDecomp_ff1e7cf::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {
+				_ensure_space(line);
 				line += "is ";
 			} break;
 			case TK_PR_ONREADY: {


### PR DESCRIPTION
occasionally decompiled code looks like `if eventis InputEventKey:`, but original code looks like
`if event is InputEventKey:`

This commit fixes missing space before `is` keyword