### PR TITLE
Translation CSV export

### DIFF
--- a/bytecode/bytecode_015d36d.cpp
+++ b/bytecode/bytecode_015d36d.cpp
@@ -230,7 +230,7 @@ Error GDScriptDecomp_015d36d::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -293,7 +293,7 @@ Error GDScriptDecomp_015d36d::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_015d36d.h
+++ b/bytecode/bytecode_015d36d.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_015d36d() { engine_ver_major = 3; }
+	GDScriptDecomp_015d36d() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_054a2ac.cpp
+++ b/bytecode/bytecode_054a2ac.cpp
@@ -238,7 +238,7 @@ Error GDScriptDecomp_054a2ac::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -301,7 +301,7 @@ Error GDScriptDecomp_054a2ac::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_054a2ac.h
+++ b/bytecode/bytecode_054a2ac.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_054a2ac() { engine_ver_major = 3; }
+	GDScriptDecomp_054a2ac() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_0b806ee.cpp
+++ b/bytecode/bytecode_0b806ee.cpp
@@ -195,7 +195,7 @@ Error GDScriptDecomp_0b806ee::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -258,7 +258,7 @@ Error GDScriptDecomp_0b806ee::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_0b806ee.h
+++ b/bytecode/bytecode_0b806ee.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_0b806ee() { engine_ver_major = 1; }
+	GDScriptDecomp_0b806ee() {
+		engine_ver_major = 1;
+		variant_ver_major = 2; // we just use variant parser/writer for v2
+	}
 };
 
 #endif

--- a/bytecode/bytecode_1a36141.cpp
+++ b/bytecode/bytecode_1a36141.cpp
@@ -248,7 +248,7 @@ Error GDScriptDecomp_1a36141::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -311,7 +311,7 @@ Error GDScriptDecomp_1a36141::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_1a36141.h
+++ b/bytecode/bytecode_1a36141.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_1a36141() { engine_ver_major = 3; }
+	GDScriptDecomp_1a36141() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_1add52b.cpp
+++ b/bytecode/bytecode_1add52b.cpp
@@ -218,7 +218,7 @@ Error GDScriptDecomp_1add52b::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -281,7 +281,7 @@ Error GDScriptDecomp_1add52b::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_1add52b.h
+++ b/bytecode/bytecode_1add52b.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_1add52b() { engine_ver_major = 3; }
+	GDScriptDecomp_1add52b() {
+		engine_ver_major = 3;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_1ca61a3.cpp
+++ b/bytecode/bytecode_1ca61a3.cpp
@@ -251,7 +251,7 @@ Error GDScriptDecomp_1ca61a3::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -314,7 +314,7 @@ Error GDScriptDecomp_1ca61a3::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_1ca61a3.h
+++ b/bytecode/bytecode_1ca61a3.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_1ca61a3() { engine_ver_major = 3; }
+	GDScriptDecomp_1ca61a3() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_216a8aa.cpp
+++ b/bytecode/bytecode_216a8aa.cpp
@@ -235,7 +235,7 @@ Error GDScriptDecomp_216a8aa::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -298,7 +298,7 @@ Error GDScriptDecomp_216a8aa::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_216a8aa.h
+++ b/bytecode/bytecode_216a8aa.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_216a8aa() { engine_ver_major = 3; }
+	GDScriptDecomp_216a8aa() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_2185c01.cpp
+++ b/bytecode/bytecode_2185c01.cpp
@@ -203,7 +203,7 @@ Error GDScriptDecomp_2185c01::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -266,7 +266,7 @@ Error GDScriptDecomp_2185c01::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_2185c01.h
+++ b/bytecode/bytecode_2185c01.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_2185c01() { engine_ver_major = 1; }
+	GDScriptDecomp_2185c01() {
+		engine_ver_major = 1;
+		variant_ver_major = 2; // we just use variant parser/writer for v2
+	}
 };
 
 #endif

--- a/bytecode/bytecode_23381a5.cpp
+++ b/bytecode/bytecode_23381a5.cpp
@@ -221,7 +221,7 @@ Error GDScriptDecomp_23381a5::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -284,7 +284,7 @@ Error GDScriptDecomp_23381a5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_23381a5.h
+++ b/bytecode/bytecode_23381a5.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_23381a5() { engine_ver_major = 3; }
+	GDScriptDecomp_23381a5() {
+		engine_ver_major = 3;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_23441ec.cpp
+++ b/bytecode/bytecode_23441ec.cpp
@@ -213,7 +213,7 @@ Error GDScriptDecomp_23441ec::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -276,7 +276,7 @@ Error GDScriptDecomp_23441ec::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_23441ec.h
+++ b/bytecode/bytecode_23441ec.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_23441ec() { engine_ver_major = 2; }
+	GDScriptDecomp_23441ec() {
+		engine_ver_major = 2;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_30c1229.cpp
+++ b/bytecode/bytecode_30c1229.cpp
@@ -208,7 +208,7 @@ Error GDScriptDecomp_30c1229::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -271,7 +271,7 @@ Error GDScriptDecomp_30c1229::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_30c1229.h
+++ b/bytecode/bytecode_30c1229.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_30c1229() { engine_ver_major = 2; }
+	GDScriptDecomp_30c1229() {
+		engine_ver_major = 2;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_31ce3c5.cpp
+++ b/bytecode/bytecode_31ce3c5.cpp
@@ -197,7 +197,7 @@ Error GDScriptDecomp_31ce3c5::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -260,7 +260,7 @@ Error GDScriptDecomp_31ce3c5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_31ce3c5.h
+++ b/bytecode/bytecode_31ce3c5.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_31ce3c5() { engine_ver_major = 1; }
+	GDScriptDecomp_31ce3c5() {
+		engine_ver_major = 1;
+		variant_ver_major = 2; // we just use variant parser/writer for v2
+	}
 };
 
 #endif

--- a/bytecode/bytecode_3ea6d9f.cpp
+++ b/bytecode/bytecode_3ea6d9f.cpp
@@ -241,7 +241,7 @@ Error GDScriptDecomp_3ea6d9f::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -304,7 +304,7 @@ Error GDScriptDecomp_3ea6d9f::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_3ea6d9f.h
+++ b/bytecode/bytecode_3ea6d9f.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_3ea6d9f() { engine_ver_major = 3; }
+	GDScriptDecomp_3ea6d9f() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_48f1d02.cpp
+++ b/bytecode/bytecode_48f1d02.cpp
@@ -207,7 +207,7 @@ Error GDScriptDecomp_48f1d02::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -270,7 +270,7 @@ Error GDScriptDecomp_48f1d02::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_48f1d02.h
+++ b/bytecode/bytecode_48f1d02.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_48f1d02() { engine_ver_major = 2; }
+	GDScriptDecomp_48f1d02() {
+		engine_ver_major = 2;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_4ee82a2.cpp
+++ b/bytecode/bytecode_4ee82a2.cpp
@@ -219,7 +219,7 @@ Error GDScriptDecomp_4ee82a2::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -282,7 +282,7 @@ Error GDScriptDecomp_4ee82a2::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_4ee82a2.h
+++ b/bytecode/bytecode_4ee82a2.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_4ee82a2() { engine_ver_major = 3; }
+	GDScriptDecomp_4ee82a2() {
+		engine_ver_major = 3;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_506df14.cpp
+++ b/bytecode/bytecode_506df14.cpp
@@ -255,7 +255,7 @@ Error GDScriptDecomp_506df14::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -318,7 +318,7 @@ Error GDScriptDecomp_506df14::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_506df14.h
+++ b/bytecode/bytecode_506df14.h
@@ -25,7 +25,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_506df14() { engine_ver_major = 4; }
+	GDScriptDecomp_506df14() {
+		engine_ver_major = 4;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_513c026.cpp
+++ b/bytecode/bytecode_513c026.cpp
@@ -220,7 +220,7 @@ Error GDScriptDecomp_513c026::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -283,7 +283,7 @@ Error GDScriptDecomp_513c026::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_513c026.h
+++ b/bytecode/bytecode_513c026.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_513c026() { engine_ver_major = 3; }
+	GDScriptDecomp_513c026() {
+		engine_ver_major = 3;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_514a3fb.cpp
+++ b/bytecode/bytecode_514a3fb.cpp
@@ -249,7 +249,7 @@ Error GDScriptDecomp_514a3fb::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -312,7 +312,7 @@ Error GDScriptDecomp_514a3fb::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_514a3fb.h
+++ b/bytecode/bytecode_514a3fb.h
@@ -25,7 +25,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_514a3fb() { engine_ver_major = 3; }
+	GDScriptDecomp_514a3fb() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_5565f55.cpp
+++ b/bytecode/bytecode_5565f55.cpp
@@ -256,7 +256,7 @@ Error GDScriptDecomp_5565f55::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -319,7 +319,7 @@ Error GDScriptDecomp_5565f55::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_5565f55.h
+++ b/bytecode/bytecode_5565f55.h
@@ -25,7 +25,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_5565f55() { engine_ver_major = 3; }
+	GDScriptDecomp_5565f55() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_5e938f0.cpp
+++ b/bytecode/bytecode_5e938f0.cpp
@@ -229,7 +229,7 @@ Error GDScriptDecomp_5e938f0::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -292,7 +292,7 @@ Error GDScriptDecomp_5e938f0::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_5e938f0.h
+++ b/bytecode/bytecode_5e938f0.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_5e938f0() { engine_ver_major = 3; }
+	GDScriptDecomp_5e938f0() {
+		engine_ver_major = 3;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_6174585.cpp
+++ b/bytecode/bytecode_6174585.cpp
@@ -211,7 +211,7 @@ Error GDScriptDecomp_6174585::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -274,7 +274,7 @@ Error GDScriptDecomp_6174585::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_6174585.h
+++ b/bytecode/bytecode_6174585.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_6174585() { engine_ver_major = 2; }
+	GDScriptDecomp_6174585() {
+		engine_ver_major = 2;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_620ec47.cpp
+++ b/bytecode/bytecode_620ec47.cpp
@@ -252,7 +252,7 @@ Error GDScriptDecomp_620ec47::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -315,7 +315,7 @@ Error GDScriptDecomp_620ec47::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_620ec47.h
+++ b/bytecode/bytecode_620ec47.h
@@ -25,7 +25,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_620ec47() { engine_ver_major = 3; }
+	GDScriptDecomp_620ec47() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_62273e5.cpp
+++ b/bytecode/bytecode_62273e5.cpp
@@ -225,7 +225,7 @@ Error GDScriptDecomp_62273e5::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -288,7 +288,7 @@ Error GDScriptDecomp_62273e5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_62273e5.h
+++ b/bytecode/bytecode_62273e5.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_62273e5() { engine_ver_major = 3; }
+	GDScriptDecomp_62273e5() {
+		engine_ver_major = 3;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_64872ca.cpp
+++ b/bytecode/bytecode_64872ca.cpp
@@ -210,7 +210,7 @@ Error GDScriptDecomp_64872ca::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -273,7 +273,7 @@ Error GDScriptDecomp_64872ca::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_64872ca.h
+++ b/bytecode/bytecode_64872ca.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_64872ca() { engine_ver_major = 2; }
+	GDScriptDecomp_64872ca() {
+		engine_ver_major = 2;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_65d48d6.cpp
+++ b/bytecode/bytecode_65d48d6.cpp
@@ -206,7 +206,7 @@ Error GDScriptDecomp_65d48d6::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -269,7 +269,7 @@ Error GDScriptDecomp_65d48d6::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_65d48d6.h
+++ b/bytecode/bytecode_65d48d6.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_65d48d6() { engine_ver_major = 1; }
+	GDScriptDecomp_65d48d6() {
+		engine_ver_major = 1;
+		variant_ver_major = 2; // we just use variant parser/writer for v2
+	}
 };
 
 #endif

--- a/bytecode/bytecode_6694c11.cpp
+++ b/bytecode/bytecode_6694c11.cpp
@@ -255,7 +255,7 @@ Error GDScriptDecomp_6694c11::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -318,7 +318,7 @@ Error GDScriptDecomp_6694c11::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_6694c11.h
+++ b/bytecode/bytecode_6694c11.h
@@ -25,7 +25,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_6694c11() { engine_ver_major = 3; }
+	GDScriptDecomp_6694c11() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_703004f.cpp
+++ b/bytecode/bytecode_703004f.cpp
@@ -198,7 +198,7 @@ Error GDScriptDecomp_703004f::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -261,7 +261,7 @@ Error GDScriptDecomp_703004f::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_703004f.h
+++ b/bytecode/bytecode_703004f.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_703004f() { engine_ver_major = 1; }
+	GDScriptDecomp_703004f() {
+		engine_ver_major = 1;
+		variant_ver_major = 2; // we just use variant parser/writer for v2
+	}
 };
 
 #endif

--- a/bytecode/bytecode_7124599.cpp
+++ b/bytecode/bytecode_7124599.cpp
@@ -214,7 +214,7 @@ Error GDScriptDecomp_7124599::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -277,7 +277,7 @@ Error GDScriptDecomp_7124599::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_7124599.h
+++ b/bytecode/bytecode_7124599.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_7124599() { engine_ver_major = 2; }
+	GDScriptDecomp_7124599() {
+		engine_ver_major = 2;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_7d2d144.cpp
+++ b/bytecode/bytecode_7d2d144.cpp
@@ -209,7 +209,7 @@ Error GDScriptDecomp_7d2d144::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -272,7 +272,7 @@ Error GDScriptDecomp_7d2d144::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_7d2d144.h
+++ b/bytecode/bytecode_7d2d144.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_7d2d144() { engine_ver_major = 2; }
+	GDScriptDecomp_7d2d144() {
+		engine_ver_major = 2;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_7f7d97f.cpp
+++ b/bytecode/bytecode_7f7d97f.cpp
@@ -251,7 +251,7 @@ Error GDScriptDecomp_7f7d97f::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -314,7 +314,7 @@ Error GDScriptDecomp_7f7d97f::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_7f7d97f.h
+++ b/bytecode/bytecode_7f7d97f.h
@@ -25,7 +25,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_7f7d97f() { engine_ver_major = 3; }
+	GDScriptDecomp_7f7d97f() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_85585c7.cpp
+++ b/bytecode/bytecode_85585c7.cpp
@@ -215,7 +215,7 @@ Error GDScriptDecomp_85585c7::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -278,7 +278,7 @@ Error GDScriptDecomp_85585c7::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_85585c7.h
+++ b/bytecode/bytecode_85585c7.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_85585c7() { engine_ver_major = 2; }
+	GDScriptDecomp_85585c7() {
+		engine_ver_major = 2;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_8aab9a0.cpp
+++ b/bytecode/bytecode_8aab9a0.cpp
@@ -248,7 +248,7 @@ Error GDScriptDecomp_8aab9a0::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -311,7 +311,7 @@ Error GDScriptDecomp_8aab9a0::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_8aab9a0.h
+++ b/bytecode/bytecode_8aab9a0.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_8aab9a0() { engine_ver_major = 3; }
+	GDScriptDecomp_8aab9a0() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_8b912d1.cpp
+++ b/bytecode/bytecode_8b912d1.cpp
@@ -222,7 +222,7 @@ Error GDScriptDecomp_8b912d1::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -285,7 +285,7 @@ Error GDScriptDecomp_8b912d1::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_8b912d1.h
+++ b/bytecode/bytecode_8b912d1.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_8b912d1() { engine_ver_major = 3; }
+	GDScriptDecomp_8b912d1() {
+		engine_ver_major = 3;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_8c1731b.cpp
+++ b/bytecode/bytecode_8c1731b.cpp
@@ -196,7 +196,7 @@ Error GDScriptDecomp_8c1731b::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -259,7 +259,7 @@ Error GDScriptDecomp_8c1731b::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_8c1731b.h
+++ b/bytecode/bytecode_8c1731b.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_8c1731b() { engine_ver_major = 1; }
+	GDScriptDecomp_8c1731b() {
+		engine_ver_major = 1;
+		variant_ver_major = 2; // we just use variant parser/writer for v2
+	}
 };
 
 #endif

--- a/bytecode/bytecode_8cab401.cpp
+++ b/bytecode/bytecode_8cab401.cpp
@@ -199,7 +199,7 @@ Error GDScriptDecomp_8cab401::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -262,7 +262,7 @@ Error GDScriptDecomp_8cab401::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_8cab401.h
+++ b/bytecode/bytecode_8cab401.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_8cab401() { engine_ver_major = 1; }
+	GDScriptDecomp_8cab401() {
+		engine_ver_major = 1;
+		variant_ver_major = 2; // we just use variant parser/writer for v2
+	}
 };
 
 #endif

--- a/bytecode/bytecode_8e35d93.cpp
+++ b/bytecode/bytecode_8e35d93.cpp
@@ -244,7 +244,7 @@ Error GDScriptDecomp_8e35d93::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -307,7 +307,7 @@ Error GDScriptDecomp_8e35d93::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_8e35d93.h
+++ b/bytecode/bytecode_8e35d93.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_8e35d93() { engine_ver_major = 3; }
+	GDScriptDecomp_8e35d93() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_91ca725.cpp
+++ b/bytecode/bytecode_91ca725.cpp
@@ -236,7 +236,7 @@ Error GDScriptDecomp_91ca725::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -299,7 +299,7 @@ Error GDScriptDecomp_91ca725::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_91ca725.h
+++ b/bytecode/bytecode_91ca725.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_91ca725() { engine_ver_major = 3; }
+	GDScriptDecomp_91ca725() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_97f34a1.cpp
+++ b/bytecode/bytecode_97f34a1.cpp
@@ -205,7 +205,7 @@ Error GDScriptDecomp_97f34a1::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -268,7 +268,7 @@ Error GDScriptDecomp_97f34a1::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_97f34a1.h
+++ b/bytecode/bytecode_97f34a1.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_97f34a1() { engine_ver_major = 1; }
+	GDScriptDecomp_97f34a1() {
+		engine_ver_major = 1;
+		variant_ver_major = 2; // we just use variant parser/writer for v2
+	}
 };
 
 #endif

--- a/bytecode/bytecode_a3f1ee5.cpp
+++ b/bytecode/bytecode_a3f1ee5.cpp
@@ -245,7 +245,7 @@ Error GDScriptDecomp_a3f1ee5::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -308,7 +308,7 @@ Error GDScriptDecomp_a3f1ee5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_a3f1ee5.h
+++ b/bytecode/bytecode_a3f1ee5.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_a3f1ee5() { engine_ver_major = 3; }
+	GDScriptDecomp_a3f1ee5() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_a56d6ff.cpp
+++ b/bytecode/bytecode_a56d6ff.cpp
@@ -240,7 +240,7 @@ Error GDScriptDecomp_a56d6ff::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -303,7 +303,7 @@ Error GDScriptDecomp_a56d6ff::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_a56d6ff.h
+++ b/bytecode/bytecode_a56d6ff.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_a56d6ff() { engine_ver_major = 3; }
+	GDScriptDecomp_a56d6ff() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_a60f242.cpp
+++ b/bytecode/bytecode_a60f242.cpp
@@ -254,7 +254,7 @@ Error GDScriptDecomp_a60f242::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -317,7 +317,7 @@ Error GDScriptDecomp_a60f242::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_a60f242.h
+++ b/bytecode/bytecode_a60f242.h
@@ -25,7 +25,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_a60f242() { engine_ver_major = 3; }
+	GDScriptDecomp_a60f242() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_base.cpp
+++ b/bytecode/bytecode_base.cpp
@@ -28,7 +28,7 @@ void GDScriptDecomp::_ensure_space(String &p_code) {
 	}
 }
 
-Error GDScriptDecomp::decompile_byte_code_encrypted(const String &p_path, Vector<uint8_t> p_key, bool is_version_3) {
+Error GDScriptDecomp::decompile_byte_code_encrypted(const String &p_path, Vector<uint8_t> p_key) {
 	Vector<uint8_t> bytecode;
 
 	Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::READ);
@@ -36,7 +36,7 @@ Error GDScriptDecomp::decompile_byte_code_encrypted(const String &p_path, Vector
 
 	// Godot v3 only encrypted the scripts and used a different format with different header fields,
 	// So we need to use an older version of FAE to access them
-	if (is_version_3) {
+	if (engine_ver_major == 3) {
 		Ref<FileAccessEncryptedv3> fae;
 		fae.instantiate();
 		ERR_FAIL_COND_V(fae.is_null(), ERR_FILE_CORRUPT);
@@ -88,7 +88,7 @@ String GDScriptDecomp::get_error_message() {
 
 String GDScriptDecomp::get_constant_string(Vector<Variant> &constants, uint32_t constId) {
 	String constString;
-	Error err = VariantWriterCompat::write_to_string(constants[constId], constString, engine_ver_major);
+	Error err = VariantWriterCompat::write_to_string(constants[constId], constString, variant_ver_major);
 	if (constants[constId].get_type() == Variant::Type::STRING) {
 		constString = constString.replace("\n", "\\n");
 	}

--- a/bytecode/bytecode_base.h
+++ b/bytecode/bytecode_base.h
@@ -21,10 +21,11 @@ protected:
 	String script_text;
 	String error_message;
 	int engine_ver_major;
+	int variant_ver_major; // Some early dev versions of 3.0 used v2 variants, and early dev versions of 4.0 used v3 variants
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) = 0;
-	Error decompile_byte_code_encrypted(const String &p_path, Vector<uint8_t> p_key, bool is_version_3 = false);
+	Error decompile_byte_code_encrypted(const String &p_path, Vector<uint8_t> p_key);
 	Error decompile_byte_code(const String &p_path);
 
 	String get_script_text();

--- a/bytecode/bytecode_be46be7.cpp
+++ b/bytecode/bytecode_be46be7.cpp
@@ -205,7 +205,7 @@ Error GDScriptDecomp_be46be7::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -268,7 +268,7 @@ Error GDScriptDecomp_be46be7::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_be46be7.h
+++ b/bytecode/bytecode_be46be7.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_be46be7() { engine_ver_major = 1; }
+	GDScriptDecomp_be46be7() {
+		engine_ver_major = 1;
+		variant_ver_major = 2; // we just use variant parser/writer for v2
+	}
 };
 
 #endif

--- a/bytecode/bytecode_c00427a.cpp
+++ b/bytecode/bytecode_c00427a.cpp
@@ -253,7 +253,7 @@ Error GDScriptDecomp_c00427a::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -316,7 +316,7 @@ Error GDScriptDecomp_c00427a::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_c00427a.h
+++ b/bytecode/bytecode_c00427a.h
@@ -25,7 +25,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_c00427a() { engine_ver_major = 3; }
+	GDScriptDecomp_c00427a() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_c24c739.cpp
+++ b/bytecode/bytecode_c24c739.cpp
@@ -227,7 +227,7 @@ Error GDScriptDecomp_c24c739::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -290,7 +290,7 @@ Error GDScriptDecomp_c24c739::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_c24c739.h
+++ b/bytecode/bytecode_c24c739.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_c24c739() { engine_ver_major = 3; }
+	GDScriptDecomp_c24c739() {
+		engine_ver_major = 3;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_c6120e7.cpp
+++ b/bytecode/bytecode_c6120e7.cpp
@@ -231,7 +231,7 @@ Error GDScriptDecomp_c6120e7::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -294,7 +294,7 @@ Error GDScriptDecomp_c6120e7::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_c6120e7.h
+++ b/bytecode/bytecode_c6120e7.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_c6120e7() { engine_ver_major = 3; }
+	GDScriptDecomp_c6120e7() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_d28da86.cpp
+++ b/bytecode/bytecode_d28da86.cpp
@@ -233,7 +233,7 @@ Error GDScriptDecomp_d28da86::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -296,7 +296,7 @@ Error GDScriptDecomp_d28da86::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_d28da86.h
+++ b/bytecode/bytecode_d28da86.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_d28da86() { engine_ver_major = 3; }
+	GDScriptDecomp_d28da86() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_d6b31da.cpp
+++ b/bytecode/bytecode_d6b31da.cpp
@@ -249,7 +249,7 @@ Error GDScriptDecomp_d6b31da::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -312,7 +312,7 @@ Error GDScriptDecomp_d6b31da::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_d6b31da.h
+++ b/bytecode/bytecode_d6b31da.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_d6b31da() { engine_ver_major = 3; }
+	GDScriptDecomp_d6b31da() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_e82dc40.cpp
+++ b/bytecode/bytecode_e82dc40.cpp
@@ -200,7 +200,7 @@ Error GDScriptDecomp_e82dc40::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -263,7 +263,7 @@ Error GDScriptDecomp_e82dc40::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_e82dc40.h
+++ b/bytecode/bytecode_e82dc40.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_e82dc40() { engine_ver_major = 1; }
+	GDScriptDecomp_e82dc40() {
+		engine_ver_major = 1;
+		variant_ver_major = 2; // we just use variant parser/writer for v2
+	}
 };
 
 #endif

--- a/bytecode/bytecode_ed80f45.cpp
+++ b/bytecode/bytecode_ed80f45.cpp
@@ -216,7 +216,7 @@ Error GDScriptDecomp_ed80f45::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -279,7 +279,7 @@ Error GDScriptDecomp_ed80f45::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_ed80f45.h
+++ b/bytecode/bytecode_ed80f45.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_ed80f45() { engine_ver_major = 2; }
+	GDScriptDecomp_ed80f45() {
+		engine_ver_major = 2;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_f3f05dc.cpp
+++ b/bytecode/bytecode_f3f05dc.cpp
@@ -253,7 +253,7 @@ Error GDScriptDecomp_f3f05dc::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -316,7 +316,7 @@ Error GDScriptDecomp_f3f05dc::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_f3f05dc.h
+++ b/bytecode/bytecode_f3f05dc.h
@@ -25,7 +25,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_f3f05dc() { engine_ver_major = 4; }
+	GDScriptDecomp_f3f05dc() {
+		engine_ver_major = 4;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_f8a7c46.cpp
+++ b/bytecode/bytecode_f8a7c46.cpp
@@ -226,7 +226,7 @@ Error GDScriptDecomp_f8a7c46::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_2(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -289,7 +289,7 @@ Error GDScriptDecomp_f8a7c46::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v2(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_f8a7c46.h
+++ b/bytecode/bytecode_f8a7c46.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_f8a7c46() { engine_ver_major = 3; }
+	GDScriptDecomp_f8a7c46() {
+		engine_ver_major = 3;
+		variant_ver_major = 2;
+	}
 };
 
 #endif

--- a/bytecode/bytecode_ff1e7cf.cpp
+++ b/bytecode/bytecode_ff1e7cf.cpp
@@ -239,7 +239,7 @@ Error GDScriptDecomp_ff1e7cf::decompile_buffer(Vector<uint8_t> p_buffer) {
 	for (int i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = VariantDecoderCompat::decode_variant_3(v, b, total_len, &len);
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
 		if (err) {
 			error_message = RTR("Invalid constant");
 			return err;
@@ -302,7 +302,7 @@ Error GDScriptDecomp_ff1e7cf::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += "self";
 			} break;
 			case TK_BUILT_IN_TYPE: {
-				line += VariantDecoderCompat::get_variant_type_name_v3(tokens[i] >> TOKEN_BITS);
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
 				line += func_names[tokens[i] >> TOKEN_BITS];

--- a/bytecode/bytecode_ff1e7cf.h
+++ b/bytecode/bytecode_ff1e7cf.h
@@ -26,7 +26,10 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	GDScriptDecomp_ff1e7cf() { engine_ver_major = 3; }
+	GDScriptDecomp_ff1e7cf() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
 };
 
 #endif

--- a/compat/optimized_translation_extractor.cpp
+++ b/compat/optimized_translation_extractor.cpp
@@ -1,0 +1,49 @@
+#include "optimized_translation_extractor.h"
+extern "C" {
+#include "thirdparty/misc/smaz.h"
+}
+void OptimizedTranslationExtractor::get_message_value_list(List<StringName> *r_messages) const {
+	Vector<int> hash_table;
+	Vector<int> bucket_table;
+	Vector<uint8_t> strings;
+	Variant r_ret;
+	ERR_FAIL_COND_MSG(!_get("hash_table", r_ret), "Fuck!");
+	hash_table = r_ret;
+	ERR_FAIL_COND_MSG(!_get("bucket_table", r_ret), "Fuck!");
+	bucket_table = r_ret;
+	ERR_FAIL_COND_MSG(!_get("strings", r_ret), "Fuck!");
+	strings = r_ret;
+
+	int htsize = hash_table.size();
+
+	if (htsize == 0) {
+		return;
+	}
+
+	const int *htr = hash_table.ptr();
+	const uint32_t *htptr = (const uint32_t *)&htr[0];
+	const int *btr = bucket_table.ptr();
+	const uint32_t *btptr = (const uint32_t *)&btr[0];
+	const uint8_t *sr = strings.ptr();
+	const char *sptr = (const char *)&sr[0];
+
+	for (int i = 0; i < htsize; i++) {
+		uint32_t p = htptr[i];
+		if (p == -1) {
+			continue;
+		}
+		const oteBucket &bucket = *(const oteBucket *)&btptr[p];
+		for (int j = 0; j < bucket.size; j++) {
+			String rstr;
+			if (bucket.elem[j].comp_size == bucket.elem[j].uncomp_size) {
+				rstr.parse_utf8(&sptr[bucket.elem[j].str_offset], bucket.elem[j].uncomp_size);
+			} else {
+				CharString uncomp;
+				uncomp.resize(bucket.elem[j].uncomp_size + 1);
+				smaz_decompress(&sptr[bucket.elem[j].str_offset], bucket.elem[j].comp_size, uncomp.ptrw(), bucket.elem[j].uncomp_size);
+				rstr.parse_utf8(uncomp.get_data());
+			}
+			r_messages->push_back(rstr);
+		}
+	}
+}

--- a/compat/optimized_translation_extractor.h
+++ b/compat/optimized_translation_extractor.h
@@ -1,0 +1,40 @@
+#ifndef __OPTIMIZED_TRANSLATION_EXTRACTOR_H__
+#define __OPTIMIZED_TRANSLATION_EXTRACTOR_H__
+
+#include "core/string/optimized_translation.h"
+
+class OptimizedTranslationExtractor : public OptimizedTranslation {
+	GDCLASS(OptimizedTranslationExtractor, OptimizedTranslation);
+
+	struct oteBucket {
+		int size;
+		uint32_t func;
+
+		struct oteElem {
+			uint32_t key;
+			uint32_t str_offset;
+			uint32_t comp_size;
+			uint32_t uncomp_size;
+		};
+
+		oteElem elem[1];
+	};
+
+	_FORCE_INLINE_ uint32_t hash(uint32_t d, const char *p_str) const {
+		if (d == 0) {
+			d = 0x1000193;
+		}
+		while (*p_str) {
+			d = (d * 0x1000193) ^ uint32_t(*p_str);
+			p_str++;
+		}
+
+		return d;
+	}
+
+public:
+	void get_message_value_list(List<StringName> *r_messages) const;
+	OptimizedTranslationExtractor() {}
+};
+
+#endif // __OPTIMIZED_TRANSLATION_EXTRACTOR_H__

--- a/compat/resource_loader_compat.cpp
+++ b/compat/resource_loader_compat.cpp
@@ -80,7 +80,7 @@ Ref<Resource> ResourceFormatLoaderCompat::load(const String &p_path, const Strin
 	loader->cache_mode = p_cache_mode;
 	loader->use_sub_threads = p_use_sub_threads;
 	if (loader->engine_ver_major != VERSION_MAJOR) {
-		WARN_PRINT(p_path + ": Doing real load on incompatible version " + itos(loader->engine_ver_major));
+		WARN_PRINT_ONCE(p_path + ": Doing real load on incompatible version " + itos(loader->engine_ver_major));
 	}
 
 	*r_error = loader->load();

--- a/compat/variant_decoder_compat.cpp
+++ b/compat/variant_decoder_compat.cpp
@@ -259,6 +259,15 @@ String VariantDecoderCompat::get_variant_type_name_v3(int p_type) {
 	return "";
 }
 
+String VariantDecoderCompat::get_variant_type_name(int p_type, int ver_major) {
+	if (ver_major <= 2) {
+		return get_variant_type_name_v2(p_type);
+	} else if (ver_major == 3) {
+		return get_variant_type_name_v3(p_type);
+	}
+	return Variant::get_type_name((Variant::Type)p_type);
+}
+
 Error VariantDecoderCompat::decode_variant_3(Variant &r_variant, const uint8_t *p_buffer, int p_len, int *r_len, bool p_allow_objects) {
 	const uint8_t *buf = p_buffer;
 	int len = p_len;
@@ -1579,4 +1588,13 @@ Error VariantDecoderCompat::decode_variant_2(Variant &r_variant, const uint8_t *
 	}
 
 	return OK;
+}
+
+Error VariantDecoderCompat::decode_variant_compat(int ver_major, Variant &r_variant, const uint8_t *p_buffer, int p_len, int *r_len, bool p_allow_objects) {
+	if (ver_major <= 2) {
+		return decode_variant_2(r_variant, p_buffer, p_len, r_len, p_allow_objects);
+	} else if (ver_major == 3) {
+		return decode_variant_3(r_variant, p_buffer, p_len, r_len, p_allow_objects);
+	}
+	return decode_variant(r_variant, p_buffer, p_len, r_len, p_allow_objects);
 }

--- a/compat/variant_decoder_compat.h
+++ b/compat/variant_decoder_compat.h
@@ -94,10 +94,12 @@ class VariantDecoderCompat {
 public:
 	static String get_variant_type_name_v3(int p_type);
 	static String get_variant_type_name_v2(int p_type);
+	static String get_variant_type_name(int p_type, int ver_major);
 
 	static Variant::Type variant_type_enum_v3_to_v4(const uint32_t type);
 
 	static Error decode_variant_3(Variant &r_variant, const uint8_t *p_buffer, int p_len, int *r_len = nullptr, bool p_allow_objects = false);
 	static Error decode_variant_2(Variant &r_variant, const uint8_t *p_buffer, int p_len, int *r_len = nullptr, bool p_allow_objects = false);
+	static Error decode_variant_compat(int ver_major, Variant &r_variant, const uint8_t *p_buffer, int p_len, int *r_len = nullptr, bool p_allow_objects = false);
 };
 #endif // VARIANT_DECODER_COMPAT_H

--- a/utility/gdre_settings.h
+++ b/utility/gdre_settings.h
@@ -196,6 +196,8 @@ public:
 	bool has_remap(const String &src, const String &dst) const;
 	Error add_remap(const String &src, const String &dst);
 	Error remove_remap(const String &src, const String &dst);
+	Variant get_project_setting(const String &p_setting);
+	bool has_project_setting(const String &p_setting);
 	String get_project_config_path();
 	String get_cwd();
 

--- a/utility/import_exporter.cpp
+++ b/utility/import_exporter.cpp
@@ -554,9 +554,6 @@ Error ImportExporter::export_translation(const String &output_dir, Ref<ImportInf
 	header += "\n";
 	if (missing_keys) {
 		iinfo->export_dest = "res://.assets/" + iinfo->source_file.replace("res://", "");
-		print_line("WARNING!!! Could not recover " + itos(missing_keys) + " keys for translation.csv");
-		print_line("Saving " + iinfo->source_file.get_file() + " to " + iinfo->export_dest);
-		print_line("If you wish to modify the translation.csv, you will have to manually find the missing keys, replace them in the csv, and then copy it back to " + iinfo->source_file);
 	}
 	String output_path = output_dir.simplify_path().path_join(iinfo->export_dest.replace("res://", ""));
 	err = ensure_dir(output_path.get_base_dir());
@@ -575,6 +572,10 @@ Error ImportExporter::export_translation(const String &output_dir, Ref<ImportInf
 	}
 	f->flush();
 	f = Ref<FileAccess>();
+	if (missing_keys) {
+		translation_export_message += "WARNING: Could not recover " + itos(missing_keys) + " keys for translation.csv" + "\n";
+		translation_export_message += "Saved " + iinfo->source_file.get_file() + " to " + iinfo->export_dest + "\n";
+	}
 	return missing_keys ? ERR_DATABASE_CANT_WRITE : OK;
 }
 
@@ -981,6 +982,11 @@ String ImportExporter::get_editor_message() {
 	report += "Note: the project may be using a custom version of Godot. Detection for this has not been implemented yet." + String("\n");
 	report += "If you find that you have many non-import errors upon opening the project " + String("\n");
 	report += "(i.e. scripts or shaders have many errors), use the original game's binary as the export template." + String("\n");
+	report += translation_export_message;
+	if (!translation_export_message.is_empty()) {
+		report += "If you wish to modify the translation csv(s), you will have to manually find the missing keys, replace them in the csv, and then copy it back to the original path\n";
+		report += "Note: consider just asking the creator if you wish to add a translation\n";
+	}
 	return report;
 }
 String ImportExporter::get_report() {
@@ -1080,6 +1086,7 @@ void ImportExporter::reset_log() {
 	not_converted.clear();
 	decompiled_scripts.clear();
 	failed_scripts.clear();
+	translation_export_message.clear();
 }
 
 void ImportExporter::reset() {

--- a/utility/import_exporter.cpp
+++ b/utility/import_exporter.cpp
@@ -351,7 +351,7 @@ Error ImportExporter::decompile_scripts(const String &p_out_dir) {
 		bool encrypted = false;
 		if (f.get_extension() == "gde") {
 			encrypted = true;
-			err = decomp->decompile_byte_code_encrypted(f, get_settings()->get_encryption_key(), get_ver_major() == 3);
+			err = decomp->decompile_byte_code_encrypted(f, get_settings()->get_encryption_key());
 		} else {
 			err = decomp->decompile_byte_code(f);
 		}

--- a/utility/import_exporter.cpp
+++ b/utility/import_exporter.cpp
@@ -219,7 +219,7 @@ Error ImportExporter::_export_imports(const String &p_out_dir, const Vector<Stri
 				dir->remove(iinfo->import_path.replace("res://", ""));
 			}
 		} else {
-			WARN_PRINT_ONCE("Conversion for Resource of type " + type + "and format " + iinfo->source_file.get_extension() + " not implemented");
+			WARN_PRINT_ONCE("Conversion for Resource of type " + type + " and format " + iinfo->source_file.get_extension() + " not implemented");
 			print_line("Did not convert " + type + " resource " + path);
 			not_converted.push_back(iinfo);
 			continue;
@@ -284,8 +284,8 @@ Error ImportExporter::_export_imports(const String &p_out_dir, const Vector<Stri
 	if (get_settings()->save_project_config(output_dir) != OK) {
 		print_line("ERROR: Failed to save project config!");
 	} else {
-		print_line("Saved " + String(get_ver_major() > 2 ? "project.godot" : "engine.cfg") + " to " + output_dir);
-		dir->remove(get_settings()->get_project_config_path().replace("res://", ""));
+		// Remove binary project config, as editors will load from it instead of the text one
+		dir->remove(get_settings()->get_project_config_path().get_file());
 	}
 	print_report();
 	return OK;

--- a/utility/import_exporter.h
+++ b/utility/import_exporter.h
@@ -33,7 +33,7 @@ class ImportExporter : public RefCounted {
 	bool had_encryption_error = false;
 	Vector<String> decompiled_scripts;
 	Vector<String> failed_scripts;
-
+	String translation_export_message;
 	Vector<Ref<ImportInfo>> lossy_imports;
 	Vector<Ref<ImportInfo>> rewrote_metadata;
 	Vector<Ref<ImportInfo>> failed_rewrite_md;

--- a/utility/import_exporter.h
+++ b/utility/import_exporter.h
@@ -48,6 +48,7 @@ class ImportExporter : public RefCounted {
 	Error export_sample(const String &output_dir, Ref<ImportInfo> &iinfo);
 	Error rewrite_import_data(const String &rel_dest_path, const String &output_dir, const Ref<ImportInfo> &iinfo);
 	Error _convert_bitmap(const String &output_dir, const String &p_path, const String &p_dst, String *r_name, bool lossy);
+	Error export_translation(const String &output_dir, Ref<ImportInfo> &iinfo);
 
 	Error _convert_tex(const String &output_dir, const String &p_path, const String &p_dst, String *r_name, bool lossy);
 	Error _convert_tex_to_jpg(const String &output_dir, const String &p_path, const String &p_dst, String *r_name);

--- a/utility/pcfg_loader.cpp
+++ b/utility/pcfg_loader.cpp
@@ -91,15 +91,7 @@ Error ProjectConfigLoader::_load_settings_binary(Ref<FileAccess> f, const String
 		d.resize(vlen);
 		f->get_buffer(d.ptrw(), vlen);
 		Variant value;
-		if (ver_major == 4) {
-			err = decode_variant(value, d.ptr(), d.size(), NULL, true);
-		} else if (ver_major == 3) {
-			err = VariantDecoderCompat::decode_variant_3(value, d.ptr(), d.size(), NULL, true);
-		} else if (ver_major == 2) {
-			err = VariantDecoderCompat::decode_variant_2(value, d.ptr(), d.size(), NULL, true);
-		} else {
-			err = ERR_INVALID_PARAMETER; //or some other error code
-		}
+		err = VariantDecoderCompat::decode_variant_compat(ver_major, value, d.ptr(), d.size(), NULL, true);
 		ERR_CONTINUE_MSG(err != OK, "Error decoding property: " + key + ".");
 		props[key] = VariantContainer(value, last_builtin_order++, true);
 	}


### PR DESCRIPTION
This is currently of limited use, because the original keys are not able to be recovered from the `translation` files, and we have to guess what the keys are (often wrongly). If we can't recover some of the original keys, we save the translation.csv under `.assets`.

Fixes #88 