### PR TITLE
Standalone: Fix icon display, disable embedded windows, disable binary export, fix CI

### DIFF
--- a/.github/actions/install-swiftshader/action.yml
+++ b/.github/actions/install-swiftshader/action.yml
@@ -26,10 +26,8 @@ runs:
     - name: Install Vulkan SDK
       shell: bash
       if: inputs.install_vulkan_sdk == 'true'
-      env:
-        VULKANSDK_MACOS_URL: https://sdk.lunarg.com/sdk/download/${{ matrix.vulkan_sdk_version }}/mac/vulkansdk-macos-${{ matrix.vulkan_sdk_version }}.dmg?Human=true
       run : |
-        wget "${{ env.VULKANSDK_MACOS_URL }}" -O vulkansdk.dmg
+        wget "https://sdk.lunarg.com/sdk/download/${{ matrix.vulkan_sdk_version }}/mac/vulkansdk-macos-${{ matrix.vulkan_sdk_version }}.dmg?Human=true" -O vulkansdk.dmg
         hdiutil attach vulkansdk.dmg
         sudo /Volumes/vulkansdk-macos-${{ matrix.vulkan_sdk_version }}/InstallVulkan.app/Contents/MacOS/InstallVulkan --root $GITHUB_WORKSPACE/vulkansdk-macos-${{ matrix.vulkan_sdk_version }} --accept-licenses --default-answer --confirm-command install
         hdiutil detach /Volumes/vulkansdk-macos-${{ matrix.vulkan_sdk_version }}
@@ -37,6 +35,7 @@ runs:
         echo "VULKAN_SDK=$VULKAN_SDK_PATH/macOS >> $GITHUB_ENV"
         echo "DYLD_LIBRARY_PATH=$VULKAN_SDK/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=$VULKAN_SDK/bin:$PATH >> $GITHUB_ENV"
+        echo $GITHUB_ENV
 
     - name: Install Swiftshader
       env:

--- a/.github/actions/install-swiftshader/action.yml
+++ b/.github/actions/install-swiftshader/action.yml
@@ -27,11 +27,11 @@ runs:
       shell: bash
       if: inputs.install_vulkan_sdk == 'true'
       run : |
-        wget "https://sdk.lunarg.com/sdk/download/${{ matrix.vulkan_sdk_version }}/mac/vulkansdk-macos-${{ matrix.vulkan_sdk_version }}.dmg?Human=true" -O vulkansdk.dmg
+        wget "https://sdk.lunarg.com/sdk/download/${{ inputs.vulkan_sdk_version }}/mac/vulkansdk-macos-${{ inputs.vulkan_sdk_version }}.dmg?Human=true" -O vulkansdk.dmg
         hdiutil attach vulkansdk.dmg
-        sudo /Volumes/vulkansdk-macos-${{ matrix.vulkan_sdk_version }}/InstallVulkan.app/Contents/MacOS/InstallVulkan --root $GITHUB_WORKSPACE/vulkansdk-macos-${{ matrix.vulkan_sdk_version }} --accept-licenses --default-answer --confirm-command install
-        hdiutil detach /Volumes/vulkansdk-macos-${{ matrix.vulkan_sdk_version }}
-        echo "VULKAN_SDK_PATH=$GITHUB_WORKSPACE/vulkansdk-macos-${{ matrix.vulkan_sdk_version }} >> $GITHUB_ENV"
+        sudo /Volumes/vulkansdk-macos-${{ inputs.vulkan_sdk_version }}/InstallVulkan.app/Contents/MacOS/InstallVulkan --root $GITHUB_WORKSPACE/vulkansdk-macos-${{ inputs.vulkan_sdk_version }} --accept-licenses --default-answer --confirm-command install
+        hdiutil detach /Volumes/vulkansdk-macos-${{ inputs.vulkan_sdk_version }}
+        echo "VULKAN_SDK_PATH=$GITHUB_WORKSPACE/vulkansdk-macos-${{ inputs.vulkan_sdk_version }} >> $GITHUB_ENV"
         echo "VULKAN_SDK=$VULKAN_SDK_PATH/macOS >> $GITHUB_ENV"
         echo "DYLD_LIBRARY_PATH=$VULKAN_SDK/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=$VULKAN_SDK/bin:$PATH >> $GITHUB_ENV"

--- a/.github/actions/install-swiftshader/action.yml
+++ b/.github/actions/install-swiftshader/action.yml
@@ -18,7 +18,8 @@ runs:
         SWIFTSHADER_WINDOWS_URL: https://github.com/nikitalita/swiftshader-dist-win/releases/download/2021-12-09_00-02/swiftshader-2021-12-09_00-02-subzero.7z.zip
         SWIFTSHADER_LINUX_URL: https://github.com/qarmin/gtk_library_store/releases/download/3.24.0/swiftshader2.zip
         SWIFTSHADER_MACOS_URL: https://github.com/nikitalita/swiftshader-builds/releases/download/1.0.0/swiftshader-vulkan-r6216.7997cbc34b-macos-10.15.zip
-        VULKANSDK_MACOS_URL: https://github.com/nikitalita/swiftshader-builds/releases/download/1.0.0/vulkansdk-macos-1.3.204.1.dmg
+        VULKANSDK_MACOS_URL: https://sdk.lunarg.com/sdk/download/1.3.204.1/mac/vulkansdk-macos-1.3.204.1.dmg?Human=true
+        VULKAN_VERSION: 1.3.204.1
       shell: bash
       run: |
         export SWIFTSHADER_DEST_DIR='${{ inputs.path }}'
@@ -42,10 +43,10 @@ runs:
           echo "VK_ICD_FILENAMES=$SWIFTSHADER_DEST_DIR/vk_swiftshader_icd.json" >> $GITHUB_ENV
           wget ${{ env.VULKANSDK_MACOS_URL }} -O vulkansdk.dmg
           hdiutil attach vulkansdk.dmg
-          sudo /Volumes/vulkansdk/InstallVulkan.app/Contents/MacOS/InstallVulkan --root $GITHUB_WORKSPACE/vulkansdk --accept-licenses --default-answer --confirm-command install
-          hdiutil detach /Volumes/vulkansdk
-          echo "VULKAN_SDK=$GITHUB_WORKSPACE/vulkansdk/macOS >> $GITHUB_ENV"
-          echo "DYLD_LIBRARY_PATH=$GITHUB_WORKSPACE/vulkansdk/macOS/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
+          sudo /Volumes/vulkansdk-macos-${{ env.VULKAN_VERSION }}/InstallVulkan.app/Contents/MacOS/InstallVulkan --root $GITHUB_WORKSPACE/vulkansdk-macos-${{ env.VULKAN_VERSION }} --accept-licenses --default-answer --confirm-command install
+          hdiutil detach /Volumes/vulkansdk-macos-${{ env.VULKAN_VERSION }}
+          echo "VULKAN_SDK=$GITHUB_WORKSPACE/vulkansdk-macos-${{ env.VULKAN_VERSION }}/macOS >> $GITHUB_ENV"
+          echo "DYLD_LIBRARY_PATH=$GITHUB_WORKSPACE/vulkansdk-macos-${{ env.VULKAN_VERSION }}/macOS/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
         elif [ "$RUNNER_OS" == "Windows" ]; then
           arch="x64"
           if [ "${{ inputs.bits }}" == "32" ]; then

--- a/.github/actions/install-swiftshader/action.yml
+++ b/.github/actions/install-swiftshader/action.yml
@@ -18,7 +18,7 @@ runs:
         SWIFTSHADER_WINDOWS_URL: https://github.com/nikitalita/swiftshader-dist-win/releases/download/2021-12-09_00-02/swiftshader-2021-12-09_00-02-subzero.7z.zip
         SWIFTSHADER_LINUX_URL: https://github.com/qarmin/gtk_library_store/releases/download/3.24.0/swiftshader2.zip
         SWIFTSHADER_MACOS_URL: https://github.com/nikitalita/swiftshader-builds/releases/download/1.0.0/swiftshader-vulkan-r6216.7997cbc34b-macos-10.15.zip
-        VULKANSDK_MACOS_URL: https://sdk.lunarg.com/sdk/download/1.3.204.1/mac/vulkansdk-macos-1.3.204.1.dmg?Human=true
+        VULKANSDK_MACOS_URL: https://github.com/nikitalita/swiftshader-builds/releases/download/1.0.0/vulkansdk-macos-1.3.204.1.dmg
       shell: bash
       run: |
         export SWIFTSHADER_DEST_DIR='${{ inputs.path }}'

--- a/.github/actions/install-swiftshader/action.yml
+++ b/.github/actions/install-swiftshader/action.yml
@@ -1,26 +1,51 @@
-name: Install SwiftShader
-description: Install SwiftShader and set environment to 
+name: Install Vulkan and Swiftshader
+description: Install Vulkan and SwiftShader and set appropriate environment variables
 inputs:
+  install_swiftshader:
+    description: If swiftshader should be installed
+    default: false
   path:
     description: The absolute folder path to extract the SwiftShader shared library to.
     default: '${{ github.workspace }}'
   bits:
     decription: 32 or 64 (only on Windows)
     default: 64
+  install_vulkan_sdk:
+    description: Whether or not the vulkan SDK should also be installed
+    default: false
+  vulkan_sdk_version:
+    description: If installing the SDK, which version to install
+    default: 1.3.204.1
+
   # backend:
   #   description: Vulkan or GLES.
   #   default: "Vulkan"
 runs:
   using: "composite"
   steps:
-    - name: Scons Build
+    - name: Install Vulkan SDK
+      shell: bash
+      if: inputs.install_vulkan_sdk == 'true'
+      env:
+        VULKANSDK_MACOS_URL: https://sdk.lunarg.com/sdk/download/${{ matrix.vulkan_sdk_version }}/mac/vulkansdk-macos-${{ matrix.vulkan_sdk_version }}.dmg?Human=true
+      run : |
+        wget "${{ env.VULKANSDK_MACOS_URL }}" -O vulkansdk.dmg
+        hdiutil attach vulkansdk.dmg
+        sudo /Volumes/vulkansdk-macos-${{ matrix.vulkan_sdk_version }}/InstallVulkan.app/Contents/MacOS/InstallVulkan --root $GITHUB_WORKSPACE/vulkansdk-macos-${{ matrix.vulkan_sdk_version }} --accept-licenses --default-answer --confirm-command install
+        hdiutil detach /Volumes/vulkansdk-macos-${{ matrix.vulkan_sdk_version }}
+        echo "VULKAN_SDK_PATH=$GITHUB_WORKSPACE/vulkansdk-macos-${{ matrix.vulkan_sdk_version }} >> $GITHUB_ENV"
+        echo "VULKAN_SDK=$VULKAN_SDK_PATH/macOS >> $GITHUB_ENV"
+        echo "DYLD_LIBRARY_PATH=$VULKAN_SDK/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PATH=$VULKAN_SDK/bin:$PATH >> $GITHUB_ENV"
+
+    - name: Install Swiftshader
       env:
         SWIFTSHADER_WINDOWS_URL: https://github.com/nikitalita/swiftshader-dist-win/releases/download/2021-12-09_00-02/swiftshader-2021-12-09_00-02-subzero.7z.zip
         SWIFTSHADER_LINUX_URL: https://github.com/qarmin/gtk_library_store/releases/download/3.24.0/swiftshader2.zip
         SWIFTSHADER_MACOS_URL: https://github.com/nikitalita/swiftshader-builds/releases/download/1.0.0/swiftshader-vulkan-r6216.7997cbc34b-macos-10.15.zip
-        VULKANSDK_MACOS_URL: https://sdk.lunarg.com/sdk/download/1.3.204.1/mac/vulkansdk-macos-1.3.204.1.dmg?Human=true
         VULKAN_VERSION: 1.3.204.1
       shell: bash
+      if: inputs.install_swiftshader == 'true'
       run: |
         export SWIFTSHADER_DEST_DIR='${{ inputs.path }}'
         mkdir -p $SWIFTSHADER_DEST_DIR
@@ -41,12 +66,6 @@ runs:
           rm -rf temp-ss-dl/
           sed -i '' "s/..\/..\/..\/lib\/libvk_swiftshader.dylib/.\/libvk_swiftshader.dylib/" "$SWIFTSHADER_DEST_DIR/vk_swiftshader_icd.json" 
           echo "VK_ICD_FILENAMES=$SWIFTSHADER_DEST_DIR/vk_swiftshader_icd.json" >> $GITHUB_ENV
-          wget ${{ env.VULKANSDK_MACOS_URL }} -O vulkansdk.dmg
-          hdiutil attach vulkansdk.dmg
-          sudo /Volumes/vulkansdk-macos-${{ env.VULKAN_VERSION }}/InstallVulkan.app/Contents/MacOS/InstallVulkan --root $GITHUB_WORKSPACE/vulkansdk-macos-${{ env.VULKAN_VERSION }} --accept-licenses --default-answer --confirm-command install
-          hdiutil detach /Volumes/vulkansdk-macos-${{ env.VULKAN_VERSION }}
-          echo "VULKAN_SDK=$GITHUB_WORKSPACE/vulkansdk-macos-${{ env.VULKAN_VERSION }}/macOS >> $GITHUB_ENV"
-          echo "DYLD_LIBRARY_PATH=$GITHUB_WORKSPACE/vulkansdk-macos-${{ env.VULKAN_VERSION }}/macOS/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
         elif [ "$RUNNER_OS" == "Windows" ]; then
           arch="x64"
           if [ "${{ inputs.bits }}" == "32" ]; then

--- a/.github/actions/install-swiftshader/action.yml
+++ b/.github/actions/install-swiftshader/action.yml
@@ -7,16 +7,29 @@ inputs:
   bits:
     decription: 32 or 64 (only on Windows)
     default: 64
+  install_vulkan_sdk:
+    description: Whether or not the vulkan SDK should also be installed
+    default: false
+  vulkan_sdk_version:
+    description: If installing the SDK, which version to install
+    default: 1.3.204.1
   # backend:
   #   description: Vulkan or GLES.
   #   default: "Vulkan"
 runs:
   using: "composite"
   steps:
+    - name: Install Vulkan SDK
+      if: inputs.install_vulkan_sdk == 'true'
+      uses: humbletim/install-vulkan-sdk@v1.1.1
+      with:
+        version: ${{ inputs.vulkan_sdk_version }}
+        cache: true
+
     - name: Scons Build
       env:
         SWIFTSHADER_WINDOWS_URL: https://github.com/nikitalita/swiftshader-dist-win/releases/download/2021-12-09_00-02/swiftshader-2021-12-09_00-02-subzero.7z.zip
-        SWIFTSHADER_LINUX_URL: https://github.com/qarmin/gtk_library_store/releases/download/3.24.0/swiftshader2.zip
+        SWIFTSHADER_LINUX_URL: https://github.com/godotengine/regression-test-project/releases/download/_ci-deps/swiftshader-ubuntu20.04-20211002.zip
         SWIFTSHADER_MACOS_URL: https://github.com/nikitalita/swiftshader-builds/releases/download/1.0.0/swiftshader-vulkan-r6216.7997cbc34b-macos-10.15.zip
       shell: bash
       run: |
@@ -39,11 +52,7 @@ runs:
           rm -rf temp-ss-dl/
           sed -i '' "s/..\/..\/..\/lib\/libvk_swiftshader.dylib/.\/libvk_swiftshader.dylib/" "$SWIFTSHADER_DEST_DIR/vk_swiftshader_icd.json" 
           echo "VK_ICD_FILENAMES=$SWIFTSHADER_DEST_DIR/vk_swiftshader_icd.json" >> $GITHUB_ENV
-          wget https://sdk.lunarg.com/sdk/download/1.2.189.0/mac/vulkansdk-macos-1.2.189.0.dmg?Human=true -O vulkansdk-macos-1.2.189.0.dmg
-          hdiutil attach vulkansdk-macos-1.2.189.0.dmg
-          sudo /Volumes/vulkansdk-macos-1.2.189.0/InstallVulkan.app/Contents/MacOS/InstallVulkan --root $GITHUB_WORKSPACE/vulkansdk-macos-1.2.189.0 --accept-licenses --default-answer --confirm-command install
-          hdiutil detach /Volumes/vulkansdk-macos-1.2.189.0
-          echo "DYLD_LIBRARY_PATH=$GITHUB_WORKSPACE/vulkansdk-macos-1.2.189.0/macOS/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "DYLD_LIBRARY_PATH=$VULKAN_SDK/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
         elif [ "$RUNNER_OS" == "Windows" ]; then
           arch="x64"
           if [ "${{ inputs.bits }}" == "32" ]; then

--- a/.github/actions/install-swiftshader/action.yml
+++ b/.github/actions/install-swiftshader/action.yml
@@ -31,11 +31,10 @@ runs:
         hdiutil attach vulkansdk.dmg
         sudo /Volumes/vulkansdk-macos-${{ inputs.vulkan_sdk_version }}/InstallVulkan.app/Contents/MacOS/InstallVulkan --root $GITHUB_WORKSPACE/vulkansdk-macos-${{ inputs.vulkan_sdk_version }} --accept-licenses --default-answer --confirm-command install
         hdiutil detach /Volumes/vulkansdk-macos-${{ inputs.vulkan_sdk_version }}
-        echo "VULKAN_SDK_PATH=$GITHUB_WORKSPACE/vulkansdk-macos-${{ inputs.vulkan_sdk_version }} >> $GITHUB_ENV"
-        echo "VULKAN_SDK=$VULKAN_SDK_PATH/macOS >> $GITHUB_ENV"
+        echo "VULKAN_SDK_PATH=$GITHUB_WORKSPACE/vulkansdk-macos-${{ inputs.vulkan_sdk_version }}" >> $GITHUB_ENV
+        echo "VULKAN_SDK=$VULKAN_SDK_PATH/macOS" >> $GITHUB_ENV
         echo "DYLD_LIBRARY_PATH=$VULKAN_SDK/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
-        echo "PATH=$VULKAN_SDK/bin:$PATH >> $GITHUB_ENV"
-        echo $GITHUB_ENV
+        echo "PATH=$VULKAN_SDK/bin:$PATH" >> $GITHUB_ENV
 
     - name: Install Swiftshader
       env:

--- a/.github/actions/install-swiftshader/action.yml
+++ b/.github/actions/install-swiftshader/action.yml
@@ -7,30 +7,18 @@ inputs:
   bits:
     decription: 32 or 64 (only on Windows)
     default: 64
-  install_vulkan_sdk:
-    description: Whether or not the vulkan SDK should also be installed
-    default: false
-  vulkan_sdk_version:
-    description: If installing the SDK, which version to install
-    default: 1.3.204.1
   # backend:
   #   description: Vulkan or GLES.
   #   default: "Vulkan"
 runs:
   using: "composite"
   steps:
-    - name: Install Vulkan SDK
-      if: inputs.install_vulkan_sdk == 'true'
-      uses: humbletim/install-vulkan-sdk@v1.1.1
-      with:
-        version: ${{ inputs.vulkan_sdk_version }}
-        cache: true
-
     - name: Scons Build
       env:
         SWIFTSHADER_WINDOWS_URL: https://github.com/nikitalita/swiftshader-dist-win/releases/download/2021-12-09_00-02/swiftshader-2021-12-09_00-02-subzero.7z.zip
-        SWIFTSHADER_LINUX_URL: https://github.com/godotengine/regression-test-project/releases/download/_ci-deps/swiftshader-ubuntu20.04-20211002.zip
+        SWIFTSHADER_LINUX_URL: https://github.com/qarmin/gtk_library_store/releases/download/3.24.0/swiftshader2.zip
         SWIFTSHADER_MACOS_URL: https://github.com/nikitalita/swiftshader-builds/releases/download/1.0.0/swiftshader-vulkan-r6216.7997cbc34b-macos-10.15.zip
+        VULKANSDK_MACOS_URL: https://sdk.lunarg.com/sdk/download/1.3.204.1/mac/vulkansdk-macos-1.3.204.1.dmg?Human=true
       shell: bash
       run: |
         export SWIFTSHADER_DEST_DIR='${{ inputs.path }}'
@@ -52,7 +40,12 @@ runs:
           rm -rf temp-ss-dl/
           sed -i '' "s/..\/..\/..\/lib\/libvk_swiftshader.dylib/.\/libvk_swiftshader.dylib/" "$SWIFTSHADER_DEST_DIR/vk_swiftshader_icd.json" 
           echo "VK_ICD_FILENAMES=$SWIFTSHADER_DEST_DIR/vk_swiftshader_icd.json" >> $GITHUB_ENV
-          echo "DYLD_LIBRARY_PATH=$VULKAN_SDK/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
+          wget ${{ env.VULKANSDK_MACOS_URL }} -O vulkansdk.dmg
+          hdiutil attach vulkansdk.dmg
+          sudo /Volumes/vulkansdk/InstallVulkan.app/Contents/MacOS/InstallVulkan --root $GITHUB_WORKSPACE/vulkansdk --accept-licenses --default-answer --confirm-command install
+          hdiutil detach /Volumes/vulkansdk
+          echo "VULKAN_SDK=$GITHUB_WORKSPACE/vulkansdk/macOS >> $GITHUB_ENV"
+          echo "DYLD_LIBRARY_PATH=$GITHUB_WORKSPACE/vulkansdk/macOS/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
         elif [ "$RUNNER_OS" == "Windows" ]; then
           arch="x64"
           if [ "${{ inputs.bits }}" == "32" ]; then

--- a/.github/workflows/all_builds.yml
+++ b/.github/workflows/all_builds.yml
@@ -53,7 +53,7 @@ jobs:
             os: "ubuntu-20.04"
             platform: linux
             sconsflags-template: optimize=size use_lto=yes 
-            command-export: $GITHUB_WORKSPACE/bin/godot.linuxbsd.opt.tools.64
+            command-export: ${env:GITHUB_WORKSPACE}/bin/godot.linuxbsd.opt.tools.64
             export-preset: "Linux/X11"
             export-name: .export/gdre_tools.x86_64
 
@@ -62,7 +62,7 @@ jobs:
             platform: osx
             sconsflags: use_volk=no VULKAN_SDK_PATH=$VULKAN_SDK_PATH
             sconsflags-template: optimize=size use_lto=yes use_volk=no VULKAN_SDK_PATH=$VULKAN_SDK_PATH
-            command-export: $GITHUB_WORKSPACE/bin/godot.osx.opt.tools.64
+            command-export: ${env:GITHUB_WORKSPACE}/bin/godot.osx.opt.tools.64
             export-preset: "macOS"
             export-name: .export/gdre_tools.x86_64.zip
 

--- a/.github/workflows/all_builds.yml
+++ b/.github/workflows/all_builds.yml
@@ -25,7 +25,7 @@ env:
   GODOT_BASE_BRANCH: master
   GODOT_MAIN_SYNC_REF: ff75a49227d8d81f99b728fc89b1e4e6e79ed5be
   SCONSFLAGS: verbose=yes warnings=all werror=no module_text_server_fb_enabled=yes debug_symbols=no
-  SCONSFLAGS_TEMPLATE: no_editor_splash=yes module_bmp_enabled=no module_bullet_enabled=no module_camera_enabled=no module_cvtt_enabled=no module_mbedtls_enabled=no module_tga_enabled=no module_enet_enabled=no module_mobile_vr_enabled=no module_upnp_enabled=no module_gdnative_enabled=no module_opensimplex_enabled=no module_pvr_enabled=no module_webm_enabled=no module_websocket_enabled=no module_xatlas_unwrap_enabled=no module_squish_enabled=no use_static_cpp=yes builtin_freetype=yes builtin_libpng=yes builtin_zlib=yes builtin_libwebp=yes builtin_libogg=yes module_csg_enabled=yes module_gridmap_enabled=yes disable_3d=no
+  SCONSFLAGS_TEMPLATE: no_editor_splash=yes module_bmp_enabled=no module_camera_enabled=no module_cvtt_enabled=no module_mbedtls_enabled=no module_tga_enabled=no module_enet_enabled=no module_mobile_vr_enabled=no module_upnp_enabled=no module_noise_enabled=no module_websocket_enabled=no module_xatlas_unwrap_enabled=no module_squish_enabled=no use_static_cpp=yes builtin_freetype=yes builtin_libpng=yes builtin_zlib=yes builtin_libwebp=yes builtin_libogg=yes module_csg_enabled=yes module_gridmap_enabled=yes disable_3d=no
   SCONS_CACHE_MSVC_CONFIG: true
 
 concurrency:
@@ -45,8 +45,7 @@ jobs:
             os: "windows-latest"
             platform: windows
             sconsflags-template: ""
-            command-export: . ${env:GITHUB_WORKSPACE}\bin\godot.windows.opt.tools.64.exe
-            command-postfix: ''
+            command-export: ${env:GITHUB_WORKSPACE}\bin\godot.windows.opt.tools.64.exe
             export-preset: "Windows Desktop"
             export-name: .export\gdre_tools.exe
 
@@ -54,17 +53,15 @@ jobs:
             os: "ubuntu-20.04"
             platform: linux
             sconsflags-template: optimize=size use_lto=yes 
-            command-export: DRI_PRIME=0 xvfb-run $GITHUB_WORKSPACE/bin/godot.linuxbsd.opt.tools.64
-            command-postfix: '|| echo OK'
+            command-export: $GITHUB_WORKSPACE/bin/godot.linuxbsd.opt.tools.64
             export-preset: "Linux/X11"
             export-name: .export/gdre_tools.x86_64
 
           - name: "🍎 macOS"
             os: "macos-latest"
             platform: osx
-            sconsflags-template: optimize=size use_lto=yes 
+            sconsflags-template: optimize=size use_lto=yes use_volk=no VULKAN_SDK_PATH=$VULKAN_SDK_PATH
             command-export: $GITHUB_WORKSPACE/bin/godot.osx.opt.tools.64
-            command-postfix: '|| echo OK'
             export-preset: "macOS"
             export-name: .export/gdre_tools.x86_64.zip
 
@@ -108,7 +105,8 @@ jobs:
       - name: Install swiftshader
         uses: ./.github/actions/install-swiftshader
         with:
-          path: ${{ github.workspace }}/bin
+          install_vulkan_sdk: true
+          install_swiftshader: false
 
       - name: Compilation
         uses: ./.github/actions/godot-build
@@ -157,12 +155,15 @@ jobs:
 
       - name: Export standalone GDRE Tools
         continue-on-error: true
+        shell: pwsh
         run: |
           cd ${{github.workspace}}/modules/gdsdecomp/standalone
           mkdir .export
-          ${{ matrix.command-export }} --headless -e -q ${{ matrix.command-postfix }}
-          ${{ matrix.command-export }} --headless --export "${{ matrix.export-preset }}" ${{ matrix.export-name }} ${{ matrix.command-postfix }}
-
+          $proc = Start-Process -PassThru -FilePath ${{ matrix.command-export }} -ArgumentList '--headless -e --quit'
+          Wait-Process -Id $proc.id -Timeout 300
+          $proc = Start-Process -PassThru -FilePath ${{ matrix.command-export }} -ArgumentList '--headless --export "${{ matrix.export-preset }}" ${{ matrix.export-name }}'
+          Wait-Process -Id $proc.id -Timeout 300
+    
       - uses: actions/upload-artifact@v2
         continue-on-error: true
         with:

--- a/.github/workflows/all_builds.yml
+++ b/.github/workflows/all_builds.yml
@@ -102,8 +102,9 @@ jobs:
       - name: Setup python and scons
         uses: ./.github/actions/godot-deps
         
-      - name: Install swiftshader
+      - name: Install Vulkan SDK
         uses: ./.github/actions/install-swiftshader
+        if: matrix.platform == 'osx'
         with:
           install_vulkan_sdk: true
           install_swiftshader: false

--- a/.github/workflows/all_builds.yml
+++ b/.github/workflows/all_builds.yml
@@ -60,6 +60,7 @@ jobs:
           - name: "🍎 macOS"
             os: "macos-latest"
             platform: osx
+            sconsflags: use_volk=no VULKAN_SDK_PATH=$VULKAN_SDK_PATH
             sconsflags-template: optimize=size use_lto=yes use_volk=no VULKAN_SDK_PATH=$VULKAN_SDK_PATH
             command-export: $GITHUB_WORKSPACE/bin/godot.osx.opt.tools.64
             export-preset: "macOS"

--- a/.github/workflows/all_builds.yml
+++ b/.github/workflows/all_builds.yml
@@ -49,7 +49,6 @@ jobs:
             command-postfix: ''
             export-preset: "Windows Desktop"
             export-name: .export\gdre_tools.exe
-            install_vulkan_sdk: false
 
           - name: "🐧 Linux"
             os: "ubuntu-20.04"
@@ -59,7 +58,6 @@ jobs:
             command-postfix: '|| echo OK'
             export-preset: "Linux/X11"
             export-name: .export/gdre_tools.x86_64
-            install_vulkan_sdk: false
 
           - name: "🍎 macOS"
             os: "macos-latest"
@@ -69,7 +67,6 @@ jobs:
             command-postfix: '|| echo OK'
             export-preset: "macOS"
             export-name: .export/gdre_tools.x86_64.zip
-            install_vulkan_sdk: true
 
     steps:
       - name: checkout-godot
@@ -107,13 +104,11 @@ jobs:
 
       - name: Setup python and scons
         uses: ./.github/actions/godot-deps
-
+        
       - name: Install swiftshader
         uses: ./.github/actions/install-swiftshader
         with:
           path: ${{ github.workspace }}/bin
-          install_vulkan_sdk: ${{ matrix.install_vulkan_sdk }}
-
 
       - name: Compilation
         uses: ./.github/actions/godot-build

--- a/.github/workflows/all_builds.yml
+++ b/.github/workflows/all_builds.yml
@@ -49,6 +49,7 @@ jobs:
             command-postfix: ''
             export-preset: "Windows Desktop"
             export-name: .export\gdre_tools.exe
+            install_vulkan_sdk: false
 
           - name: "🐧 Linux"
             os: "ubuntu-20.04"
@@ -58,6 +59,7 @@ jobs:
             command-postfix: '|| echo OK'
             export-preset: "Linux/X11"
             export-name: .export/gdre_tools.x86_64
+            install_vulkan_sdk: false
 
           - name: "🍎 macOS"
             os: "macos-latest"
@@ -67,6 +69,7 @@ jobs:
             command-postfix: '|| echo OK'
             export-preset: "macOS"
             export-name: .export/gdre_tools.x86_64.zip
+            install_vulkan_sdk: true
 
     steps:
       - name: checkout-godot
@@ -104,11 +107,13 @@ jobs:
 
       - name: Setup python and scons
         uses: ./.github/actions/godot-deps
-        
-      # - name: Install swiftshader
-      #   uses: ./.github/actions/install-swiftshader
-      #   with:
-      #     path: ${{ github.workspace }}/bin
+
+      - name: Install swiftshader
+        uses: ./.github/actions/install-swiftshader
+        with:
+          path: ${{ github.workspace }}/bin
+          install_vulkan_sdk: ${{ matrix.install_vulkan_sdk }}
+
 
       - name: Compilation
         uses: ./.github/actions/godot-build

--- a/SCsub
+++ b/SCsub
@@ -3,13 +3,31 @@
 Import("env")
 Import("env_modules")
 
+from platform_methods import run_in_subprocess
+import gdre_icon_builder
+
 mmp3thirdparty_dir = "#thirdparty/minimp3/"
 liboggthirdparty_dir = "#thirdparty/libogg/"
 
 env_gdsdecomp = env_modules.Clone()
 
 env_gdsdecomp.Append(CPPPATH=["."])
-env_gdsdecomp.Append(CPPPATH=["#thirdparty/nanosvg/"])
+env_gdsdecomp.Append(CPPPATH=["#thirdparty/thorsvg/"])
+
+env_gdsdecomp["BUILDERS"]["MakeGDREIconsBuilder"] = Builder(
+    action=env_gdsdecomp.Run(
+        gdre_icon_builder.make_gdre_icons_action, "Generating default project theme icons header."
+    ),
+    suffix=".h",
+    src_suffix=".svg",
+)
+
+icon_sources = Glob("icons/*.svg")
+
+env_gdsdecomp.Alias(
+    "gdre_icons",
+    [env_gdsdecomp.MakeGDREIconsBuilder("editor/gdre_icons.gen.h", icon_sources)],
+)
 
 if env["builtin_libogg"]:
     env_gdsdecomp.Prepend(CPPPATH=[liboggthirdparty_dir])

--- a/gdre_icon_builder.py
+++ b/gdre_icon_builder.py
@@ -1,0 +1,75 @@
+"""Functions used to generate source files during build time
+
+All such functions are invoked in a subprocess on Windows to prevent build flakiness.
+
+"""
+
+import os
+from io import StringIO
+from platform_methods import subprocess_main
+
+
+# See also `editor/icons/editor_icons_builders.py`.
+def make_gdre_icons_action(target, source, env):
+
+    dst = target[0]
+    svg_icons = source
+
+    icons_string = StringIO()
+
+    for f in svg_icons:
+
+        fname = str(f)
+
+        icons_string.write('\t"')
+
+        with open(fname, "rb") as svgf:
+            b = svgf.read(1)
+            while len(b) == 1:
+                icons_string.write("\\" + str(hex(ord(b)))[1:])
+                b = svgf.read(1)
+
+        icons_string.write('"')
+        if fname != svg_icons[-1]:
+            icons_string.write(",")
+        icons_string.write("\n")
+
+    s = StringIO()
+    s.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n\n")
+    s.write('#include "modules/modules_enabled.gen.h"\n\n')
+    s.write("#ifndef _GDRE_ICONS_H\n")
+    s.write("#define _GDRE_ICONS_H\n")
+    s.write("static const int gdre_icons_count = {};\n\n".format(len(svg_icons)))
+    s.write("#ifdef MODULE_SVG_ENABLED\n")
+    s.write("static const char *gdre_icons_sources[] = {\n")
+    s.write(icons_string.getvalue())
+    s.write("};\n")
+    s.write("#endif // MODULE_SVG_ENABLED\n\n")
+    s.write("static const char *gdre_icons_names[] = {\n")
+
+    for f in svg_icons:
+
+        fname = str(f)
+
+        # Trim the `.svg` extension from the string.
+        icon_name = os.path.basename(fname)[:-4]
+
+        s.write('\t"{0}"'.format(icon_name))
+
+        if fname != svg_icons[-1]:
+            s.write(",")
+        s.write("\n")
+
+    s.write("};\n")
+
+    s.write("#endif\n")
+
+    with open(dst, "w") as f:
+        f.write(s.getvalue())
+
+    s.close()
+    icons_string.close()
+
+
+if __name__ == "__main__":
+    subprocess_main(globals())

--- a/standalone/gdre_icon.png.import
+++ b/standalone/gdre_icon.png.import
@@ -1,9 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture2D"
+type="CompressedTexture2D"
 uid="uid://ced15puo3davk"
-path="res://.godot/imported/gdre_icon.png-8d41c83d97faf920ed253320806f28dd.stex"
+path="res://.godot/imported/gdre_icon.png-8d41c83d97faf920ed253320806f28dd.ctex"
 metadata={
 "vram_texture": false
 }
@@ -11,7 +11,7 @@ metadata={
 [deps]
 
 source_file="res://gdre_icon.png"
-dest_files=["res://.godot/imported/gdre_icon.png-8d41c83d97faf920ed253320806f28dd.stex"]
+dest_files=["res://.godot/imported/gdre_icon.png-8d41c83d97faf920ed253320806f28dd.ctex"]
 
 [params]
 
@@ -21,7 +21,6 @@ compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
-compress/streamed=false
 mipmaps/generate=false
 mipmaps/limit=-1
 roughness/mode=0
@@ -29,7 +28,7 @@ roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
-process/HDR_as_SRGB=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0

--- a/standalone/gdre_main.tscn
+++ b/standalone/gdre_main.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3 uid="uid://el6o5uk15g2c"]
 
-[ext_resource type="Theme" path="res://gdre_theme.tres" id="1"]
+[ext_resource type="Theme" uid="uid://crq1fwn0ajw7b" path="res://gdre_theme.tres" id="1"]
 [ext_resource type="Script" path="res://gdre_main.gd" id="2"]
 
 [node name="root" type="Control"]
@@ -8,9 +8,6 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 theme = ExtResource( "1" )
 script = ExtResource( "2" )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="log_window" type="RichTextLabel" parent="."]
 anchor_right = 1.0
@@ -19,16 +16,9 @@ focus_mode = 2
 theme_override_colors/default_color = Color(0.470588, 0.45098, 0.45098, 1)
 theme_override_constants/line_separation = 5
 selection_enabled = true
-custom_effects = []
-structured_text_bidi_override_options = []
-script = null
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="menu_background" type="Panel" parent="."]
 anchor_right = 1.0
-script = null
 
 [node name="version_lbl" type="Button" parent="menu_background"]
 anchor_left = 1.0
@@ -37,16 +27,10 @@ anchor_right = 1.0
 anchor_bottom = 0.5
 text = "$$$"
 flat = true
-align = 2
-script = null
 
 [node name="re_editor_standalone" type="GodotREEditorStandalone" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-script = null
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [connection signal="pressed" from="menu_background/version_lbl" to="." method="_on_version_lbl_pressed"]
 [connection signal="write_log_message" from="re_editor_standalone" to="." method="_on_re_editor_standalone_write_log_message"]

--- a/standalone/project.godot
+++ b/standalone/project.godot
@@ -25,7 +25,7 @@ window/size/height=1024
 
 [editor]
 
-export/convert_text_resources_to_binary=true
+export/convert_text_resources_to_binary=false
 
 [rendering]
 

--- a/standalone/project.godot
+++ b/standalone/project.godot
@@ -20,6 +20,7 @@ config/features=PackedStringArray("4.0")
 
 [display]
 
+window/subwindows/embed_subwindows=false
 window/size/width=1200
 window/size/height=1024
 

--- a/standalone/project.godot
+++ b/standalone/project.godot
@@ -9,8 +9,7 @@
 config_version=5
 
 _global_script_classes=[]
-_global_script_class_icons={
-}
+_global_script_class_icons={}
 
 [application]
 


### PR DESCRIPTION
We were previously importing all the Editor icons into the theme resource to load the icons in the standalone binary; Godot 4.x doesn't allow you to import the theme resource by reference any more, so we would have to manually update the theme each time, and it also massively bloats the size of that resource. Instead, we now dynamically generate them and include them in a generated header.

I also disabled binary resource conversion upon export because it is currently broken (see https://github.com/godotengine/godot/pull/56185)