### PR TITLE
Rewrite v3 import metadata if source is absolute and inside project tree

### DIFF
--- a/compat/resource_import_metadatav2.cpp
+++ b/compat/resource_import_metadatav2.cpp
@@ -9,12 +9,19 @@ void ResourceImportMetadatav2::set_editor(const String &p_editor) {
 String ResourceImportMetadatav2::get_editor() const {
 	return editor;
 }
-
 void ResourceImportMetadatav2::add_source(const String &p_path, const String &p_md5) {
+	add_source_at(p_path, p_md5, sources.size());
+}
+void ResourceImportMetadatav2::add_source_at(const String &p_path, const String &p_md5, int p_idx) {
 	Source s;
 	s.md5 = p_md5;
 	s.path = p_path;
-	sources.push_back(s);
+	ERR_FAIL_COND(p_idx < 0 || p_idx > sources.size());
+	if (p_idx == sources.size()) {
+		sources.push_back(s);
+	} else {
+		sources.insert(p_idx, s);
+	}
 }
 
 String ResourceImportMetadatav2::get_source_path(int p_idx) const {
@@ -82,6 +89,7 @@ void ResourceImportMetadatav2::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_editor", "name"), &ResourceImportMetadatav2::set_editor);
 	ClassDB::bind_method(D_METHOD("get_editor"), &ResourceImportMetadatav2::get_editor);
 	ClassDB::bind_method(D_METHOD("add_source", "path", "md5"), &ResourceImportMetadatav2::add_source, "");
+	ClassDB::bind_method(D_METHOD("add_source_at", "path", "md5", "p_idx"), &ResourceImportMetadatav2::add_source_at);
 	ClassDB::bind_method(D_METHOD("get_source_path", "idx"), &ResourceImportMetadatav2::get_source_path);
 	ClassDB::bind_method(D_METHOD("get_source_md5", "idx"), &ResourceImportMetadatav2::get_source_md5);
 	ClassDB::bind_method(D_METHOD("set_source_md5", "idx", "md5"), &ResourceImportMetadatav2::set_source_md5);

--- a/compat/resource_import_metadatav2.h
+++ b/compat/resource_import_metadatav2.h
@@ -29,6 +29,7 @@ public:
 	void set_editor(const String &p_editor);
 	String get_editor() const;
 	void add_source(const String &p_path, const String &p_md5 = "");
+	void add_source_at(const String &p_path, const String &p_md5, int p_idx);
 	String get_source_path(int p_idx) const;
 	String get_source_md5(int p_idx) const;
 	void set_source_md5(int p_idx, const String &p_md5);

--- a/utility/import_exporter.h
+++ b/utility/import_exporter.h
@@ -46,7 +46,7 @@ class ImportExporter : public RefCounted {
 	Error rewrite_v2_import_metadata(const String &p_path, const String &p_dst, const String &p_res_name, const String &output_dir);
 	Error export_texture(const String &output_dir, Ref<ImportInfo> &iinfo);
 	Error export_sample(const String &output_dir, Ref<ImportInfo> &iinfo);
-
+	Error rewrite_import_data(const String &rel_dest_path, const String &output_dir, const Ref<ImportInfo> &iinfo);
 	Error _convert_bitmap(const String &output_dir, const String &p_path, const String &p_dst, String *r_name, bool lossy);
 
 	Error _convert_tex(const String &output_dir, const String &p_path, const String &p_dst, String *r_name, bool lossy);

--- a/utility/import_exporter.h
+++ b/utility/import_exporter.h
@@ -27,7 +27,7 @@ class ImportExporter : public RefCounted {
 	bool opt_export_jpg = true;
 	bool opt_export_webp = true;
 	bool opt_rewrite_imd_v2 = true;
-	bool opt_rewrite_imd_v3 = false;
+	bool opt_rewrite_imd_v3 = true;
 	bool opt_decompile = true;
 	bool opt_only_decompile = false;
 	bool had_encryption_error = false;

--- a/utility/import_info.cpp
+++ b/utility/import_info.cpp
@@ -191,12 +191,6 @@ Error ImportInfo::load_from_file_v2(const String &p_path) {
 	if (err == OK) {
 		// If this is a "converted" file, then it won't have import metadata...
 		if (has_import_data()) {
-			// If this is a path outside of the project directory, we change it to the ".assets" directory in the project dir
-			if (get_source_file().begins_with("../") ||
-					(get_source_file().is_absolute_path() && GDRESettings::get_singleton()->is_fs_path(get_source_file()))) {
-				dest = String(".assets").path_join(p_path.replace("res://", "").get_base_dir().path_join(get_source_file().get_file()));
-				source_file = dest;
-			}
 			return OK;
 		} else {
 			not_an_import = true;
@@ -257,26 +251,6 @@ Error ImportInfo::load_from_file_v2(const String &p_path) {
 		}
 	}
 
-	return OK;
-}
-
-Error ImportInfo::rename_source(const String &p_new_source) {
-	ERR_FAIL_COND_V_MSG(ver_major <= 2, ERR_BUG, "Don't use this for version <= 2 ");
-	String old_import_path = import_md_path;
-	String new_import_path = import_md_path.get_base_dir().path_join(p_new_source.get_file() + ".import");
-
-	Ref<ConfigFile> import_file;
-	import_file.instantiate();
-	Error err = import_file->load(import_md_path);
-	ERR_FAIL_COND_V_MSG(err, ERR_BUG, "Failed to load import file " + import_md_path);
-
-	import_file->set_value("deps", "source_file", p_new_source);
-
-	ERR_FAIL_COND_V_MSG(import_file->save(new_import_path) != OK, ERR_BUG, "Failed to save changed import data");
-	cf->set_value("deps", "source_file", p_new_source);
-	source_file = p_new_source;
-	//ERR_FAIL_COND_V_MSG(load_from_file(new_import_path, ver_major, ver_minor) != OK, ERR_BUG, "Failed to reload changed import file");
-	DirAccess::remove_file_or_error(old_import_path);
 	return OK;
 }
 

--- a/utility/import_info.cpp
+++ b/utility/import_info.cpp
@@ -86,7 +86,7 @@ void ImportInfo::_init() {
 	ver_major = 0;
 	ver_minor = 0;
 	dest_files = Vector<String>();
-	preferred_dest = "";
+	export_dest = "";
 	params = Dictionary();
 	v3metadata_prop = Dictionary();
 }

--- a/utility/import_info.h
+++ b/utility/import_info.h
@@ -106,7 +106,6 @@ public:
 	Error reload();
 	virtual String to_string() override;
 	int get_import_loss_type() const;
-	Error rename_source(const String &p_new_source);
 	bool is_auto_converted() const { return auto_converted_export; }
 	bool is_import() const { return !not_an_import; }
 

--- a/utility/import_info.h
+++ b/utility/import_info.h
@@ -68,7 +68,9 @@ private:
 	String source_file; // file to import
 	Vector<String> additional_sources; // For v2 Atlas and large textures
 	Vector<String> dest_files;
-	String preferred_dest;
+	String export_dest;
+	String export_lossless_copy;
+	String resource_name;
 	Dictionary params; // import options (like compression mode, lossy quality, etc.)
 	Ref<ConfigFile> cf; // raw v3-v4 import data
 	Ref<ResourceImportMetadatav2> v2metadata; // Raw v2 import metadata


### PR DESCRIPTION
there are certain cases where godot 3.x will import resources and record the source as an absolute path rather than a relative path. In that case, if the source path is in the project tree, rewrite the import metadata.

This also refactors export path rewriting to occur during `export_imports()` only instead of in import_info and preserves the original source file location in the info