### PR TITLE
bytecode: Ensure space before "extends"

### DIFF
--- a/bytecode/bytecode_015d36d.cpp
+++ b/bytecode/bytecode_015d36d.cpp
@@ -483,6 +483,7 @@ Error GDScriptDecomp_015d36d::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_054a2ac.cpp
+++ b/bytecode/bytecode_054a2ac.cpp
@@ -491,6 +491,7 @@ Error GDScriptDecomp_054a2ac::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_0b806ee.cpp
+++ b/bytecode/bytecode_0b806ee.cpp
@@ -445,6 +445,7 @@ Error GDScriptDecomp_0b806ee::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_TOOL: {

--- a/bytecode/bytecode_1a36141.cpp
+++ b/bytecode/bytecode_1a36141.cpp
@@ -495,6 +495,7 @@ Error GDScriptDecomp_1a36141::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class_name ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_1add52b.cpp
+++ b/bytecode/bytecode_1add52b.cpp
@@ -468,6 +468,7 @@ Error GDScriptDecomp_1add52b::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_1ca61a3.cpp
+++ b/bytecode/bytecode_1ca61a3.cpp
@@ -507,6 +507,7 @@ Error GDScriptDecomp_1ca61a3::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class_name ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_216a8aa.cpp
+++ b/bytecode/bytecode_216a8aa.cpp
@@ -488,6 +488,7 @@ Error GDScriptDecomp_216a8aa::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_2185c01.cpp
+++ b/bytecode/bytecode_2185c01.cpp
@@ -453,6 +453,7 @@ Error GDScriptDecomp_2185c01::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_TOOL: {

--- a/bytecode/bytecode_23381a5.cpp
+++ b/bytecode/bytecode_23381a5.cpp
@@ -471,6 +471,7 @@ Error GDScriptDecomp_23381a5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_23441ec.cpp
+++ b/bytecode/bytecode_23441ec.cpp
@@ -463,6 +463,7 @@ Error GDScriptDecomp_23441ec::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_30c1229.cpp
+++ b/bytecode/bytecode_30c1229.cpp
@@ -458,6 +458,7 @@ Error GDScriptDecomp_30c1229::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_31ce3c5.cpp
+++ b/bytecode/bytecode_31ce3c5.cpp
@@ -447,6 +447,7 @@ Error GDScriptDecomp_31ce3c5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_TOOL: {

--- a/bytecode/bytecode_3ea6d9f.cpp
+++ b/bytecode/bytecode_3ea6d9f.cpp
@@ -494,6 +494,7 @@ Error GDScriptDecomp_3ea6d9f::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_48f1d02.cpp
+++ b/bytecode/bytecode_48f1d02.cpp
@@ -457,6 +457,7 @@ Error GDScriptDecomp_48f1d02::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_TOOL: {

--- a/bytecode/bytecode_4ee82a2.cpp
+++ b/bytecode/bytecode_4ee82a2.cpp
@@ -469,6 +469,7 @@ Error GDScriptDecomp_4ee82a2::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_506df14.cpp
+++ b/bytecode/bytecode_506df14.cpp
@@ -502,6 +502,7 @@ Error GDScriptDecomp_506df14::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class_name ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_513c026.cpp
+++ b/bytecode/bytecode_513c026.cpp
@@ -470,6 +470,7 @@ Error GDScriptDecomp_513c026::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_514a3fb.cpp
+++ b/bytecode/bytecode_514a3fb.cpp
@@ -496,6 +496,7 @@ Error GDScriptDecomp_514a3fb::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class_name ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_5565f55.cpp
+++ b/bytecode/bytecode_5565f55.cpp
@@ -503,6 +503,7 @@ Error GDScriptDecomp_5565f55::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class_name ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_5e938f0.cpp
+++ b/bytecode/bytecode_5e938f0.cpp
@@ -482,6 +482,7 @@ Error GDScriptDecomp_5e938f0::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_6174585.cpp
+++ b/bytecode/bytecode_6174585.cpp
@@ -461,6 +461,7 @@ Error GDScriptDecomp_6174585::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_620ec47.cpp
+++ b/bytecode/bytecode_620ec47.cpp
@@ -499,6 +499,7 @@ Error GDScriptDecomp_620ec47::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class_name ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_62273e5.cpp
+++ b/bytecode/bytecode_62273e5.cpp
@@ -475,6 +475,7 @@ Error GDScriptDecomp_62273e5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_64872ca.cpp
+++ b/bytecode/bytecode_64872ca.cpp
@@ -460,6 +460,7 @@ Error GDScriptDecomp_64872ca::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_65d48d6.cpp
+++ b/bytecode/bytecode_65d48d6.cpp
@@ -456,6 +456,7 @@ Error GDScriptDecomp_65d48d6::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_TOOL: {

--- a/bytecode/bytecode_6694c11.cpp
+++ b/bytecode/bytecode_6694c11.cpp
@@ -502,6 +502,7 @@ Error GDScriptDecomp_6694c11::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class_name ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_703004f.cpp
+++ b/bytecode/bytecode_703004f.cpp
@@ -448,6 +448,7 @@ Error GDScriptDecomp_703004f::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_TOOL: {

--- a/bytecode/bytecode_7124599.cpp
+++ b/bytecode/bytecode_7124599.cpp
@@ -464,6 +464,7 @@ Error GDScriptDecomp_7124599::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_7d2d144.cpp
+++ b/bytecode/bytecode_7d2d144.cpp
@@ -459,6 +459,7 @@ Error GDScriptDecomp_7d2d144::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_7f7d97f.cpp
+++ b/bytecode/bytecode_7f7d97f.cpp
@@ -498,6 +498,7 @@ Error GDScriptDecomp_7f7d97f::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class_name ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_85585c7.cpp
+++ b/bytecode/bytecode_85585c7.cpp
@@ -465,6 +465,7 @@ Error GDScriptDecomp_85585c7::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_8aab9a0.cpp
+++ b/bytecode/bytecode_8aab9a0.cpp
@@ -504,6 +504,7 @@ Error GDScriptDecomp_8aab9a0::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class_name ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_8b912d1.cpp
+++ b/bytecode/bytecode_8b912d1.cpp
@@ -472,6 +472,7 @@ Error GDScriptDecomp_8b912d1::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_8c1731b.cpp
+++ b/bytecode/bytecode_8c1731b.cpp
@@ -446,6 +446,7 @@ Error GDScriptDecomp_8c1731b::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_TOOL: {

--- a/bytecode/bytecode_8cab401.cpp
+++ b/bytecode/bytecode_8cab401.cpp
@@ -449,6 +449,7 @@ Error GDScriptDecomp_8cab401::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_TOOL: {

--- a/bytecode/bytecode_8e35d93.cpp
+++ b/bytecode/bytecode_8e35d93.cpp
@@ -497,6 +497,7 @@ Error GDScriptDecomp_8e35d93::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_91ca725.cpp
+++ b/bytecode/bytecode_91ca725.cpp
@@ -489,6 +489,7 @@ Error GDScriptDecomp_91ca725::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_97f34a1.cpp
+++ b/bytecode/bytecode_97f34a1.cpp
@@ -455,6 +455,7 @@ Error GDScriptDecomp_97f34a1::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_TOOL: {

--- a/bytecode/bytecode_a3f1ee5.cpp
+++ b/bytecode/bytecode_a3f1ee5.cpp
@@ -501,6 +501,7 @@ Error GDScriptDecomp_a3f1ee5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class_name ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_a56d6ff.cpp
+++ b/bytecode/bytecode_a56d6ff.cpp
@@ -493,6 +493,7 @@ Error GDScriptDecomp_a56d6ff::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_a60f242.cpp
+++ b/bytecode/bytecode_a60f242.cpp
@@ -501,6 +501,7 @@ Error GDScriptDecomp_a60f242::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class_name ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_be46be7.cpp
+++ b/bytecode/bytecode_be46be7.cpp
@@ -455,6 +455,7 @@ Error GDScriptDecomp_be46be7::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_TOOL: {

--- a/bytecode/bytecode_c00427a.cpp
+++ b/bytecode/bytecode_c00427a.cpp
@@ -500,6 +500,7 @@ Error GDScriptDecomp_c00427a::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class_name ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_c24c739.cpp
+++ b/bytecode/bytecode_c24c739.cpp
@@ -480,6 +480,7 @@ Error GDScriptDecomp_c24c739::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_c6120e7.cpp
+++ b/bytecode/bytecode_c6120e7.cpp
@@ -484,6 +484,7 @@ Error GDScriptDecomp_c6120e7::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_d28da86.cpp
+++ b/bytecode/bytecode_d28da86.cpp
@@ -486,6 +486,7 @@ Error GDScriptDecomp_d28da86::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_d6b31da.cpp
+++ b/bytecode/bytecode_d6b31da.cpp
@@ -505,6 +505,7 @@ Error GDScriptDecomp_d6b31da::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class_name ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_e82dc40.cpp
+++ b/bytecode/bytecode_e82dc40.cpp
@@ -452,6 +452,7 @@ Error GDScriptDecomp_e82dc40::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_TOOL: {

--- a/bytecode/bytecode_ed80f45.cpp
+++ b/bytecode/bytecode_ed80f45.cpp
@@ -466,6 +466,7 @@ Error GDScriptDecomp_ed80f45::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_f3f05dc.cpp
+++ b/bytecode/bytecode_f3f05dc.cpp
@@ -500,6 +500,7 @@ Error GDScriptDecomp_f3f05dc::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class_name ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {

--- a/bytecode/bytecode_f8a7c46.cpp
+++ b/bytecode/bytecode_f8a7c46.cpp
@@ -479,6 +479,7 @@ Error GDScriptDecomp_f8a7c46::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_ONREADY: {

--- a/bytecode/bytecode_ff1e7cf.cpp
+++ b/bytecode/bytecode_ff1e7cf.cpp
@@ -492,6 +492,7 @@ Error GDScriptDecomp_ff1e7cf::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "class ";
 			} break;
 			case TK_PR_EXTENDS: {
+				_ensure_space(line);
 				line += "extends ";
 			} break;
 			case TK_PR_IS: {


### PR DESCRIPTION
Fixes issue were "class Name extends Original" was rendered as "class Nameextends Original"