### PR TITLE
Update 4.0 API to current master, fix string constant newlines

### DIFF
--- a/bytecode/bytecode_015d36d.cpp
+++ b/bytecode/bytecode_015d36d.cpp
@@ -291,7 +291,7 @@ Error GDScriptDecomp_015d36d::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_015d36d.cpp
+++ b/bytecode/bytecode_015d36d.cpp
@@ -613,7 +613,7 @@ Error GDScriptDecomp_015d36d::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_054a2ac.cpp
+++ b/bytecode/bytecode_054a2ac.cpp
@@ -299,7 +299,7 @@ Error GDScriptDecomp_054a2ac::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_054a2ac.cpp
+++ b/bytecode/bytecode_054a2ac.cpp
@@ -624,7 +624,7 @@ Error GDScriptDecomp_054a2ac::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_0b806ee.cpp
+++ b/bytecode/bytecode_0b806ee.cpp
@@ -256,7 +256,7 @@ Error GDScriptDecomp_0b806ee::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_0b806ee.cpp
+++ b/bytecode/bytecode_0b806ee.cpp
@@ -523,7 +523,7 @@ Error GDScriptDecomp_0b806ee::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_1a36141.cpp
+++ b/bytecode/bytecode_1a36141.cpp
@@ -309,7 +309,7 @@ Error GDScriptDecomp_1a36141::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_1a36141.cpp
+++ b/bytecode/bytecode_1a36141.cpp
@@ -649,7 +649,7 @@ Error GDScriptDecomp_1a36141::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_1add52b.cpp
+++ b/bytecode/bytecode_1add52b.cpp
@@ -279,7 +279,7 @@ Error GDScriptDecomp_1add52b::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_1add52b.cpp
+++ b/bytecode/bytecode_1add52b.cpp
@@ -579,7 +579,7 @@ Error GDScriptDecomp_1add52b::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_1ca61a3.cpp
+++ b/bytecode/bytecode_1ca61a3.cpp
@@ -312,7 +312,7 @@ Error GDScriptDecomp_1ca61a3::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_1ca61a3.cpp
+++ b/bytecode/bytecode_1ca61a3.cpp
@@ -661,7 +661,7 @@ Error GDScriptDecomp_1ca61a3::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_216a8aa.cpp
+++ b/bytecode/bytecode_216a8aa.cpp
@@ -296,7 +296,7 @@ Error GDScriptDecomp_216a8aa::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_216a8aa.cpp
+++ b/bytecode/bytecode_216a8aa.cpp
@@ -618,7 +618,7 @@ Error GDScriptDecomp_216a8aa::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_2185c01.cpp
+++ b/bytecode/bytecode_2185c01.cpp
@@ -264,7 +264,7 @@ Error GDScriptDecomp_2185c01::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_2185c01.cpp
+++ b/bytecode/bytecode_2185c01.cpp
@@ -540,7 +540,7 @@ Error GDScriptDecomp_2185c01::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_23381a5.cpp
+++ b/bytecode/bytecode_23381a5.cpp
@@ -282,7 +282,7 @@ Error GDScriptDecomp_23381a5::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_23381a5.cpp
+++ b/bytecode/bytecode_23381a5.cpp
@@ -585,7 +585,7 @@ Error GDScriptDecomp_23381a5::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_23441ec.cpp
+++ b/bytecode/bytecode_23441ec.cpp
@@ -274,7 +274,7 @@ Error GDScriptDecomp_23441ec::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_23441ec.cpp
+++ b/bytecode/bytecode_23441ec.cpp
@@ -562,7 +562,7 @@ Error GDScriptDecomp_23441ec::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_30c1229.cpp
+++ b/bytecode/bytecode_30c1229.cpp
@@ -269,7 +269,7 @@ Error GDScriptDecomp_30c1229::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_30c1229.cpp
+++ b/bytecode/bytecode_30c1229.cpp
@@ -551,7 +551,7 @@ Error GDScriptDecomp_30c1229::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_31ce3c5.cpp
+++ b/bytecode/bytecode_31ce3c5.cpp
@@ -258,7 +258,7 @@ Error GDScriptDecomp_31ce3c5::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_31ce3c5.cpp
+++ b/bytecode/bytecode_31ce3c5.cpp
@@ -525,7 +525,7 @@ Error GDScriptDecomp_31ce3c5::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_3ea6d9f.cpp
+++ b/bytecode/bytecode_3ea6d9f.cpp
@@ -302,7 +302,7 @@ Error GDScriptDecomp_3ea6d9f::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_3ea6d9f.cpp
+++ b/bytecode/bytecode_3ea6d9f.cpp
@@ -627,7 +627,7 @@ Error GDScriptDecomp_3ea6d9f::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_48f1d02.cpp
+++ b/bytecode/bytecode_48f1d02.cpp
@@ -268,7 +268,7 @@ Error GDScriptDecomp_48f1d02::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_48f1d02.cpp
+++ b/bytecode/bytecode_48f1d02.cpp
@@ -547,7 +547,7 @@ Error GDScriptDecomp_48f1d02::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_4ee82a2.cpp
+++ b/bytecode/bytecode_4ee82a2.cpp
@@ -280,7 +280,7 @@ Error GDScriptDecomp_4ee82a2::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_4ee82a2.cpp
+++ b/bytecode/bytecode_4ee82a2.cpp
@@ -583,7 +583,7 @@ Error GDScriptDecomp_4ee82a2::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_506df14.cpp
+++ b/bytecode/bytecode_506df14.cpp
@@ -316,7 +316,7 @@ Error GDScriptDecomp_506df14::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_506df14.cpp
+++ b/bytecode/bytecode_506df14.cpp
@@ -656,7 +656,7 @@ Error GDScriptDecomp_506df14::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_513c026.cpp
+++ b/bytecode/bytecode_513c026.cpp
@@ -281,7 +281,7 @@ Error GDScriptDecomp_513c026::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_513c026.cpp
+++ b/bytecode/bytecode_513c026.cpp
@@ -584,7 +584,7 @@ Error GDScriptDecomp_513c026::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_514a3fb.cpp
+++ b/bytecode/bytecode_514a3fb.cpp
@@ -310,7 +310,7 @@ Error GDScriptDecomp_514a3fb::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_514a3fb.cpp
+++ b/bytecode/bytecode_514a3fb.cpp
@@ -650,7 +650,7 @@ Error GDScriptDecomp_514a3fb::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_5565f55.cpp
+++ b/bytecode/bytecode_5565f55.cpp
@@ -317,7 +317,7 @@ Error GDScriptDecomp_5565f55::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_5565f55.cpp
+++ b/bytecode/bytecode_5565f55.cpp
@@ -657,7 +657,7 @@ Error GDScriptDecomp_5565f55::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_5e938f0.cpp
+++ b/bytecode/bytecode_5e938f0.cpp
@@ -290,7 +290,7 @@ Error GDScriptDecomp_5e938f0::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_5e938f0.cpp
+++ b/bytecode/bytecode_5e938f0.cpp
@@ -608,7 +608,7 @@ Error GDScriptDecomp_5e938f0::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_6174585.cpp
+++ b/bytecode/bytecode_6174585.cpp
@@ -272,7 +272,7 @@ Error GDScriptDecomp_6174585::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_6174585.cpp
+++ b/bytecode/bytecode_6174585.cpp
@@ -560,7 +560,7 @@ Error GDScriptDecomp_6174585::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_620ec47.cpp
+++ b/bytecode/bytecode_620ec47.cpp
@@ -313,7 +313,7 @@ Error GDScriptDecomp_620ec47::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_620ec47.cpp
+++ b/bytecode/bytecode_620ec47.cpp
@@ -653,7 +653,7 @@ Error GDScriptDecomp_620ec47::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_62273e5.cpp
+++ b/bytecode/bytecode_62273e5.cpp
@@ -286,7 +286,7 @@ Error GDScriptDecomp_62273e5::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_62273e5.cpp
+++ b/bytecode/bytecode_62273e5.cpp
@@ -592,7 +592,7 @@ Error GDScriptDecomp_62273e5::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_64872ca.cpp
+++ b/bytecode/bytecode_64872ca.cpp
@@ -271,7 +271,7 @@ Error GDScriptDecomp_64872ca::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_64872ca.cpp
+++ b/bytecode/bytecode_64872ca.cpp
@@ -556,7 +556,7 @@ Error GDScriptDecomp_64872ca::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_65d48d6.cpp
+++ b/bytecode/bytecode_65d48d6.cpp
@@ -267,7 +267,7 @@ Error GDScriptDecomp_65d48d6::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_65d48d6.cpp
+++ b/bytecode/bytecode_65d48d6.cpp
@@ -543,7 +543,7 @@ Error GDScriptDecomp_65d48d6::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_6694c11.cpp
+++ b/bytecode/bytecode_6694c11.cpp
@@ -316,7 +316,7 @@ Error GDScriptDecomp_6694c11::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_6694c11.cpp
+++ b/bytecode/bytecode_6694c11.cpp
@@ -656,7 +656,7 @@ Error GDScriptDecomp_6694c11::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_703004f.cpp
+++ b/bytecode/bytecode_703004f.cpp
@@ -259,7 +259,7 @@ Error GDScriptDecomp_703004f::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_703004f.cpp
+++ b/bytecode/bytecode_703004f.cpp
@@ -526,7 +526,7 @@ Error GDScriptDecomp_703004f::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_7124599.cpp
+++ b/bytecode/bytecode_7124599.cpp
@@ -275,7 +275,7 @@ Error GDScriptDecomp_7124599::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_7124599.cpp
+++ b/bytecode/bytecode_7124599.cpp
@@ -563,7 +563,7 @@ Error GDScriptDecomp_7124599::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_7d2d144.cpp
+++ b/bytecode/bytecode_7d2d144.cpp
@@ -270,7 +270,7 @@ Error GDScriptDecomp_7d2d144::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_7d2d144.cpp
+++ b/bytecode/bytecode_7d2d144.cpp
@@ -555,7 +555,7 @@ Error GDScriptDecomp_7d2d144::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_7f7d97f.cpp
+++ b/bytecode/bytecode_7f7d97f.cpp
@@ -312,7 +312,7 @@ Error GDScriptDecomp_7f7d97f::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_7f7d97f.cpp
+++ b/bytecode/bytecode_7f7d97f.cpp
@@ -652,7 +652,7 @@ Error GDScriptDecomp_7f7d97f::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_85585c7.cpp
+++ b/bytecode/bytecode_85585c7.cpp
@@ -276,7 +276,7 @@ Error GDScriptDecomp_85585c7::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_85585c7.cpp
+++ b/bytecode/bytecode_85585c7.cpp
@@ -564,7 +564,7 @@ Error GDScriptDecomp_85585c7::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_8aab9a0.cpp
+++ b/bytecode/bytecode_8aab9a0.cpp
@@ -309,7 +309,7 @@ Error GDScriptDecomp_8aab9a0::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_8aab9a0.cpp
+++ b/bytecode/bytecode_8aab9a0.cpp
@@ -655,7 +655,7 @@ Error GDScriptDecomp_8aab9a0::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_8b912d1.cpp
+++ b/bytecode/bytecode_8b912d1.cpp
@@ -283,7 +283,7 @@ Error GDScriptDecomp_8b912d1::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_8b912d1.cpp
+++ b/bytecode/bytecode_8b912d1.cpp
@@ -589,7 +589,7 @@ Error GDScriptDecomp_8b912d1::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_8c1731b.cpp
+++ b/bytecode/bytecode_8c1731b.cpp
@@ -257,7 +257,7 @@ Error GDScriptDecomp_8c1731b::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_8c1731b.cpp
+++ b/bytecode/bytecode_8c1731b.cpp
@@ -524,7 +524,7 @@ Error GDScriptDecomp_8c1731b::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_8cab401.cpp
+++ b/bytecode/bytecode_8cab401.cpp
@@ -260,7 +260,7 @@ Error GDScriptDecomp_8cab401::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_8cab401.cpp
+++ b/bytecode/bytecode_8cab401.cpp
@@ -530,7 +530,7 @@ Error GDScriptDecomp_8cab401::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_8e35d93.cpp
+++ b/bytecode/bytecode_8e35d93.cpp
@@ -305,7 +305,7 @@ Error GDScriptDecomp_8e35d93::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_8e35d93.cpp
+++ b/bytecode/bytecode_8e35d93.cpp
@@ -639,7 +639,7 @@ Error GDScriptDecomp_8e35d93::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_91ca725.cpp
+++ b/bytecode/bytecode_91ca725.cpp
@@ -297,7 +297,7 @@ Error GDScriptDecomp_91ca725::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_91ca725.cpp
+++ b/bytecode/bytecode_91ca725.cpp
@@ -622,7 +622,7 @@ Error GDScriptDecomp_91ca725::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_97f34a1.cpp
+++ b/bytecode/bytecode_97f34a1.cpp
@@ -266,7 +266,7 @@ Error GDScriptDecomp_97f34a1::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_97f34a1.cpp
+++ b/bytecode/bytecode_97f34a1.cpp
@@ -542,7 +542,7 @@ Error GDScriptDecomp_97f34a1::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_a3f1ee5.cpp
+++ b/bytecode/bytecode_a3f1ee5.cpp
@@ -306,7 +306,7 @@ Error GDScriptDecomp_a3f1ee5::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_a3f1ee5.cpp
+++ b/bytecode/bytecode_a3f1ee5.cpp
@@ -643,7 +643,7 @@ Error GDScriptDecomp_a3f1ee5::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_a56d6ff.cpp
+++ b/bytecode/bytecode_a56d6ff.cpp
@@ -301,7 +301,7 @@ Error GDScriptDecomp_a56d6ff::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_a56d6ff.cpp
+++ b/bytecode/bytecode_a56d6ff.cpp
@@ -626,7 +626,7 @@ Error GDScriptDecomp_a56d6ff::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_a60f242.cpp
+++ b/bytecode/bytecode_a60f242.cpp
@@ -315,7 +315,7 @@ Error GDScriptDecomp_a60f242::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_a60f242.cpp
+++ b/bytecode/bytecode_a60f242.cpp
@@ -655,7 +655,7 @@ Error GDScriptDecomp_a60f242::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_base.cpp
+++ b/bytecode/bytecode_base.cpp
@@ -74,3 +74,11 @@ String GDScriptDecomp::get_error_message() {
 
 	return error_message;
 }
+
+String GDScriptDecomp::get_constant_string(Vector<Variant> &constants, uint32_t constId) {
+	String constString = constants[constId].get_construct_string();
+	if (constants[constId].get_type() == Variant::Type::STRING) {
+		constString = constString.replace("\n", "\\n");
+	}
+	return constString;
+}

--- a/bytecode/bytecode_base.h
+++ b/bytecode/bytecode_base.h
@@ -26,6 +26,7 @@ public:
 
 	String get_script_text();
 	String get_error_message();
+	String get_constant_string(Vector<Variant>& constants, uint32_t constId);
 };
 
 #endif

--- a/bytecode/bytecode_be46be7.cpp
+++ b/bytecode/bytecode_be46be7.cpp
@@ -266,7 +266,7 @@ Error GDScriptDecomp_be46be7::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_be46be7.cpp
+++ b/bytecode/bytecode_be46be7.cpp
@@ -542,7 +542,7 @@ Error GDScriptDecomp_be46be7::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_c00427a.cpp
+++ b/bytecode/bytecode_c00427a.cpp
@@ -314,7 +314,7 @@ Error GDScriptDecomp_c00427a::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_c00427a.cpp
+++ b/bytecode/bytecode_c00427a.cpp
@@ -654,7 +654,7 @@ Error GDScriptDecomp_c00427a::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_c24c739.cpp
+++ b/bytecode/bytecode_c24c739.cpp
@@ -288,7 +288,7 @@ Error GDScriptDecomp_c24c739::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_c24c739.cpp
+++ b/bytecode/bytecode_c24c739.cpp
@@ -600,7 +600,7 @@ Error GDScriptDecomp_c24c739::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_c6120e7.cpp
+++ b/bytecode/bytecode_c6120e7.cpp
@@ -292,7 +292,7 @@ Error GDScriptDecomp_c6120e7::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_c6120e7.cpp
+++ b/bytecode/bytecode_c6120e7.cpp
@@ -614,7 +614,7 @@ Error GDScriptDecomp_c6120e7::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_d28da86.cpp
+++ b/bytecode/bytecode_d28da86.cpp
@@ -294,7 +294,7 @@ Error GDScriptDecomp_d28da86::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_d28da86.cpp
+++ b/bytecode/bytecode_d28da86.cpp
@@ -616,7 +616,7 @@ Error GDScriptDecomp_d28da86::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_d6b31da.cpp
+++ b/bytecode/bytecode_d6b31da.cpp
@@ -310,7 +310,7 @@ Error GDScriptDecomp_d6b31da::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_d6b31da.cpp
+++ b/bytecode/bytecode_d6b31da.cpp
@@ -659,7 +659,7 @@ Error GDScriptDecomp_d6b31da::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_e82dc40.cpp
+++ b/bytecode/bytecode_e82dc40.cpp
@@ -261,7 +261,7 @@ Error GDScriptDecomp_e82dc40::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_e82dc40.cpp
+++ b/bytecode/bytecode_e82dc40.cpp
@@ -534,7 +534,7 @@ Error GDScriptDecomp_e82dc40::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_ed80f45.cpp
+++ b/bytecode/bytecode_ed80f45.cpp
@@ -277,7 +277,7 @@ Error GDScriptDecomp_ed80f45::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_ed80f45.cpp
+++ b/bytecode/bytecode_ed80f45.cpp
@@ -568,7 +568,7 @@ Error GDScriptDecomp_ed80f45::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_f3f05dc.cpp
+++ b/bytecode/bytecode_f3f05dc.cpp
@@ -314,7 +314,7 @@ Error GDScriptDecomp_f3f05dc::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_f3f05dc.cpp
+++ b/bytecode/bytecode_f3f05dc.cpp
@@ -648,7 +648,7 @@ Error GDScriptDecomp_f3f05dc::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_f8a7c46.cpp
+++ b/bytecode/bytecode_f8a7c46.cpp
@@ -287,7 +287,7 @@ Error GDScriptDecomp_f8a7c46::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_f8a7c46.cpp
+++ b/bytecode/bytecode_f8a7c46.cpp
@@ -596,7 +596,7 @@ Error GDScriptDecomp_f8a7c46::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/bytecode/bytecode_ff1e7cf.cpp
+++ b/bytecode/bytecode_ff1e7cf.cpp
@@ -300,7 +300,7 @@ Error GDScriptDecomp_ff1e7cf::decompile_buffer(Vector<uint8_t> p_buffer) {
 			case TK_CONSTANT: {
 				uint32_t constant = tokens[i] >> TOKEN_BITS;
 				ERR_FAIL_INDEX_V(constant, (uint32_t)constants.size(), ERR_INVALID_DATA);
-				line += constants[constant].get_construct_string();
+				line += get_constant_string(constants, constant);
 			} break;
 			case TK_SELF: {
 				line += "self";

--- a/bytecode/bytecode_ff1e7cf.cpp
+++ b/bytecode/bytecode_ff1e7cf.cpp
@@ -625,7 +625,7 @@ Error GDScriptDecomp_ff1e7cf::decompile_buffer(Vector<uint8_t> p_buffer) {
 		}
 	}
 
-	if (!line.empty()) {
+	if (!line.is_empty()) {
 		for (int j = 0; j < indent; j++) {
 			script_text += "\t";
 		}

--- a/editor/gdre_cmp_dlg.cpp
+++ b/editor/gdre_cmp_dlg.cpp
@@ -68,10 +68,10 @@ ScriptCompDialog::ScriptCompDialog() {
 
 	add_child(script_vb);
 
-	get_ok()->set_text(RTR("Compile"));
+	get_ok_button()->set_text(RTR("Compile"));
 	_validate_input();
 
-	add_cancel(RTR("Cancel"));
+	add_cancel_button(RTR("Cancel"));
 }
 
 ScriptCompDialog::~ScriptCompDialog() {
@@ -131,7 +131,7 @@ void ScriptCompDialog::_validate_input() {
 	Color error_color = Color(1, 0, 0);
 #endif
 
-	if (target_dir->get_text().empty()) {
+	if (target_dir->get_text().is_empty()) {
 		error_message += RTR("No destination folder selected") + "\n";
 		script_key_error->add_theme_color_override("font_color", error_color);
 		ok = false;
@@ -144,7 +144,7 @@ void ScriptCompDialog::_validate_input() {
 
 	script_key_error->set_text(error_message);
 
-	get_ok()->set_disabled(!ok);
+	get_ok_button()->set_disabled(!ok);
 }
 
 void ScriptCompDialog::_dir_select_pressed() {

--- a/editor/gdre_dec_dlg.cpp
+++ b/editor/gdre_dec_dlg.cpp
@@ -79,10 +79,10 @@ ScriptDecompDialog::ScriptDecompDialog() {
 
 	add_child(script_vb);
 
-	get_ok()->set_text(RTR("Decompile"));
+	get_ok_button()->set_text(RTR("Decompile"));
 	_validate_input();
 
-	add_cancel(RTR("Cancel"));
+	add_cancel_button(RTR("Cancel"));
 }
 
 ScriptDecompDialog::~ScriptDecompDialog() {
@@ -160,7 +160,7 @@ void ScriptDecompDialog::_validate_input() {
 	Color error_color = Color(1, 0, 0);
 #endif
 
-	if (target_dir->get_text().empty()) {
+	if (target_dir->get_text().is_empty()) {
 		error_message += RTR("No destination folder selected") + "\n";
 		script_key_error->add_theme_color_override("font_color", error_color);
 		ok = false;
@@ -179,7 +179,7 @@ void ScriptDecompDialog::_validate_input() {
 
 	script_key_error->set_text(error_message);
 
-	get_ok()->set_disabled(!ok);
+	get_ok_button()->set_disabled(!ok);
 }
 
 void ScriptDecompDialog::_dir_select_pressed() {

--- a/editor/gdre_editor.cpp
+++ b/editor/gdre_editor.cpp
@@ -7,7 +7,7 @@
 #include "gdre_editor.h"
 
 #include "modules/gdscript/gdscript.h"
-#include "modules/gdscript/gdscript_functions.h"
+#include "modules/gdscript/gdscript_function.h"
 #include "modules/gdscript/gdscript_tokenizer.h"
 
 #include "bytecode/bytecode_versions.h"
@@ -32,7 +32,7 @@
 /*************************************************************************/
 
 #ifndef TOOLS_ENABLED
-#include "core/message_queue.h"
+#include "core/object/message_queue.h"
 #include "core/os/os.h"
 #include "main/main.h"
 
@@ -48,10 +48,10 @@ void ProgressDialog::_popup() {
 
 	Ref<StyleBox> style = get_theme_stylebox("panel", "PopupMenu");
 	ms += style->get_minimum_size();
-	main->set_margin(MARGIN_LEFT, style->get_margin(MARGIN_LEFT));
-	main->set_margin(MARGIN_RIGHT, -style->get_margin(MARGIN_RIGHT));
-	main->set_margin(MARGIN_TOP, style->get_margin(MARGIN_TOP));
-	main->set_margin(MARGIN_BOTTOM, -style->get_margin(MARGIN_BOTTOM));
+	main->set_offset(SIDE_LEFT, style->get_margin(SIDE_LEFT));
+	main->set_offset(SIDE_RIGHT, -style->get_margin(SIDE_RIGHT));
+	main->set_offset(SIDE_TOP, style->get_margin(SIDE_TOP));
+	main->set_offset(SIDE_BOTTOM, -style->get_margin(SIDE_BOTTOM));
 
 	popup_centered(ms);
 }
@@ -124,7 +124,7 @@ void ProgressDialog::end_task(const String &p_task) {
 	memdelete(t.vb);
 	tasks.erase(p_task);
 
-	if (tasks.empty())
+	if (tasks.is_empty())
 		hide();
 	else
 		_popup();
@@ -142,7 +142,7 @@ ProgressDialog::ProgressDialog() {
 
 	main = memnew(VBoxContainer);
 	add_child(main);
-	main->set_anchors_and_margins_preset(Control::PRESET_WIDE);
+	main->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	set_exclusive(true);
 	last_progress_tick = 0;
 	singleton = this;
@@ -220,8 +220,8 @@ OverwriteDialog::OverwriteDialog() {
 
 	add_child(script_vb);
 
-	get_ok()->set_text(RTR("Overwrite"));
-	add_cancel(RTR("Cancel"));
+	get_ok_button()->set_text(RTR("Overwrite"));
+	add_cancel_button(RTR("Cancel"));
 };
 
 OverwriteDialog::~OverwriteDialog() {

--- a/editor/gdre_enc_key.cpp
+++ b/editor/gdre_enc_key.cpp
@@ -21,10 +21,10 @@ EncKeyDialog::EncKeyDialog() {
 
 	add_child(script_vb);
 
-	get_ok()->set_text(RTR("Set"));
+	get_ok_button()->set_text(RTR("Set"));
 	_validate_input();
 
-	add_cancel(RTR("Cancel"));
+	add_cancel_button(RTR("Cancel"));
 }
 
 EncKeyDialog::~EncKeyDialog() {
@@ -35,7 +35,7 @@ Vector<uint8_t> EncKeyDialog::get_key() const {
 
 	Vector<uint8_t> key;
 
-	if (script_key->get_text().empty() || !script_key->get_text().is_valid_hex_number(false) || script_key->get_text().length() != 64) {
+	if (script_key->get_text().is_empty() || !script_key->get_text().is_valid_hex_number(false) || script_key->get_text().length() != 64) {
 		return key;
 	}
 
@@ -77,7 +77,7 @@ void EncKeyDialog::_validate_input() {
 	Color warn_color = Color(1, 1, 0);
 #endif
 
-	if (script_key->get_text().empty()) {
+	if (script_key->get_text().is_empty()) {
 		error_message += RTR("No encryption key") + "\n";
 		script_key_error->add_theme_color_override("font_color", warn_color);
 	} else if (!script_key->get_text().is_valid_hex_number(false) || script_key->get_text().length() != 64) {
@@ -88,7 +88,7 @@ void EncKeyDialog::_validate_input() {
 
 	script_key_error->set_text(error_message);
 
-	get_ok()->set_disabled(!ok);
+	get_ok_button()->set_disabled(!ok);
 }
 
 void EncKeyDialog::_script_encryption_key_changed(const String &p_key) {

--- a/editor/gdre_npck_dlg.cpp
+++ b/editor/gdre_npck_dlg.cpp
@@ -89,8 +89,8 @@ NewPackDialog::NewPackDialog() {
 
 	add_child(script_vb);
 
-	get_ok()->set_text(RTR("Save..."));
-	add_cancel(RTR("Cancel"));
+	get_ok_button()->set_text(RTR("Save..."));
+	add_cancel_button(RTR("Cancel"));
 }
 
 void NewPackDialog::_val_change(double p_val) {

--- a/editor/gdre_pck_dlg.cpp
+++ b/editor/gdre_pck_dlg.cpp
@@ -79,10 +79,10 @@ PackDialog::PackDialog() {
 
 	add_child(script_vb);
 
-	get_ok()->set_text(RTR("Extract..."));
+	get_ok_button()->set_text(RTR("Extract..."));
 	_validate_selection();
 
-	add_cancel(RTR("Cancel"));
+	add_cancel_button(RTR("Cancel"));
 }
 
 PackDialog::~PackDialog() {
@@ -253,7 +253,7 @@ void PackDialog::_validate_selection() {
 		error_message += RTR("Some files have malformed names") + "\n";
 		script_key_error->add_theme_color_override("font_color", error_color);
 	}
-	if (target_dir->get_text().empty()) {
+	if (target_dir->get_text().is_empty()) {
 		error_message += RTR("No destination folder selected") + "\n";
 		script_key_error->add_theme_color_override("font_color", error_color);
 		ok = false;
@@ -266,7 +266,7 @@ void PackDialog::_validate_selection() {
 
 	script_key_error->set_text(error_message);
 
-	get_ok()->set_disabled(!ok);
+	get_ok_button()->set_disabled(!ok);
 }
 
 Vector<String> PackDialog::get_selected_files() const {


### PR DESCRIPTION
This updates the module to use the latest 4.0 api since many functions and classes have changed.

This also fixes the issue with newlines in string constants; Newlines are not allowed in the middle of statements in scripts in godot versions < 4, which means that these scripts will have compile errors. We now replace newlines with an escaped '\n'.