### PR TITLE
Fix v3 InputEventKey

### DIFF
--- a/bytecode/bytecode_015d36d.h
+++ b/bytecode/bytecode_015d36d.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_015d36d(){ engine_ver_major = 3; }
+	GDScriptDecomp_015d36d() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_015d36d.h
+++ b/bytecode/bytecode_015d36d.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_015d36d(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_054a2ac.h
+++ b/bytecode/bytecode_054a2ac.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_054a2ac(){ engine_ver_major = 3; }
+	GDScriptDecomp_054a2ac() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_054a2ac.h
+++ b/bytecode/bytecode_054a2ac.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_054a2ac(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_0b806ee.h
+++ b/bytecode/bytecode_0b806ee.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_0b806ee(){ engine_ver_major = 1; }
+	GDScriptDecomp_0b806ee() { engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_0b806ee.h
+++ b/bytecode/bytecode_0b806ee.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_0b806ee(){ engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_1a36141.h
+++ b/bytecode/bytecode_1a36141.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_1a36141(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_1a36141.h
+++ b/bytecode/bytecode_1a36141.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_1a36141(){ engine_ver_major = 3; }
+	GDScriptDecomp_1a36141() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_1add52b.h
+++ b/bytecode/bytecode_1add52b.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_1add52b(){ engine_ver_major = 3; }
+	GDScriptDecomp_1add52b() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_1add52b.h
+++ b/bytecode/bytecode_1add52b.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_1add52b(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_1ca61a3.h
+++ b/bytecode/bytecode_1ca61a3.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_1ca61a3(){ engine_ver_major = 3; }
+	GDScriptDecomp_1ca61a3() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_1ca61a3.h
+++ b/bytecode/bytecode_1ca61a3.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_1ca61a3(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_216a8aa.h
+++ b/bytecode/bytecode_216a8aa.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_216a8aa(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_216a8aa.h
+++ b/bytecode/bytecode_216a8aa.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_216a8aa(){ engine_ver_major = 3; }
+	GDScriptDecomp_216a8aa() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_2185c01.h
+++ b/bytecode/bytecode_2185c01.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_2185c01(){ engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_2185c01.h
+++ b/bytecode/bytecode_2185c01.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_2185c01(){ engine_ver_major = 1; }
+	GDScriptDecomp_2185c01() { engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_23381a5.h
+++ b/bytecode/bytecode_23381a5.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_23381a5(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_23381a5.h
+++ b/bytecode/bytecode_23381a5.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_23381a5(){ engine_ver_major = 3; }
+	GDScriptDecomp_23381a5() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_23441ec.h
+++ b/bytecode/bytecode_23441ec.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_23441ec(){ engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_23441ec.h
+++ b/bytecode/bytecode_23441ec.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_23441ec(){ engine_ver_major = 2; }
+	GDScriptDecomp_23441ec() { engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_30c1229.h
+++ b/bytecode/bytecode_30c1229.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_30c1229(){ engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_30c1229.h
+++ b/bytecode/bytecode_30c1229.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_30c1229(){ engine_ver_major = 2; }
+	GDScriptDecomp_30c1229() { engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_31ce3c5.h
+++ b/bytecode/bytecode_31ce3c5.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_31ce3c5(){ engine_ver_major = 1; }
+	GDScriptDecomp_31ce3c5() { engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_31ce3c5.h
+++ b/bytecode/bytecode_31ce3c5.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_31ce3c5(){ engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_3ea6d9f.h
+++ b/bytecode/bytecode_3ea6d9f.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_3ea6d9f(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_3ea6d9f.h
+++ b/bytecode/bytecode_3ea6d9f.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_3ea6d9f(){ engine_ver_major = 3; }
+	GDScriptDecomp_3ea6d9f() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_48f1d02.h
+++ b/bytecode/bytecode_48f1d02.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_48f1d02(){ engine_ver_major = 2; }
+	GDScriptDecomp_48f1d02() { engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_48f1d02.h
+++ b/bytecode/bytecode_48f1d02.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_48f1d02(){ engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_4ee82a2.h
+++ b/bytecode/bytecode_4ee82a2.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_4ee82a2(){ engine_ver_major = 3; }
+	GDScriptDecomp_4ee82a2() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_4ee82a2.h
+++ b/bytecode/bytecode_4ee82a2.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_4ee82a2(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_506df14.h
+++ b/bytecode/bytecode_506df14.h
@@ -25,7 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_506df14(){ engine_ver_major = 4; }
+	GDScriptDecomp_506df14() { engine_ver_major = 4; }
 };
 
 #endif

--- a/bytecode/bytecode_506df14.h
+++ b/bytecode/bytecode_506df14.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_506df14(){ engine_ver_major = 4; }
 };
 
 #endif

--- a/bytecode/bytecode_513c026.h
+++ b/bytecode/bytecode_513c026.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_513c026(){ engine_ver_major = 3; }
+	GDScriptDecomp_513c026() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_513c026.h
+++ b/bytecode/bytecode_513c026.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_513c026(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_514a3fb.h
+++ b/bytecode/bytecode_514a3fb.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_514a3fb(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_514a3fb.h
+++ b/bytecode/bytecode_514a3fb.h
@@ -25,7 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_514a3fb(){ engine_ver_major = 3; }
+	GDScriptDecomp_514a3fb() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_5565f55.h
+++ b/bytecode/bytecode_5565f55.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_5565f55(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_5565f55.h
+++ b/bytecode/bytecode_5565f55.h
@@ -25,7 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_5565f55(){ engine_ver_major = 3; }
+	GDScriptDecomp_5565f55() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_5e938f0.h
+++ b/bytecode/bytecode_5e938f0.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_5e938f0(){ engine_ver_major = 3; }
+	GDScriptDecomp_5e938f0() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_5e938f0.h
+++ b/bytecode/bytecode_5e938f0.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_5e938f0(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_6174585.h
+++ b/bytecode/bytecode_6174585.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_6174585(){ engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_6174585.h
+++ b/bytecode/bytecode_6174585.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_6174585(){ engine_ver_major = 2; }
+	GDScriptDecomp_6174585() { engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_620ec47.h
+++ b/bytecode/bytecode_620ec47.h
@@ -25,7 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_620ec47(){ engine_ver_major = 3; }
+	GDScriptDecomp_620ec47() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_620ec47.h
+++ b/bytecode/bytecode_620ec47.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_620ec47(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_62273e5.h
+++ b/bytecode/bytecode_62273e5.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_62273e5(){ engine_ver_major = 3; }
+	GDScriptDecomp_62273e5() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_62273e5.h
+++ b/bytecode/bytecode_62273e5.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_62273e5(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_64872ca.h
+++ b/bytecode/bytecode_64872ca.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_64872ca(){ engine_ver_major = 2; }
+	GDScriptDecomp_64872ca() { engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_64872ca.h
+++ b/bytecode/bytecode_64872ca.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_64872ca(){ engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_65d48d6.h
+++ b/bytecode/bytecode_65d48d6.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_65d48d6(){ engine_ver_major = 1; }
+	GDScriptDecomp_65d48d6() { engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_65d48d6.h
+++ b/bytecode/bytecode_65d48d6.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_65d48d6(){ engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_6694c11.h
+++ b/bytecode/bytecode_6694c11.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_6694c11(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_6694c11.h
+++ b/bytecode/bytecode_6694c11.h
@@ -25,7 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_6694c11(){ engine_ver_major = 3; }
+	GDScriptDecomp_6694c11() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_703004f.h
+++ b/bytecode/bytecode_703004f.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_703004f(){ engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_703004f.h
+++ b/bytecode/bytecode_703004f.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_703004f(){ engine_ver_major = 1; }
+	GDScriptDecomp_703004f() { engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_7124599.h
+++ b/bytecode/bytecode_7124599.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_7124599(){ engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_7124599.h
+++ b/bytecode/bytecode_7124599.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_7124599(){ engine_ver_major = 2; }
+	GDScriptDecomp_7124599() { engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_7d2d144.h
+++ b/bytecode/bytecode_7d2d144.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_7d2d144(){ engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_7d2d144.h
+++ b/bytecode/bytecode_7d2d144.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_7d2d144(){ engine_ver_major = 2; }
+	GDScriptDecomp_7d2d144() { engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_7f7d97f.h
+++ b/bytecode/bytecode_7f7d97f.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_7f7d97f(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_7f7d97f.h
+++ b/bytecode/bytecode_7f7d97f.h
@@ -25,7 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_7f7d97f(){ engine_ver_major = 3; }
+	GDScriptDecomp_7f7d97f() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_85585c7.h
+++ b/bytecode/bytecode_85585c7.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_85585c7(){ engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_85585c7.h
+++ b/bytecode/bytecode_85585c7.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_85585c7(){ engine_ver_major = 2; }
+	GDScriptDecomp_85585c7() { engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_8aab9a0.h
+++ b/bytecode/bytecode_8aab9a0.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_8aab9a0(){ engine_ver_major = 3; }
+	GDScriptDecomp_8aab9a0() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_8aab9a0.h
+++ b/bytecode/bytecode_8aab9a0.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_8aab9a0(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_8b912d1.h
+++ b/bytecode/bytecode_8b912d1.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_8b912d1(){ engine_ver_major = 3; }
+	GDScriptDecomp_8b912d1() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_8b912d1.h
+++ b/bytecode/bytecode_8b912d1.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_8b912d1(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_8c1731b.h
+++ b/bytecode/bytecode_8c1731b.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_8c1731b() { engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_8cab401.h
+++ b/bytecode/bytecode_8cab401.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_8cab401(){ engine_ver_major = 1; }
+	GDScriptDecomp_8cab401() { engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_8cab401.h
+++ b/bytecode/bytecode_8cab401.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_8cab401(){ engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_8e35d93.h
+++ b/bytecode/bytecode_8e35d93.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_8e35d93(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_8e35d93.h
+++ b/bytecode/bytecode_8e35d93.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_8e35d93(){ engine_ver_major = 3; }
+	GDScriptDecomp_8e35d93() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_91ca725.h
+++ b/bytecode/bytecode_91ca725.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_91ca725(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_91ca725.h
+++ b/bytecode/bytecode_91ca725.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_91ca725(){ engine_ver_major = 3; }
+	GDScriptDecomp_91ca725() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_97f34a1.h
+++ b/bytecode/bytecode_97f34a1.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_97f34a1(){ engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_97f34a1.h
+++ b/bytecode/bytecode_97f34a1.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_97f34a1(){ engine_ver_major = 1; }
+	GDScriptDecomp_97f34a1() { engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_a3f1ee5.h
+++ b/bytecode/bytecode_a3f1ee5.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_a3f1ee5(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_a3f1ee5.h
+++ b/bytecode/bytecode_a3f1ee5.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_a3f1ee5(){ engine_ver_major = 3; }
+	GDScriptDecomp_a3f1ee5() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_a56d6ff.h
+++ b/bytecode/bytecode_a56d6ff.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_a56d6ff(){ engine_ver_major = 3; }
+	GDScriptDecomp_a56d6ff() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_a56d6ff.h
+++ b/bytecode/bytecode_a56d6ff.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_a56d6ff(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_a60f242.h
+++ b/bytecode/bytecode_a60f242.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_a60f242(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_a60f242.h
+++ b/bytecode/bytecode_a60f242.h
@@ -25,7 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_a60f242(){ engine_ver_major = 3; }
+	GDScriptDecomp_a60f242() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_base.cpp
+++ b/bytecode/bytecode_base.cpp
@@ -4,6 +4,7 @@
 
 #include "bytecode_base.h"
 #include "compat/file_access_encrypted_v3.h"
+#include "compat/variant_writer_compat.h"
 
 #include "core/config/engine.h"
 #include "core/io/file_access.h"
@@ -86,7 +87,8 @@ String GDScriptDecomp::get_error_message() {
 }
 
 String GDScriptDecomp::get_constant_string(Vector<Variant> &constants, uint32_t constId) {
-	String constString = constants[constId].get_construct_string();
+	String constString;
+	Error err = VariantWriterCompat::write_to_string(constants[constId], constString, engine_ver_major);
 	if (constants[constId].get_type() == Variant::Type::STRING) {
 		constString = constString.replace("\n", "\\n");
 	}

--- a/bytecode/bytecode_base.h
+++ b/bytecode/bytecode_base.h
@@ -22,6 +22,7 @@ protected:
 	String error_message;
 
 public:
+	int engine_ver_major = 4;
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) = 0;
 	Error decompile_byte_code_encrypted(const String &p_path, Vector<uint8_t> p_key, bool is_version_3 = false);
 	Error decompile_byte_code(const String &p_path);

--- a/bytecode/bytecode_base.h
+++ b/bytecode/bytecode_base.h
@@ -20,9 +20,9 @@ protected:
 
 	String script_text;
 	String error_message;
+	int engine_ver_major;
 
 public:
-	int engine_ver_major = 4;
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) = 0;
 	Error decompile_byte_code_encrypted(const String &p_path, Vector<uint8_t> p_key, bool is_version_3 = false);
 	Error decompile_byte_code(const String &p_path);

--- a/bytecode/bytecode_be46be7.h
+++ b/bytecode/bytecode_be46be7.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_be46be7(){ engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_be46be7.h
+++ b/bytecode/bytecode_be46be7.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_be46be7(){ engine_ver_major = 1; }
+	GDScriptDecomp_be46be7() { engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_c00427a.h
+++ b/bytecode/bytecode_c00427a.h
@@ -25,7 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_c00427a(){ engine_ver_major = 3; }
+	GDScriptDecomp_c00427a() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_c00427a.h
+++ b/bytecode/bytecode_c00427a.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_c00427a(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_c24c739.h
+++ b/bytecode/bytecode_c24c739.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_c24c739(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_c24c739.h
+++ b/bytecode/bytecode_c24c739.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_c24c739(){ engine_ver_major = 3; }
+	GDScriptDecomp_c24c739() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_c6120e7.h
+++ b/bytecode/bytecode_c6120e7.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_c6120e7(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_c6120e7.h
+++ b/bytecode/bytecode_c6120e7.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_c6120e7(){ engine_ver_major = 3; }
+	GDScriptDecomp_c6120e7() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_d28da86.h
+++ b/bytecode/bytecode_d28da86.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_d28da86(){ engine_ver_major = 3; }
+	GDScriptDecomp_d28da86() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_d28da86.h
+++ b/bytecode/bytecode_d28da86.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_d28da86(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_d6b31da.h
+++ b/bytecode/bytecode_d6b31da.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_d6b31da(){ engine_ver_major = 3; }
+	GDScriptDecomp_d6b31da() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_d6b31da.h
+++ b/bytecode/bytecode_d6b31da.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_d6b31da(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_e82dc40.h
+++ b/bytecode/bytecode_e82dc40.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_e82dc40(){ engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_e82dc40.h
+++ b/bytecode/bytecode_e82dc40.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_e82dc40(){ engine_ver_major = 1; }
+	GDScriptDecomp_e82dc40() { engine_ver_major = 1; }
 };
 
 #endif

--- a/bytecode/bytecode_ed80f45.h
+++ b/bytecode/bytecode_ed80f45.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_ed80f45(){ engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_ed80f45.h
+++ b/bytecode/bytecode_ed80f45.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_ed80f45(){ engine_ver_major = 2; }
+	GDScriptDecomp_ed80f45() { engine_ver_major = 2; }
 };
 
 #endif

--- a/bytecode/bytecode_f3f05dc.h
+++ b/bytecode/bytecode_f3f05dc.h
@@ -25,7 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_f3f05dc(){ engine_ver_major = 4; }
+	GDScriptDecomp_f3f05dc() { engine_ver_major = 4; }
 };
 
 #endif

--- a/bytecode/bytecode_f3f05dc.h
+++ b/bytecode/bytecode_f3f05dc.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_f3f05dc(){ engine_ver_major = 4; }
 };
 
 #endif

--- a/bytecode/bytecode_f8a7c46.h
+++ b/bytecode/bytecode_f8a7c46.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_f8a7c46(){ engine_ver_major = 3; }
+	GDScriptDecomp_f8a7c46() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_f8a7c46.h
+++ b/bytecode/bytecode_f8a7c46.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_f8a7c46(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_ff1e7cf.h
+++ b/bytecode/bytecode_ff1e7cf.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_ff1e7cf(){ engine_ver_major = 3; }
+	GDScriptDecomp_ff1e7cf() { engine_ver_major = 3; }
 };
 
 #endif

--- a/bytecode/bytecode_ff1e7cf.h
+++ b/bytecode/bytecode_ff1e7cf.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	GDScriptDecomp_ff1e7cf(){ engine_ver_major = 3; }
 };
 
 #endif

--- a/compat/resource_import_metadatav2.cpp
+++ b/compat/resource_import_metadatav2.cpp
@@ -9,12 +9,19 @@ void ResourceImportMetadatav2::set_editor(const String &p_editor) {
 String ResourceImportMetadatav2::get_editor() const {
 	return editor;
 }
-
 void ResourceImportMetadatav2::add_source(const String &p_path, const String &p_md5) {
+	add_source_at(p_path, p_md5, sources.size());
+}
+void ResourceImportMetadatav2::add_source_at(const String &p_path, const String &p_md5, int p_idx) {
 	Source s;
 	s.md5 = p_md5;
 	s.path = p_path;
-	sources.push_back(s);
+	ERR_FAIL_COND(p_idx < 0 || p_idx > sources.size());
+	if (p_idx == sources.size()) {
+		sources.push_back(s);
+	} else {
+		sources.insert(p_idx, s);
+	}
 }
 
 String ResourceImportMetadatav2::get_source_path(int p_idx) const {
@@ -82,6 +89,7 @@ void ResourceImportMetadatav2::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_editor", "name"), &ResourceImportMetadatav2::set_editor);
 	ClassDB::bind_method(D_METHOD("get_editor"), &ResourceImportMetadatav2::get_editor);
 	ClassDB::bind_method(D_METHOD("add_source", "path", "md5"), &ResourceImportMetadatav2::add_source, "");
+	ClassDB::bind_method(D_METHOD("add_source_at", "path", "md5", "p_idx"), &ResourceImportMetadatav2::add_source_at);
 	ClassDB::bind_method(D_METHOD("get_source_path", "idx"), &ResourceImportMetadatav2::get_source_path);
 	ClassDB::bind_method(D_METHOD("get_source_md5", "idx"), &ResourceImportMetadatav2::get_source_md5);
 	ClassDB::bind_method(D_METHOD("set_source_md5", "idx", "md5"), &ResourceImportMetadatav2::set_source_md5);

--- a/compat/resource_import_metadatav2.h
+++ b/compat/resource_import_metadatav2.h
@@ -29,6 +29,7 @@ public:
 	void set_editor(const String &p_editor);
 	String get_editor() const;
 	void add_source(const String &p_path, const String &p_md5 = "");
+	void add_source_at(const String &p_path, const String &p_md5, int p_idx);
 	String get_source_path(int p_idx) const;
 	String get_source_md5(int p_idx) const;
 	void set_source_md5(int p_idx, const String &p_md5);

--- a/compat/variant_decoder_compat.cpp
+++ b/compat/variant_decoder_compat.cpp
@@ -570,7 +570,7 @@ Error VariantDecoderCompat::decode_variant_3(Variant &r_variant, const uint8_t *
 					r_variant = (Object *)nullptr;
 				} else {
 					Object *obj = ClassDB::instantiate(str);
-
+					bool is_input_event_key = str == "InputEventKey";
 					ERR_FAIL_COND_V(!obj, ERR_UNAVAILABLE);
 					ERR_FAIL_COND_V(len < 4, ERR_INVALID_DATA);
 
@@ -600,7 +600,15 @@ Error VariantDecoderCompat::decode_variant_3(Variant &r_variant, const uint8_t *
 						if (r_len) {
 							(*r_len) += used;
 						}
-
+						// Hack for v3 Input Events, which will be the only Objects we encounter encoded into the project.binary
+						// scancode was renamed to keycode in v4
+						if (is_input_event_key) {
+							if (str == "scancode") {
+								str = "keycode";
+							} else if (str == "physical_scancode") {
+								str = "physical_keycode";
+							}
+						}
 						obj->set(str, value);
 					}
 

--- a/compat/variant_decoder_compat.cpp
+++ b/compat/variant_decoder_compat.cpp
@@ -267,7 +267,7 @@ Error VariantDecoderCompat::decode_variant_3(Variant &r_variant, const uint8_t *
 
 	uint32_t type = decode_uint32(buf);
 
-	ERR_FAIL_COND_V((type & ENCODE_MASK) >= 27, ERR_INVALID_DATA);
+	ERR_FAIL_COND_V((type & ENCODE_MASK) >= V3Type::VARIANT_MAX, ERR_INVALID_DATA);
 
 	buf += 4;
 	len -= 4;
@@ -920,7 +920,7 @@ Error VariantDecoderCompat::decode_variant_2(Variant &r_variant, const uint8_t *
 
 	uint32_t type = decode_uint32(buf);
 
-	ERR_FAIL_COND_V((type & ENCODE_MASK) >= 29, ERR_INVALID_DATA);
+	ERR_FAIL_COND_V((type & ENCODE_MASK) >= V2Type::VARIANT_MAX, ERR_INVALID_DATA);
 
 	buf += 4;
 	len -= 4;

--- a/compat/variant_writer_compat.h
+++ b/compat/variant_writer_compat.h
@@ -7,9 +7,11 @@
 #include "core/variant/variant_parser.h"
 
 class VariantParserCompat : VariantParser {
-	static Error fake_parse_object(VariantParser::Token &token, Variant &value, VariantParser::Stream *p_stream, int &line, String &r_err_str, VariantParser::ResourceParser *p_res_parser);
+	static Error _parse_dictionary(Dictionary &object, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser = nullptr);
+	static Error _parse_array(Array &array, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser = nullptr);
 
 public:
+	static Error parse_value(VariantParser::Token &token, Variant &value, VariantParser::Stream *p_stream, int &line, String &r_err_str, VariantParser::ResourceParser *p_res_parser);
 	static Error parse_tag(VariantParser::Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, VariantParser::ResourceParser *p_res_parser = nullptr, bool p_simple_tag = false);
 	static Error parse_tag_assign_eof(VariantParser::Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, String &r_assign, Variant &r_value, VariantParser::ResourceParser *p_res_parser = nullptr, bool p_simple_tag = false);
 };

--- a/utility/import_exporter.cpp
+++ b/utility/import_exporter.cpp
@@ -341,6 +341,8 @@ Error ImportExporter::decompile_scripts(const String &p_out_dir) {
 		default:
 			ERR_FAIL_V_MSG(ERR_FILE_UNRECOGNIZED, "Unknown version, failed to decompile");
 	}
+	// TODO: REMOVE THIS HACK!!!!!
+	decomp->engine_ver_major = get_ver_major();
 	print_line("Script version " + itos(get_ver_major()) + "." + itos(get_ver_minor()) + ".x detected");
 	Error err;
 

--- a/utility/import_exporter.cpp
+++ b/utility/import_exporter.cpp
@@ -341,8 +341,6 @@ Error ImportExporter::decompile_scripts(const String &p_out_dir) {
 		default:
 			ERR_FAIL_V_MSG(ERR_FILE_UNRECOGNIZED, "Unknown version, failed to decompile");
 	}
-	// TODO: REMOVE THIS HACK!!!!!
-	decomp->engine_ver_major = get_ver_major();
 	print_line("Script version " + itos(get_ver_major()) + "." + itos(get_ver_minor()) + ".x detected");
 	Error err;
 

--- a/utility/import_exporter.h
+++ b/utility/import_exporter.h
@@ -46,7 +46,7 @@ class ImportExporter : public RefCounted {
 	Error rewrite_v2_import_metadata(const String &p_path, const String &p_dst, const String &p_res_name, const String &output_dir);
 	Error export_texture(const String &output_dir, Ref<ImportInfo> &iinfo);
 	Error export_sample(const String &output_dir, Ref<ImportInfo> &iinfo);
-
+	Error rewrite_import_data(const String &rel_dest_path, const String &output_dir, const Ref<ImportInfo> &iinfo);
 	Error _convert_bitmap(const String &output_dir, const String &p_path, const String &p_dst, String *r_name, bool lossy);
 
 	Error _convert_tex(const String &output_dir, const String &p_path, const String &p_dst, String *r_name, bool lossy);

--- a/utility/import_exporter.h
+++ b/utility/import_exporter.h
@@ -27,7 +27,7 @@ class ImportExporter : public RefCounted {
 	bool opt_export_jpg = true;
 	bool opt_export_webp = true;
 	bool opt_rewrite_imd_v2 = true;
-	bool opt_rewrite_imd_v3 = false;
+	bool opt_rewrite_imd_v3 = true;
 	bool opt_decompile = true;
 	bool opt_only_decompile = false;
 	bool had_encryption_error = false;

--- a/utility/import_info.cpp
+++ b/utility/import_info.cpp
@@ -191,12 +191,6 @@ Error ImportInfo::load_from_file_v2(const String &p_path) {
 	if (err == OK) {
 		// If this is a "converted" file, then it won't have import metadata...
 		if (has_import_data()) {
-			// If this is a path outside of the project directory, we change it to the ".assets" directory in the project dir
-			if (get_source_file().begins_with("../") ||
-					(get_source_file().is_absolute_path() && GDRESettings::get_singleton()->is_fs_path(get_source_file()))) {
-				dest = String(".assets").path_join(p_path.replace("res://", "").get_base_dir().path_join(get_source_file().get_file()));
-				source_file = dest;
-			}
 			return OK;
 		} else {
 			not_an_import = true;
@@ -257,26 +251,6 @@ Error ImportInfo::load_from_file_v2(const String &p_path) {
 		}
 	}
 
-	return OK;
-}
-
-Error ImportInfo::rename_source(const String &p_new_source) {
-	ERR_FAIL_COND_V_MSG(ver_major <= 2, ERR_BUG, "Don't use this for version <= 2 ");
-	String old_import_path = import_md_path;
-	String new_import_path = import_md_path.get_base_dir().path_join(p_new_source.get_file() + ".import");
-
-	Ref<ConfigFile> import_file;
-	import_file.instantiate();
-	Error err = import_file->load(import_md_path);
-	ERR_FAIL_COND_V_MSG(err, ERR_BUG, "Failed to load import file " + import_md_path);
-
-	import_file->set_value("deps", "source_file", p_new_source);
-
-	ERR_FAIL_COND_V_MSG(import_file->save(new_import_path) != OK, ERR_BUG, "Failed to save changed import data");
-	cf->set_value("deps", "source_file", p_new_source);
-	source_file = p_new_source;
-	//ERR_FAIL_COND_V_MSG(load_from_file(new_import_path, ver_major, ver_minor) != OK, ERR_BUG, "Failed to reload changed import file");
-	DirAccess::remove_file_or_error(old_import_path);
 	return OK;
 }
 

--- a/utility/import_info.cpp
+++ b/utility/import_info.cpp
@@ -86,7 +86,7 @@ void ImportInfo::_init() {
 	ver_major = 0;
 	ver_minor = 0;
 	dest_files = Vector<String>();
-	preferred_dest = "";
+	export_dest = "";
 	params = Dictionary();
 	v3metadata_prop = Dictionary();
 }

--- a/utility/import_info.h
+++ b/utility/import_info.h
@@ -106,7 +106,6 @@ public:
 	Error reload();
 	virtual String to_string() override;
 	int get_import_loss_type() const;
-	Error rename_source(const String &p_new_source);
 	bool is_auto_converted() const { return auto_converted_export; }
 	bool is_import() const { return !not_an_import; }
 

--- a/utility/import_info.h
+++ b/utility/import_info.h
@@ -68,7 +68,9 @@ private:
 	String source_file; // file to import
 	Vector<String> additional_sources; // For v2 Atlas and large textures
 	Vector<String> dest_files;
-	String preferred_dest;
+	String export_dest;
+	String export_lossless_copy;
+	String resource_name;
 	Dictionary params; // import options (like compression mode, lossy quality, etc.)
 	Ref<ConfigFile> cf; // raw v3-v4 import data
 	Ref<ResourceImportMetadatav2> v2metadata; // Raw v2 import metadata


### PR DESCRIPTION
InputEventKey was being written to project.godot incorrectly because InputEventKey.scancode and physical_scancode were renamed in v4. 

Also refactor bytecode to write variants via VariantWriterCompat instead of the v4 one