### PR TITLE
Remove project.binary after recovery

### DIFF
--- a/.github/workflows/all_builds.yml
+++ b/.github/workflows/all_builds.yml
@@ -133,7 +133,6 @@ jobs:
           path: ${{github.workspace}}/bin/*
           retention-days: 90
 
-      # target template_release makes CLI flags not work; use template_debug instead and then just strip it
       - name: Compile godot export template (x86_64)
         uses: ./.github/actions/godot-build
         with:

--- a/utility/gdre_settings.cpp
+++ b/utility/gdre_settings.cpp
@@ -635,6 +635,11 @@ Error GDRESettings::remove_remap(const String &src, const String &dst) {
 	ERR_FAIL_V_MSG(ERR_DOES_NOT_EXIST, "Remap between" + src + " and " + dst + " does not exist!");
 }
 
+String GDRESettings::get_project_config_path() {
+	ERR_FAIL_COND_V_MSG(!is_project_config_loaded(), String(), "project config not loaded!");
+	return current_pack->pcfg->get_cfg_path();
+}
+
 void GDRELogger::logv(const char *p_format, va_list p_list, bool p_err) {
 	if (!should_log(p_err)) {
 		return;

--- a/utility/gdre_settings.h
+++ b/utility/gdre_settings.h
@@ -196,6 +196,7 @@ public:
 	bool has_remap(const String &src, const String &dst) const;
 	Error add_remap(const String &src, const String &dst);
 	Error remove_remap(const String &src, const String &dst);
+	String get_project_config_path();
 	String get_cwd();
 
 	String get_exec_dir();

--- a/utility/import_exporter.cpp
+++ b/utility/import_exporter.cpp
@@ -241,6 +241,7 @@ Error ImportExporter::_export_imports(const String &p_out_dir, const Vector<Stri
 		print_line("ERROR: Failed to save project config!");
 	} else {
 		print_line("Saved " + String(get_ver_major() > 2 ? "project.godot" : "engine.cfg") + " to " + output_dir);
+		dir->remove(get_settings()->get_project_config_path().replace("res://", ""));
 	}
 	print_report();
 	return OK;

--- a/utility/pcfg_loader.cpp
+++ b/utility/pcfg_loader.cpp
@@ -103,7 +103,7 @@ Error ProjectConfigLoader::_load_settings_binary(Ref<FileAccess> f, const String
 		ERR_CONTINUE_MSG(err != OK, "Error decoding property: " + key + ".");
 		props[key] = VariantContainer(value, last_builtin_order++, true);
 	}
-
+	cfb_path = p_path;
 	return OK;
 }
 

--- a/utility/pcfg_loader.h
+++ b/utility/pcfg_loader.h
@@ -55,6 +55,7 @@ public:
 	Variant get_setting(String p_var, Variant default_value) const;
 	Error remove_setting(String p_var);
 	Error set_setting(String p_var, Variant value);
+	String get_cfg_path() { return cfb_path; }
 	int get_major_version() { return (int)get_setting("config_version", 0); }
 	Variant g_set(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false);
 	ProjectConfigLoader();


### PR DESCRIPTION
Leaving project.binary causes the editor to load from it rather than project.godot