### PR TITLE
Fix relative paths in CLI

### DIFF
--- a/bytecode/bytecode_base.cpp
+++ b/bytecode/bytecode_base.cpp
@@ -8,7 +8,7 @@
 #include "core/io/file_access_encrypted.h"
 #include "core/io/image.h"
 #include "core/io/marshalls.h"
-#include "core/os/file_access.h"
+#include "core/io/file_access.h"
 
 #include <limits.h>
 
@@ -736,8 +736,8 @@ Error GDScriptDecomp::decode_variant_3(Variant &r_variant, const uint8_t *p_buff
 						obj->set(str, value);
 					}
 
-					if (Object::cast_to<Reference>(obj)) {
-						REF ref = REF(Object::cast_to<Reference>(obj));
+					if (Object::cast_to<RefCounted>(obj)) {
+						REF ref = REF(Object::cast_to<RefCounted>(obj));
 						r_variant = ref;
 					} else {
 						r_variant = obj;
@@ -1401,8 +1401,8 @@ Error GDScriptDecomp::decode_variant_2(Variant &r_variant, const uint8_t *p_buff
 						obj->set(str, value);
 					}
 
-					if (Object::cast_to<Reference>(obj)) {
-						REF ref = REF(Object::cast_to<Reference>(obj));
+					if (Object::cast_to<RefCounted>(obj)) {
+						REF ref = REF(Object::cast_to<RefCounted>(obj));
 						r_variant = ref;
 					} else {
 						r_variant = obj;

--- a/standalone/gdre_main.gd
+++ b/standalone/gdre_main.gd
@@ -20,9 +20,8 @@ func get_arg_value(arg):
 	var split_args = arg.split("=")
 	if split_args.size() < 2:
 		print("Error: args have to be in the format of --key=value (with equals sign)")
-		$root.quit()
+		get_tree().quit()
 	return split_args[1]
-
 
 func export_imports(output_dir:String):
 	var importer:ImportExporter = ImportExporter.new()
@@ -207,6 +206,8 @@ func handle_cli():
 			print_usage()
 		else:
 			var main = GDRECLIMain.new()
+			exe_file = main.get_cli_abs_path(exe_file)
+			output_dir = main.get_cli_abs_path(output_dir)
 			main.open_log(output_dir)
 			#debugging
 			#print_import_info(output_dir)

--- a/utility/gdre_cli_main.cpp
+++ b/utility/gdre_cli_main.cpp
@@ -6,8 +6,15 @@ Error GDRECLIMain::open_log(const String &path) {
 Error GDRECLIMain::close_log() {
 	return GDRESettings::get_singleton()->close_log_file();
 }
-
+String GDRECLIMain::get_cli_abs_path(const String &path) {
+	if (path.is_absolute_path()){
+		return path;
+	}
+	String exec_path = GDRESettings::get_singleton()->get_exec_dir();
+	return exec_path.plus_file(path).replace("\\","/");
+}
 void GDRECLIMain::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("open_log"), &GDRECLIMain::open_log);
 	ClassDB::bind_method(D_METHOD("close_log"), &GDRECLIMain::close_log);
+	ClassDB::bind_method(D_METHOD("get_cli_abs_path"), &GDRECLIMain::get_cli_abs_path);
 }

--- a/utility/gdre_cli_main.h
+++ b/utility/gdre_cli_main.h
@@ -1,10 +1,10 @@
 #ifndef GDRE_CLI_MAIN_H
 #define GDRE_CLI_MAIN_H
 
-#include "core/object/reference.h"
+#include "core/object/ref_counted.h"
 #include "gdre_settings.h"
-class GDRECLIMain : public Reference {
-	GDCLASS(GDRECLIMain, Reference);
+class GDRECLIMain : public RefCounted {
+	GDCLASS(GDRECLIMain, RefCounted);
 
 private:
 	GDRESettings *gdres_singleton;

--- a/utility/gdre_cli_main.h
+++ b/utility/gdre_cli_main.h
@@ -15,7 +15,7 @@ protected:
 public:
 	Error open_log(const String &path);
 	Error close_log();
-
+	String get_cli_abs_path(const String &path);
 	GDRECLIMain() {
 		gdres_singleton = memnew(GDRESettings);
 	}

--- a/utility/gdre_packed_data.h
+++ b/utility/gdre_packed_data.h
@@ -1,7 +1,7 @@
 #ifndef GDRE_PACKED_DATA_H
 #define GDRE_PACKED_DATA_H
 
-#include "core/object/reference.h"
+#include "core/object/ref_counted.h"
 #include "packed_file_info.h"
 
 class GDREPackedSource : public PackSource {

--- a/utility/gdre_project_exporter.h
+++ b/utility/gdre_project_exporter.h
@@ -1,12 +1,12 @@
 #ifndef GDRE_PROJECT_EXPORTER_H
 #define GDRE_PROJECT_EXPORTER_H
 
-#include "core/object/reference.h"
+#include "core/object/ref_counted.h"
 #include "import_exporter.h"
 #include "pck_dumper.h"
 
-class GDREProjectExporter : public Reference {
-	GDCLASS(GDREProjectExporter, Reference)
+class GDREProjectExporter : public RefCounted {
+	GDCLASS(GDREProjectExporter, RefCounted)
 
 	Ref<PckDumper> pck_dumper;
 	Ref<ImportExporter> import_exporter;

--- a/utility/gdre_settings.cpp
+++ b/utility/gdre_settings.cpp
@@ -185,7 +185,7 @@ String GDRESettings::localize_path(const String &p_path, const String &resource_
 
 	if (res_path == "") {
 		//not initialized yet
-		if (!p_path.is_abs_path()) {
+		if (!p_path.is_absolute_path()) {
 			//just tack on a "res://" here
 			return "res://" + p_path;
 		}
@@ -193,7 +193,7 @@ String GDRESettings::localize_path(const String &p_path, const String &resource_
 	}
 
 	if (p_path.begins_with("res://") || p_path.begins_with("user://") ||
-			(p_path.is_abs_path() && !p_path.begins_with(res_path))) {
+			(p_path.is_absolute_path() && !p_path.begins_with(res_path))) {
 		return p_path.simplify_path();
 	}
 
@@ -254,7 +254,7 @@ String GDRESettings::globalize_path(const String &p_path, const String &resource
 			return p_path.replace("user:/", data_dir);
 		}
 		return p_path.replace("user://", "");
-	} else if (!p_path.is_abs_path()) {
+	} else if (!p_path.is_absolute_path()) {
 		return res_path.plus_file(p_path);
 	}
 
@@ -262,7 +262,7 @@ String GDRESettings::globalize_path(const String &p_path, const String &resource
 }
 
 bool GDRESettings::is_fs_path(const String &p_path) {
-	if (!p_path.is_abs_path()) {
+	if (!p_path.is_absolute_path()) {
 		return true;
 	}
 	if (p_path.find("://") == -1 || p_path.begins_with("file://")) {
@@ -301,7 +301,7 @@ String GDRESettings::_get_res_path(const String &p_path, const String &resource_
 			return res_path;
 		}
 		// localize_path did nothing
-		if (!res_path.is_abs_path()) {
+		if (!res_path.is_absolute_path()) {
 			res_path = "res://" + res_path;
 			if (PackedData::get_singleton()->has_path(res_path)) {
 				return res_path;
@@ -313,7 +313,7 @@ String GDRESettings::_get_res_path(const String &p_path, const String &resource_
 	}
 	//try and find it on the file system
 	res_path = p_path;
-	if (res_path.is_abs_path() && is_fs_path(res_path)) {
+	if (res_path.is_absolute_path() && is_fs_path(res_path)) {
 		if (!FileAccess::exists(res_path)) {
 			ERR_FAIL_COND_V_MSG(!suppress_errors, "", "Resource " + res_path + " does not exist");
 			return "";

--- a/utility/gdre_settings.h
+++ b/utility/gdre_settings.h
@@ -33,7 +33,6 @@
 template <class T>
 class GDREOS : public T {
 	static_assert(std::is_base_of<OS, T>::value, "T must derive from OS");
-
 public:
 	void _add_logger(Logger *p_logger) { T::add_logger(p_logger); }
 };
@@ -99,11 +98,13 @@ private:
 	bool first_load = true;
 	String project_path = "";
 	static GDRESettings *singleton;
+	static String exec_dir;
 	void remove_current_pack();
 	Vector<Ref<PackedFileInfo> > files;
 	String _get_res_path(const String &p_path, const String &resource_dir, const bool suppress_errors);
 	void add_logger();
 
+	static String _get_cwd();
 public:
 	Error load_pack(const String &p_path);
 	Error unload_pack();
@@ -133,7 +134,8 @@ public:
 	Error open_log_file(const String &output_dir);
 	bool is_fs_path(const String &p_path);
 	Error close_log_file();
-
+	String get_cwd() { return GDRESettings::_get_cwd(); };
+	String get_exec_dir() {return GDRESettings::exec_dir; };
 	static GDRESettings *get_singleton() {
 		// TODO: remove this hack
 		if (!singleton) {

--- a/utility/gdre_settings.h
+++ b/utility/gdre_settings.h
@@ -56,8 +56,8 @@ class GDRESettings : public Object {
 	GDCLASS(GDRESettings, Object);
 	_THREAD_SAFE_CLASS_
 public:
-	class PackInfo : public Reference {
-		GDCLASS(PackInfo, Reference);
+	class PackInfo : public RefCounted {
+		GDCLASS(PackInfo, RefCounted);
 
 		friend class GDRESettings;
 		String pack_file = "";

--- a/utility/image_parser_v2.cpp
+++ b/utility/image_parser_v2.cpp
@@ -135,7 +135,7 @@ Error ImageParserV2::write_image_v2_to_bin(FileAccess *f, const Variant &r_v, co
 
 	if (val->get_format() <= Image::FORMAT_RGB565) {
 		//can only compress uncompressed stuff
-		if (p_hint == PROPERTY_HINT_IMAGE_COMPRESS_LOSSLESS && Image::lossless_packer) {
+		if (p_hint == PROPERTY_HINT_IMAGE_COMPRESS_LOSSLESS && Image::png_packer) {
 			encoding = V2Image::IMAGE_ENCODING_LOSSLESS;
 		}
 	}
@@ -238,9 +238,9 @@ Error ImageParserV2::write_image_v2_to_bin(FileAccess *f, const Variant &r_v, co
 	} else {
 		Vector<uint8_t> data;
 		if (encoding == V2Image::IMAGE_ENCODING_LOSSY) {
-			data = Image::lossy_packer(val, quality);
+			data = Image::webp_lossy_packer(val, quality);
 		} else if (encoding == V2Image::IMAGE_ENCODING_LOSSLESS) {
-			data = Image::lossless_packer(val);
+			data = Image::png_packer(val);
 		}
 
 		int ds = data.size();
@@ -399,12 +399,10 @@ Error ImageParserV2::parse_image_v2(FileAccess *f, Variant &r_v, bool hacks_for_
 		uint8_t *w = data.ptrw();
 		f->get_buffer(w, data.size());
 
-		if (encoding == V2Image::IMAGE_ENCODING_LOSSY && Image::lossy_unpacker) {
-
-			img = img->lossy_unpacker(data);
-		} else if (encoding == V2Image::IMAGE_ENCODING_LOSSLESS && Image::lossless_unpacker) {
-
-			img = img->lossless_unpacker(data);
+		if (encoding == V2Image::IMAGE_ENCODING_LOSSY && Image::webp_unpacker) {
+			img = img->webp_unpacker(data);
+		} else if (encoding == V2Image::IMAGE_ENCODING_LOSSLESS && Image::png_unpacker) {
+			img = img->png_unpacker(data);
 		}
 		_advance_padding(f, data.size());
 	}

--- a/utility/image_parser_v2.h
+++ b/utility/image_parser_v2.h
@@ -4,7 +4,7 @@
 #define V2_IMAGE_PARSER_H
 
 #include "core/io/resource.h"
-#include "core/os/file_access.h"
+#include "core/io/file_access.h"
 #include "core/variant/variant.h"
 
 class ImageParserV2 {

--- a/utility/import_exporter.cpp
+++ b/utility/import_exporter.cpp
@@ -14,8 +14,8 @@
 #include "scene/resources/audio_stream_sample.h"
 #include "texture_loader_compat.h"
 #include "thirdparty/minimp3/minimp3_ex.h"
-#include <core/os/dir_access.h>
-#include <core/os/file_access.h>
+#include <core/io/dir_access.h>
+#include <core/io/file_access.h>
 #include <core/os/os.h>
 #include <core/version_generated.gen.h>
 
@@ -148,7 +148,7 @@ Error ImportExporter::load_import_file_v2(const String &p_path) {
 		if (iinfo->has_import_data()) {
 			// If this is a path outside of the project directory, we change it to the ".assets" directory in the project dir
 			if (iinfo->get_source_file().begins_with("../") ||
-					(iinfo->get_source_file().is_abs_path() && GDRESettings::get_singleton()->is_fs_path(iinfo->get_source_file()))) {
+					(iinfo->get_source_file().is_absolute_path() && GDRESettings::get_singleton()->is_fs_path(iinfo->get_source_file()))) {
 
 				dest = String(".assets").plus_file(p_path.replace("res://", "").get_base_dir().plus_file(iinfo->get_source_file().get_file()));
 				iinfo->source_file = dest;
@@ -672,7 +672,7 @@ Error ImportExporter::convert_tex_to_png(const String &output_dir, const String 
 
 String ImportExporter::_get_path(const String &output_dir, const String &p_path) {
 	if (GDRESettings::get_singleton()->get_project_path() == "" && !GDRESettings::get_singleton()->is_pack_loaded()) {
-		if (p_path.is_abs_path()) {
+		if (p_path.is_absolute_path()) {
 			return p_path;
 		} else {
 			return output_dir.plus_file(p_path.replace("res://", ""));

--- a/utility/import_exporter.h
+++ b/utility/import_exporter.h
@@ -4,14 +4,14 @@
 #include "core/io/resource.h"
 #include "core/io/resource_importer.h"
 #include "core/object/object.h"
-#include "core/object/reference.h"
-#include "core/os/file_access.h"
+#include "core/object/ref_counted.h"
+#include "core/io/file_access.h"
 #include "core/templates/map.h"
 #include "import_info.h"
 #include "resource_import_metadatav2.h"
 
-class ImportExporter : public Reference {
-	GDCLASS(ImportExporter, Reference)
+class ImportExporter : public RefCounted {
+	GDCLASS(ImportExporter, RefCounted)
 	Array files;
 	String project_dir;
 	bool opt_bin2text = true;

--- a/utility/import_info.h
+++ b/utility/import_info.h
@@ -5,7 +5,7 @@
 #include "core/io/resource.h"
 #include "core/io/resource_importer.h"
 #include "core/object/object.h"
-#include "core/object/reference.h"
+#include "core/object/ref_counted.h"
 #include "core/templates/map.h"
 #include "resource_import_metadatav2.h"
 
@@ -51,8 +51,8 @@ enum SceneFlags {
 };
 } // namespace V2ImportEnums
 
-class ImportInfo : public Reference {
-	GDCLASS(ImportInfo, Reference)
+class ImportInfo : public RefCounted {
+	GDCLASS(ImportInfo, RefCounted)
 private:
 	friend class ImportExporter;
 	friend class ResourceFormatLoaderCompat;

--- a/utility/packed_file_info.h
+++ b/utility/packed_file_info.h
@@ -3,10 +3,10 @@
 #include "core/object/object.h"
 
 #include "core/io/file_access_pack.h"
-#include "core/object/reference.h"
+#include "core/object/ref_counted.h"
 
-class PackedFileInfo : public Reference {
-	GDCLASS(PackedFileInfo, Reference);
+class PackedFileInfo : public RefCounted {
+	GDCLASS(PackedFileInfo, RefCounted);
 	friend class GDRESettings;
 	friend class PckDumper;
 	friend class GDREPackedSource;

--- a/utility/pcfg_loader.cpp
+++ b/utility/pcfg_loader.cpp
@@ -5,7 +5,7 @@
 #include <core/input/input_event.h>
 #include <core/io/compression.h>
 #include <core/io/marshalls.h>
-#include <core/os/file_access.h>
+#include <core/io/file_access.h>
 #include <core/os/keyboard.h>
 #include <core/variant/variant_parser.h>
 

--- a/utility/pcfg_loader.h
+++ b/utility/pcfg_loader.h
@@ -4,14 +4,14 @@
 #define PCFG_LOADER_H
 
 #include "core/object/class_db.h"
-#include "core/object/reference.h"
+#include "core/object/ref_counted.h"
 #include <core/object/object.h>
-#include <core/os/file_access.h>
+#include <core/io/file_access.h>
 
 typedef Map<String, Variant> CustomMap;
 
-class ProjectConfigLoader : public Reference {
-	GDCLASS(ProjectConfigLoader, Reference);
+class ProjectConfigLoader : public RefCounted {
+	GDCLASS(ProjectConfigLoader, RefCounted);
 	struct VariantContainer {
 		int order;
 		bool persist;

--- a/utility/pck_dumper.cpp
+++ b/utility/pck_dumper.cpp
@@ -5,8 +5,8 @@
 #include "pcfg_loader.h"
 #include "resource_loader_compat.h"
 #include <core/io/file_access_encrypted.h>
-#include <core/os/dir_access.h>
-#include <core/os/file_access.h>
+#include <core/io/dir_access.h>
+#include <core/io/file_access.h>
 #include <core/os/os.h>
 #include <core/version_generated.gen.h>
 

--- a/utility/pck_dumper.h
+++ b/utility/pck_dumper.h
@@ -5,14 +5,14 @@
 #include "core/io/resource.h"
 #include "core/io/resource_importer.h"
 #include "core/object/object.h"
-#include "core/object/reference.h"
-#include "core/os/file_access.h"
+#include "core/object/ref_counted.h"
+#include "core/io/file_access.h"
 #include "core/templates/map.h"
 
 #include "gdre_packed_data.h"
 
-class PckDumper : public Reference {
-	GDCLASS(PckDumper, Reference)
+class PckDumper : public RefCounted {
+	GDCLASS(PckDumper, RefCounted)
 	bool skip_malformed_paths = false;
 	bool skip_failed_md5 = false;
 	bool should_check_md5 = false;

--- a/utility/resource_import_metadatav2.h
+++ b/utility/resource_import_metadatav2.h
@@ -3,10 +3,10 @@
 #define RESOURCE_IMPORT_METADATAV2_H
 
 #include "core/io/resource.h"
-#include "core/object/reference.h"
+#include "core/object/ref_counted.h"
 
-class ResourceImportMetadatav2 : public Reference {
-	GDCLASS(ResourceImportMetadatav2, Reference);
+class ResourceImportMetadatav2 : public RefCounted {
+	GDCLASS(ResourceImportMetadatav2, RefCounted);
 
 	struct Source {
 		String path;

--- a/utility/resource_loader_compat.cpp
+++ b/utility/resource_loader_compat.cpp
@@ -1,7 +1,7 @@
 #include "resource_loader_compat.h"
 #include "core/crypto/crypto_core.h"
 #include "core/io/file_access_compressed.h"
-#include "core/os/dir_access.h"
+#include "core/io/dir_access.h"
 #include "core/string/ustring.h"
 #include "core/variant/variant_parser.h"
 #include "core/version.h"

--- a/utility/resource_loader_compat.h
+++ b/utility/resource_loader_compat.h
@@ -4,7 +4,7 @@
 #define RESOURCE_LOADER_COMPAT_H
 #include "core/io/resource.h"
 #include "core/io/resource_format_binary.h"
-#include "core/os/file_access.h"
+#include "core/io/file_access.h"
 #include "core/variant/variant.h"
 #include "import_info.h"
 #include "resource_import_metadatav2.h"

--- a/utility/texture_loader_compat.cpp
+++ b/utility/texture_loader_compat.cpp
@@ -1,5 +1,5 @@
 #include "texture_loader_compat.h"
-#include "core/os/file_access.h"
+#include "core/io/file_access.h"
 #include "gdre_packed_data.h"
 #include "gdre_settings.h"
 #include "resource_loader_compat.h"
@@ -117,9 +117,9 @@ Error TextureLoaderCompat::load_image_from_fileV3(FileAccess *f, int tw, int th,
 
 			Ref<Image> img;
 			if (df & FORMAT_BIT_LOSSLESS) {
-				img = Image::lossless_unpacker(pv);
+				img = Image::png_unpacker(pv);
 			} else {
-				img = Image::lossy_unpacker(pv);
+				img = Image::webp_unpacker(pv);
 			}
 			ERR_FAIL_COND_V_MSG(img.is_null() || img->is_empty(), ERR_FILE_CORRUPT, "File is corrupt");
 
@@ -386,7 +386,7 @@ Error TextureLoaderCompat::_load_layered_texture_v3(const String &p_path, Vector
 				{
 					f->get_buffer(pv.ptrw(), size);
 				}
-				Ref<Image> img = Image::lossless_unpacker(pv);
+				Ref<Image> img = Image::png_unpacker(pv);
 
 				if (img.is_null() || img->is_empty() || format != img->get_format()) {
 					memdelete(f);

--- a/utility/texture_loader_compat.h
+++ b/utility/texture_loader_compat.h
@@ -2,15 +2,15 @@
 #include "core/io/image.h"
 #include "core/io/resource.h"
 #include "core/io/resource_loader.h"
-#include "core/object/reference.h"
-#include "core/os/file_access.h"
+#include "core/object/ref_counted.h"
+#include "core/io/file_access.h"
 #include "core/templates/vector.h"
 #include "scene/resources/texture.h"
 #ifndef TEXTURE_LOADER_COMPAT_H
 #define TEXTURE_LOADER_COMPAT_H
 
-class TextureLoaderCompat : public Reference {
-	GDCLASS(TextureLoaderCompat, Reference);
+class TextureLoaderCompat : public RefCounted {
+	GDCLASS(TextureLoaderCompat, RefCounted);
 
 	Error _load_data_stexlayered_v4(const String &p_path, Vector<Ref<Image> > &r_data, Image::Format &r_format, int &r_width, int &r_height, int &r_depth, int &r_type, bool &r_mipmaps) const;
 	Error _load_layered_texture_v3(const String &p_path, Vector<Ref<Image> > &r_data, Image::Format &r_format, int &r_width, int &r_height, int &r_depth, bool &r_mipmaps) const;

--- a/utility/variant_writer_compat.h
+++ b/utility/variant_writer_compat.h
@@ -2,7 +2,7 @@
 #define VARIANT_WRITER_COMPAT_H
 
 #include "core/io/resource.h"
-#include "core/os/file_access.h"
+#include "core/io/file_access.h"
 #include "core/variant/variant.h"
 
 class VariantWriterCompat {


### PR DESCRIPTION
Relative paths now work with CLI extract. We get the initial execution directory for the program, and then use that as the relative root instead of CWD. Synced to https://github.com/godotengine/godot/commit/fe7559f751e81b21da2eb8252123f384b8a8622d