### PR TITLE
Update action versions

### DIFF
--- a/.github/workflows/all_builds.yml
+++ b/.github/workflows/all_builds.yml
@@ -69,13 +69,13 @@ jobs:
 
     steps:
       - name: checkout-godot
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: godotengine/godot
           ref: ${{env.GODOT_MAIN_SYNC_REF}}
 
       - name: checkout-gdsdecomp
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: modules/gdsdecomp
           fetch-depth: 0
@@ -124,7 +124,7 @@ jobs:
       - name: Prepare artifact
         uses: ./.github/actions/godot-prepare-artifact
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         continue-on-error: true
         with:
           name: GDRE_tools-editor-${{ matrix.platform }}
@@ -170,7 +170,7 @@ jobs:
 
 
       - name: Download rcedit.exe
-        uses: robinraju/release-downloader@v1
+        uses: robinraju/release-downloader@v1.5
         if: matrix.platform == 'windows'
         with:
           repository: electron/rcedit
@@ -194,7 +194,7 @@ jobs:
           $proc = Start-Process -NoNewWindow -PassThru -FilePath "${{ matrix.command-export }}" -ArgumentList '--headless --export "${{ matrix.export-preset }}" ${{ matrix.export-name }}'
           Wait-Process -Id $proc.id -Timeout 300
     
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         continue-on-error: true
         with:
           name: GDRE_tools-standalone-${{ matrix.platform }}

--- a/.github/workflows/check_api_sync.yml
+++ b/.github/workflows/check_api_sync.yml
@@ -31,14 +31,14 @@ jobs:
 
     steps:
       - name: checkout-godot
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: godotengine/godot
           # check out latest from master branch
           ref: ${{env.GODOT_BASE_BRANCH}}
 
       - name: checkout-gdsdecomp
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: modules/gdsdecomp
           ref: ${{env.GDSDECOMP_BASE_BRANCH}}

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -8,7 +8,7 @@ jobs:
     name: Static checks (clang-format)
     steps:
     - name: checkout-gdsdecomp
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
       # get all history
         fetch-depth: 0


### PR DESCRIPTION
The old GitHub v2 actions are deprecated, upgrade to v3