### PR TITLE
Fix godot 2.x and 3.x variant type print

### DIFF
--- a/bytecode/bytecode_015d36d.cpp
+++ b/bytecode/bytecode_015d36d.cpp
@@ -298,7 +298,7 @@ Error GDScriptDecomp_015d36d::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_054a2ac.cpp
+++ b/bytecode/bytecode_054a2ac.cpp
@@ -306,7 +306,7 @@ Error GDScriptDecomp_054a2ac::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_0b806ee.cpp
+++ b/bytecode/bytecode_0b806ee.cpp
@@ -263,7 +263,7 @@ Error GDScriptDecomp_0b806ee::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_1a36141.cpp
+++ b/bytecode/bytecode_1a36141.cpp
@@ -528,6 +528,7 @@ Error GDScriptDecomp_1a36141::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "var ";
 			} break;
 			case TK_PR_AS: {
+				_ensure_space(line);
 				line += "as ";
 			} break;
 			case TK_PR_VOID: {

--- a/bytecode/bytecode_1a36141.cpp
+++ b/bytecode/bytecode_1a36141.cpp
@@ -316,7 +316,7 @@ Error GDScriptDecomp_1a36141::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_1add52b.cpp
+++ b/bytecode/bytecode_1add52b.cpp
@@ -286,7 +286,7 @@ Error GDScriptDecomp_1add52b::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_1add52b.cpp
+++ b/bytecode/bytecode_1add52b.cpp
@@ -286,7 +286,7 @@ Error GDScriptDecomp_1add52b::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_1ca61a3.cpp
+++ b/bytecode/bytecode_1ca61a3.cpp
@@ -540,6 +540,7 @@ Error GDScriptDecomp_1ca61a3::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "var ";
 			} break;
 			case TK_PR_AS: {
+				_ensure_space(line);
 				line += "as ";
 			} break;
 			case TK_PR_VOID: {

--- a/bytecode/bytecode_1ca61a3.cpp
+++ b/bytecode/bytecode_1ca61a3.cpp
@@ -319,7 +319,7 @@ Error GDScriptDecomp_1ca61a3::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_216a8aa.cpp
+++ b/bytecode/bytecode_216a8aa.cpp
@@ -303,7 +303,7 @@ Error GDScriptDecomp_216a8aa::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_2185c01.cpp
+++ b/bytecode/bytecode_2185c01.cpp
@@ -271,7 +271,7 @@ Error GDScriptDecomp_2185c01::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_23381a5.cpp
+++ b/bytecode/bytecode_23381a5.cpp
@@ -289,7 +289,7 @@ Error GDScriptDecomp_23381a5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_23381a5.cpp
+++ b/bytecode/bytecode_23381a5.cpp
@@ -289,7 +289,7 @@ Error GDScriptDecomp_23381a5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_23441ec.cpp
+++ b/bytecode/bytecode_23441ec.cpp
@@ -281,7 +281,7 @@ Error GDScriptDecomp_23441ec::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_30c1229.cpp
+++ b/bytecode/bytecode_30c1229.cpp
@@ -276,7 +276,7 @@ Error GDScriptDecomp_30c1229::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_31ce3c5.cpp
+++ b/bytecode/bytecode_31ce3c5.cpp
@@ -265,7 +265,7 @@ Error GDScriptDecomp_31ce3c5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_3ea6d9f.cpp
+++ b/bytecode/bytecode_3ea6d9f.cpp
@@ -309,7 +309,7 @@ Error GDScriptDecomp_3ea6d9f::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_48f1d02.cpp
+++ b/bytecode/bytecode_48f1d02.cpp
@@ -275,7 +275,7 @@ Error GDScriptDecomp_48f1d02::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_4ee82a2.cpp
+++ b/bytecode/bytecode_4ee82a2.cpp
@@ -287,7 +287,7 @@ Error GDScriptDecomp_4ee82a2::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_4ee82a2.cpp
+++ b/bytecode/bytecode_4ee82a2.cpp
@@ -287,7 +287,7 @@ Error GDScriptDecomp_4ee82a2::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_506df14.cpp
+++ b/bytecode/bytecode_506df14.cpp
@@ -323,7 +323,7 @@ Error GDScriptDecomp_506df14::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_506df14.cpp
+++ b/bytecode/bytecode_506df14.cpp
@@ -535,6 +535,7 @@ Error GDScriptDecomp_506df14::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "var ";
 			} break;
 			case TK_PR_AS: {
+				_ensure_space(line);
 				line += "as ";
 			} break;
 			case TK_PR_VOID: {

--- a/bytecode/bytecode_513c026.cpp
+++ b/bytecode/bytecode_513c026.cpp
@@ -288,7 +288,7 @@ Error GDScriptDecomp_513c026::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_513c026.cpp
+++ b/bytecode/bytecode_513c026.cpp
@@ -288,7 +288,7 @@ Error GDScriptDecomp_513c026::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_514a3fb.cpp
+++ b/bytecode/bytecode_514a3fb.cpp
@@ -529,6 +529,7 @@ Error GDScriptDecomp_514a3fb::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "var ";
 			} break;
 			case TK_PR_AS: {
+				_ensure_space(line);
 				line += "as ";
 			} break;
 			case TK_PR_VOID: {

--- a/bytecode/bytecode_514a3fb.cpp
+++ b/bytecode/bytecode_514a3fb.cpp
@@ -317,7 +317,7 @@ Error GDScriptDecomp_514a3fb::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_5565f55.cpp
+++ b/bytecode/bytecode_5565f55.cpp
@@ -536,6 +536,7 @@ Error GDScriptDecomp_5565f55::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "var ";
 			} break;
 			case TK_PR_AS: {
+				_ensure_space(line);
 				line += "as ";
 			} break;
 			case TK_PR_VOID: {

--- a/bytecode/bytecode_5565f55.cpp
+++ b/bytecode/bytecode_5565f55.cpp
@@ -324,7 +324,7 @@ Error GDScriptDecomp_5565f55::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_5e938f0.cpp
+++ b/bytecode/bytecode_5e938f0.cpp
@@ -297,7 +297,7 @@ Error GDScriptDecomp_5e938f0::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_5e938f0.cpp
+++ b/bytecode/bytecode_5e938f0.cpp
@@ -297,7 +297,7 @@ Error GDScriptDecomp_5e938f0::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_6174585.cpp
+++ b/bytecode/bytecode_6174585.cpp
@@ -279,7 +279,7 @@ Error GDScriptDecomp_6174585::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_620ec47.cpp
+++ b/bytecode/bytecode_620ec47.cpp
@@ -320,7 +320,7 @@ Error GDScriptDecomp_620ec47::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_620ec47.cpp
+++ b/bytecode/bytecode_620ec47.cpp
@@ -532,6 +532,7 @@ Error GDScriptDecomp_620ec47::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "var ";
 			} break;
 			case TK_PR_AS: {
+				_ensure_space(line);
 				line += "as ";
 			} break;
 			case TK_PR_VOID: {

--- a/bytecode/bytecode_62273e5.cpp
+++ b/bytecode/bytecode_62273e5.cpp
@@ -293,7 +293,7 @@ Error GDScriptDecomp_62273e5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_62273e5.cpp
+++ b/bytecode/bytecode_62273e5.cpp
@@ -293,7 +293,7 @@ Error GDScriptDecomp_62273e5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_64872ca.cpp
+++ b/bytecode/bytecode_64872ca.cpp
@@ -278,7 +278,7 @@ Error GDScriptDecomp_64872ca::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_65d48d6.cpp
+++ b/bytecode/bytecode_65d48d6.cpp
@@ -274,7 +274,7 @@ Error GDScriptDecomp_65d48d6::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_6694c11.cpp
+++ b/bytecode/bytecode_6694c11.cpp
@@ -323,7 +323,7 @@ Error GDScriptDecomp_6694c11::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_6694c11.cpp
+++ b/bytecode/bytecode_6694c11.cpp
@@ -535,6 +535,7 @@ Error GDScriptDecomp_6694c11::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "var ";
 			} break;
 			case TK_PR_AS: {
+				_ensure_space(line);
 				line += "as ";
 			} break;
 			case TK_PR_VOID: {

--- a/bytecode/bytecode_703004f.cpp
+++ b/bytecode/bytecode_703004f.cpp
@@ -266,7 +266,7 @@ Error GDScriptDecomp_703004f::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_7124599.cpp
+++ b/bytecode/bytecode_7124599.cpp
@@ -282,7 +282,7 @@ Error GDScriptDecomp_7124599::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_7d2d144.cpp
+++ b/bytecode/bytecode_7d2d144.cpp
@@ -277,7 +277,7 @@ Error GDScriptDecomp_7d2d144::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_7f7d97f.cpp
+++ b/bytecode/bytecode_7f7d97f.cpp
@@ -319,7 +319,7 @@ Error GDScriptDecomp_7f7d97f::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_7f7d97f.cpp
+++ b/bytecode/bytecode_7f7d97f.cpp
@@ -531,6 +531,7 @@ Error GDScriptDecomp_7f7d97f::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "var ";
 			} break;
 			case TK_PR_AS: {
+				_ensure_space(line);
 				line += "as ";
 			} break;
 			case TK_PR_VOID: {

--- a/bytecode/bytecode_85585c7.cpp
+++ b/bytecode/bytecode_85585c7.cpp
@@ -283,7 +283,7 @@ Error GDScriptDecomp_85585c7::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_8aab9a0.cpp
+++ b/bytecode/bytecode_8aab9a0.cpp
@@ -537,6 +537,7 @@ Error GDScriptDecomp_8aab9a0::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "var ";
 			} break;
 			case TK_PR_AS: {
+				_ensure_space(line);
 				line += "as ";
 			} break;
 			case TK_PR_VOID: {

--- a/bytecode/bytecode_8aab9a0.cpp
+++ b/bytecode/bytecode_8aab9a0.cpp
@@ -316,7 +316,7 @@ Error GDScriptDecomp_8aab9a0::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_8b912d1.cpp
+++ b/bytecode/bytecode_8b912d1.cpp
@@ -290,7 +290,7 @@ Error GDScriptDecomp_8b912d1::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_8b912d1.cpp
+++ b/bytecode/bytecode_8b912d1.cpp
@@ -290,7 +290,7 @@ Error GDScriptDecomp_8b912d1::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_8c1731b.cpp
+++ b/bytecode/bytecode_8c1731b.cpp
@@ -264,7 +264,7 @@ Error GDScriptDecomp_8c1731b::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_8cab401.cpp
+++ b/bytecode/bytecode_8cab401.cpp
@@ -267,7 +267,7 @@ Error GDScriptDecomp_8cab401::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_8e35d93.cpp
+++ b/bytecode/bytecode_8e35d93.cpp
@@ -312,7 +312,7 @@ Error GDScriptDecomp_8e35d93::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_91ca725.cpp
+++ b/bytecode/bytecode_91ca725.cpp
@@ -304,7 +304,7 @@ Error GDScriptDecomp_91ca725::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_97f34a1.cpp
+++ b/bytecode/bytecode_97f34a1.cpp
@@ -273,7 +273,7 @@ Error GDScriptDecomp_97f34a1::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_a3f1ee5.cpp
+++ b/bytecode/bytecode_a3f1ee5.cpp
@@ -313,7 +313,7 @@ Error GDScriptDecomp_a3f1ee5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_a56d6ff.cpp
+++ b/bytecode/bytecode_a56d6ff.cpp
@@ -308,7 +308,7 @@ Error GDScriptDecomp_a56d6ff::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_a60f242.cpp
+++ b/bytecode/bytecode_a60f242.cpp
@@ -322,7 +322,7 @@ Error GDScriptDecomp_a60f242::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_a60f242.cpp
+++ b/bytecode/bytecode_a60f242.cpp
@@ -534,6 +534,7 @@ Error GDScriptDecomp_a60f242::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "var ";
 			} break;
 			case TK_PR_AS: {
+				_ensure_space(line);
 				line += "as ";
 			} break;
 			case TK_PR_VOID: {

--- a/bytecode/bytecode_base.cpp
+++ b/bytecode/bytecode_base.cpp
@@ -128,6 +128,267 @@ String GDScriptDecomp::get_constant_string(Vector<Variant> &constants, uint32_t 
 	return constString;
 }
 
+String GDScriptDecomp::get_type_name_v2(int p_type) {
+	switch (p_type) {
+		case V2Type::Type::NIL: {
+
+			return "Nil";
+		} break;
+
+		// atomic types
+		case V2Type::Type::BOOL: {
+
+			return "bool";
+		} break;
+		case V2Type::Type::INT: {
+
+			return "int";
+
+		} break;
+		case V2Type::Type::REAL: {
+
+			return "float";
+
+		} break;
+		case V2Type::Type::STRING: {
+
+			return "String";
+		} break;
+
+		// math types
+		case V2Type::Type::VECTOR2: {
+
+			return "Vector2";
+		} break;
+		case V2Type::Type::RECT2: {
+
+			return "Rect2";
+		} break;
+		case V2Type::Type::MATRIX32: {
+
+			return "Matrix32";
+		} break;
+		case V2Type::Type::VECTOR3: {
+
+			return "Vector3";
+		} break;
+		case V2Type::Type::PLANE: {
+
+			return "Plane";
+
+		} break;
+		/*
+			case V2Type::Type::QUAT: {
+			} break;*/
+		case V2Type::Type::_AABB: {
+
+			return "AABB";
+		} break;
+		case V2Type::Type::QUAT: {
+
+			return "Quat";
+
+		} break;
+		case V2Type::Type::MATRIX3: {
+
+			return "Matrix3";
+
+		} break;
+		case V2Type::Type::TRANSFORM: {
+
+			return "Transform";
+
+		} break;
+
+		// misc types
+		case V2Type::Type::COLOR: {
+
+			return "Color";
+
+		} break;
+		case V2Type::Type::IMAGE: {
+
+			return "Image";
+
+		} break;
+		case V2Type::Type::_RID: {
+
+			return "RID";
+		} break;
+		case V2Type::Type::OBJECT: {
+
+			return "Object";
+		} break;
+		case V2Type::Type::NODE_PATH: {
+
+			return "NodePath";
+
+		} break;
+		case V2Type::Type::INPUT_EVENT: {
+
+			return "InputEvent";
+
+		} break;
+		case V2Type::Type::DICTIONARY: {
+
+			return "Dictionary";
+
+		} break;
+		case V2Type::Type::ARRAY: {
+
+			return "Array";
+
+		} break;
+
+		// arrays
+		case V2Type::Type::RAW_ARRAY: {
+
+			return "RawArray";
+
+		} break;
+		case V2Type::Type::INT_ARRAY: {
+
+			return "IntArray";
+
+		} break;
+		case V2Type::Type::REAL_ARRAY: {
+
+			return "RealArray";
+
+		} break;
+		case V2Type::Type::STRING_ARRAY: {
+
+			return "StringArray";
+		} break;
+		case V2Type::Type::VECTOR2_ARRAY: {
+
+			return "Vector2Array";
+
+		} break;
+		case V2Type::Type::VECTOR3_ARRAY: {
+
+			return "Vector3Array";
+
+		} break;
+		case V2Type::Type::COLOR_ARRAY: {
+
+			return "ColorArray";
+
+		} break;
+		default: {
+		}
+	}
+
+	return "";
+}
+
+String GDScriptDecomp::get_type_name_v3(int p_type) {
+
+	switch (p_type) {
+		case V3Type::Type::NIL: {
+			return "Nil";
+		} break;
+
+		// atomic types
+		case V3Type::Type::BOOL: {
+
+			return "bool";
+		} break;
+		case V3Type::Type::INT: {
+			return "int";
+		} break;
+		case V3Type::Type::REAL: {
+			return "float";
+		} break;
+		case V3Type::Type::STRING: {
+			return "String";
+		} break;
+
+		// math types
+		case V3Type::Type::VECTOR2: {
+			return "Vector2";
+		} break;
+		case V3Type::Type::RECT2: {
+			return "Rect2";
+		} break;
+		case V3Type::Type::TRANSFORM2D: {
+			return "Transform2D";
+		} break;
+		case V3Type::Type::VECTOR3: {
+			return "Vector3";
+		} break;
+		case V3Type::Type::PLANE: {
+			return "Plane";
+		} break;
+		/*
+			case V3Type::Type::QUAT: {
+			} break;*/
+		case V3Type::Type::AABB: {
+			return "AABB";
+		} break;
+		case V3Type::Type::QUAT: {
+			return "Quat";
+
+		} break;
+		case V3Type::Type::BASIS: {
+			return "Basis";
+
+		} break;
+		case V3Type::Type::TRANSFORM: {
+			return "Transform";
+		} break;
+
+		// misc types
+		case V3Type::Type::COLOR: {
+			return "Color";
+		} break;
+		case V3Type::Type::_RID: {
+			return "RID";
+		} break;
+		case V3Type::Type::OBJECT: {
+
+			return "Object";
+		} break;
+		case V3Type::Type::NODE_PATH: {
+			return "NodePath";
+
+		} break;
+		case V3Type::Type::DICTIONARY: {
+			return "Dictionary";
+		} break;
+		case V3Type::Type::ARRAY: {
+			return "Array";
+		} break;
+
+		// arrays
+		case V3Type::Type::POOL_BYTE_ARRAY: {
+			return "PoolByteArray";
+		} break;
+		case V3Type::Type::POOL_INT_ARRAY: {
+			return "PoolIntArray";
+		} break;
+		case V3Type::Type::POOL_REAL_ARRAY: {
+			return "PoolRealArray";
+		} break;
+		case V3Type::Type::POOL_STRING_ARRAY: {
+			return "PoolStringArray";
+		} break;
+		case V3Type::Type::POOL_VECTOR2_ARRAY: {
+			return "PoolVector2Array";
+		} break;
+		case V3Type::Type::POOL_VECTOR3_ARRAY: {
+			return "PoolVector3Array";
+		} break;
+		case V3Type::Type::POOL_COLOR_ARRAY: {
+			return "PoolColorArray";
+		} break;
+		default: {
+		}
+	}
+
+	return "";
+}
+
 Error GDScriptDecomp::decode_variant_3(Variant &r_variant, const uint8_t *p_buffer, int p_len, int *r_len, bool p_allow_objects) {
 	const uint8_t *buf = p_buffer;
 	int len = p_len;

--- a/bytecode/bytecode_base.h
+++ b/bytecode/bytecode_base.h
@@ -8,7 +8,90 @@
 #include "core/templates/map.h"
 #include "core/object/object.h"
 #include "core/object/class_db.h"
+namespace V2Type{
+	enum Type {
 
+		NIL,
+
+		// atomic types
+		BOOL,
+		INT,
+		REAL,
+		STRING,
+
+		// math types
+
+		VECTOR2, // 5
+		RECT2,
+		VECTOR3,
+		MATRIX32,
+		PLANE,
+		QUAT, // 10
+		_AABB, //sorry naming convention fail :( not like it's used often
+		MATRIX3,
+		TRANSFORM,
+
+		// misc types
+		COLOR,
+		IMAGE, // 15
+		NODE_PATH,
+		_RID,
+		OBJECT,
+		INPUT_EVENT,
+		DICTIONARY, // 20
+		ARRAY,
+
+		// arrays
+		RAW_ARRAY,
+		INT_ARRAY,
+		REAL_ARRAY,
+		STRING_ARRAY, // 25
+		VECTOR2_ARRAY,
+		VECTOR3_ARRAY,
+		COLOR_ARRAY,
+
+		VARIANT_MAX
+
+	};
+}
+
+namespace V3Type{
+	enum Type {
+
+		NIL,
+		// atomic types
+		BOOL,
+		INT,
+		REAL,
+		STRING,
+		// math types
+		VECTOR2, // 5
+		RECT2,
+		VECTOR3,
+		TRANSFORM2D,
+		PLANE,
+		QUAT, // 10
+		AABB,
+		BASIS,
+		TRANSFORM,
+		// misc types
+		COLOR,
+		NODE_PATH, // 15
+		_RID,
+		OBJECT,
+		DICTIONARY,
+		ARRAY,
+		// arrays
+		POOL_BYTE_ARRAY, // 20
+		POOL_INT_ARRAY,
+		POOL_REAL_ARRAY,
+		POOL_STRING_ARRAY,
+		POOL_VECTOR2_ARRAY,
+		POOL_VECTOR3_ARRAY, // 25
+		POOL_COLOR_ARRAY,
+		VARIANT_MAX
+	};
+}
 class GDScriptDecomp : public Object {
 	GDCLASS(GDScriptDecomp, Object);
 
@@ -23,10 +106,13 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) = 0;
 	Error decompile_byte_code_encrypted(const String &p_path, Vector<uint8_t> p_key);
 	Error decompile_byte_code(const String &p_path);
+	
 
 	String get_script_text();
 	String get_error_message();
 	String get_constant_string(Vector<Variant>& constants, uint32_t constId);
+	static String get_type_name_v3(int p_type);
+	static String get_type_name_v2(int p_type);
 
 	Error decode_variant_3(Variant &r_variant, const uint8_t *p_buffer, int p_len, int *r_len = nullptr, bool p_allow_objects = false);
 	Error decode_variant_2(Variant &r_variant, const uint8_t *p_buffer, int p_len, int *r_len = nullptr, bool p_allow_objects = false);

--- a/bytecode/bytecode_be46be7.cpp
+++ b/bytecode/bytecode_be46be7.cpp
@@ -273,7 +273,7 @@ Error GDScriptDecomp_be46be7::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_c00427a.cpp
+++ b/bytecode/bytecode_c00427a.cpp
@@ -533,6 +533,7 @@ Error GDScriptDecomp_c00427a::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "var ";
 			} break;
 			case TK_PR_AS: {
+				_ensure_space(line);
 				line += "as ";
 			} break;
 			case TK_PR_VOID: {

--- a/bytecode/bytecode_c00427a.cpp
+++ b/bytecode/bytecode_c00427a.cpp
@@ -321,7 +321,7 @@ Error GDScriptDecomp_c00427a::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_c24c739.cpp
+++ b/bytecode/bytecode_c24c739.cpp
@@ -295,7 +295,7 @@ Error GDScriptDecomp_c24c739::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_c24c739.cpp
+++ b/bytecode/bytecode_c24c739.cpp
@@ -295,7 +295,7 @@ Error GDScriptDecomp_c24c739::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_c6120e7.cpp
+++ b/bytecode/bytecode_c6120e7.cpp
@@ -299,7 +299,7 @@ Error GDScriptDecomp_c6120e7::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_d28da86.cpp
+++ b/bytecode/bytecode_d28da86.cpp
@@ -301,7 +301,7 @@ Error GDScriptDecomp_d28da86::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_d6b31da.cpp
+++ b/bytecode/bytecode_d6b31da.cpp
@@ -317,7 +317,7 @@ Error GDScriptDecomp_d6b31da::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_d6b31da.cpp
+++ b/bytecode/bytecode_d6b31da.cpp
@@ -538,6 +538,7 @@ Error GDScriptDecomp_d6b31da::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "var ";
 			} break;
 			case TK_PR_AS: {
+				_ensure_space(line);
 				line += "as ";
 			} break;
 			case TK_PR_VOID: {

--- a/bytecode/bytecode_e82dc40.cpp
+++ b/bytecode/bytecode_e82dc40.cpp
@@ -268,7 +268,7 @@ Error GDScriptDecomp_e82dc40::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_ed80f45.cpp
+++ b/bytecode/bytecode_ed80f45.cpp
@@ -284,7 +284,7 @@ Error GDScriptDecomp_ed80f45::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_f3f05dc.cpp
+++ b/bytecode/bytecode_f3f05dc.cpp
@@ -533,6 +533,7 @@ Error GDScriptDecomp_f3f05dc::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "var ";
 			} break;
 			case TK_PR_AS: {
+				_ensure_space(line);
 				line += "as ";
 			} break;
 			case TK_PR_VOID: {

--- a/bytecode/bytecode_f3f05dc.cpp
+++ b/bytecode/bytecode_f3f05dc.cpp
@@ -321,7 +321,7 @@ Error GDScriptDecomp_f3f05dc::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_f8a7c46.cpp
+++ b/bytecode/bytecode_f8a7c46.cpp
@@ -294,7 +294,7 @@ Error GDScriptDecomp_f8a7c46::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += get_type_name_v2(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_f8a7c46.cpp
+++ b/bytecode/bytecode_f8a7c46.cpp
@@ -294,7 +294,7 @@ Error GDScriptDecomp_f8a7c46::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_ff1e7cf.cpp
+++ b/bytecode/bytecode_ff1e7cf.cpp
@@ -307,7 +307,7 @@ Error GDScriptDecomp_ff1e7cf::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += Variant::get_type_name(Variant::Type(tokens[i] >> TOKEN_BITS));
+				line += get_type_name_v3(tokens[i] >> TOKEN_BITS);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];


### PR DESCRIPTION
v3 and v2 Variant type names were not printing correctly due to using the v4 Variant enum and print function, change to use backported `get_type_name`