### PR TITLE
Fix conversion of auto-converted resources, pack loading

### DIFF
--- a/register_types.cpp
+++ b/register_types.cpp
@@ -49,6 +49,8 @@ void initialize_gdsdecomp_module(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<ScriptCompDialog>();
 	ClassDB::register_class<ScriptDecompDialog>();
 
+	Engine::get_singleton()->add_singleton(Engine::Singleton("GDRECLIMain", memnew(GDRECLIMain)));
+
 #ifdef TOOLS_ENABLED
 	EditorNode::add_init_callback(&gdsdecomp_init_callback);
 #endif

--- a/standalone/gdre_main.gd
+++ b/standalone/gdre_main.gd
@@ -2,7 +2,6 @@ extends Control
 
 var ver_major = 0
 var ver_minor = 0
-var main : GDRECLIMain
 
 func test_text_to_bin(txt_to_bin: String, output_dir: String):
 	var importer:ImportExporter = ImportExporter.new()
@@ -130,13 +129,13 @@ func recovery(input_file:String, output_dir:String, enc_key:String, extract_only
 	var da:DirAccess
 	var is_dir:bool = false
 	var err: int = OK
-	input_file = main.get_cli_abs_path(input_file)
+	input_file = GDRECLIMain.get_cli_abs_path(input_file)
 	if output_dir == "":
 		output_dir = input_file.get_basename()
 		if output_dir.get_extension():
 			output_dir += "_recovery"
 	else:
-		output_dir = main.get_cli_abs_path(output_dir)
+		output_dir = GDRECLIMain.get_cli_abs_path(output_dir)
 
 	da = DirAccess.open(input_file.get_base_dir())
 
@@ -152,22 +151,22 @@ func recovery(input_file:String, output_dir:String, enc_key:String, extract_only
 		print("Error: failed to locate " + input_file)
 		return
 
-	main.open_log(output_dir)
+	GDRECLIMain.open_log(output_dir)
 	if (enc_key != ""):
-		err = main.set_key(enc_key)
+		err = GDRECLIMain.set_key(enc_key)
 		if (err != OK):
 			print("Error: failed to set key!")
 			return
 	
-	err = main.load_pack(input_file)
+	err = GDRECLIMain.load_pack(input_file)
 	if (err != OK):
 		print("Error: failed to open " + input_file)
 		return
 
 	print("Successfully loaded PCK!") 
-	ver_major = main.get_engine_version().split(".")[0].to_int()
-	ver_minor = main.get_engine_version().split(".")[1].to_int()
-	var version:String = main.get_engine_version()
+	ver_major = GDRECLIMain.get_engine_version().split(".")[0].to_int()
+	ver_minor = GDRECLIMain.get_engine_version().split(".")[1].to_int()
+	var version:String = GDRECLIMain.get_engine_version()
 	print("Version: " + version)
 
 	if output_dir != input_file and not is_dir: 
@@ -178,7 +177,7 @@ func recovery(input_file:String, output_dir:String, enc_key:String, extract_only
 		if extract_only:
 			print("Why did you open a folder to extract it??? What's wrong with you?!!?")
 			return
-		if main.copy_dir(input_file, output_dir) != OK:
+		if GDRECLIMain.copy_dir(input_file, output_dir) != OK:
 			print("Error: failed to copy " + input_file + " to " + output_dir)
 			return
 	else:
@@ -191,7 +190,7 @@ func recovery(input_file:String, output_dir:String, enc_key:String, extract_only
 	export_imports(output_dir)
 
 func print_version():
-	print("Godot RE Tools " + main.get_gdre_version())
+	print("Godot RE Tools " + GDRECLIMain.get_gdre_version())
 
 func handle_cli() -> bool:
 	var args = OS.get_cmdline_args()
@@ -202,7 +201,6 @@ func handle_cli() -> bool:
 	var txt_to_bin: String = ""
 	if (args.size() == 0 or (args.size() == 1 and args[0] == "res://gdre_main.tscn")):
 		return false
-	main = GDRECLIMain.new()
 	for i in range(args.size()):
 		var arg:String = args[i]
 		if arg == "--help":
@@ -224,17 +222,17 @@ func handle_cli() -> bool:
 			enc_key = get_arg_value(arg)
 	if input_file != "":
 		recovery(input_file, output_dir, enc_key, false)
-		main.clear_data()
-		main.close_log()
+		GDRECLIMain.clear_data()
+		GDRECLIMain.close_log()
 		get_tree().quit()
 	elif input_extract_file != "":
 		recovery(input_extract_file, output_dir, enc_key, true)
-		main.clear_data()
-		main.close_log()
+		GDRECLIMain.clear_data()
+		GDRECLIMain.close_log()
 		get_tree().quit()
 	elif txt_to_bin != "":
-		txt_to_bin = main.get_cli_abs_path(txt_to_bin)
-		output_dir = main.get_cli_abs_path(output_dir)
+		txt_to_bin = GDRECLIMain.get_cli_abs_path(txt_to_bin)
+		output_dir = GDRECLIMain.get_cli_abs_path(output_dir)
 		test_text_to_bin(txt_to_bin, output_dir)
 		get_tree().quit()
 	else:

--- a/utility/gdre_cli_main.cpp
+++ b/utility/gdre_cli_main.cpp
@@ -1,6 +1,8 @@
 #include "gdre_cli_main.h"
 #include "editor/gdre_version.gen.h"
 
+GDRECLIMain *GDRECLIMain::singleton = nullptr;
+
 Error GDRECLIMain::open_log(const String &path) {
 	return GDRESettings::get_singleton()->open_log_file(path);
 }
@@ -90,10 +92,6 @@ String GDRECLIMain::get_gdre_version() {
 	return GDRE_VERSION;
 }
 GDRECLIMain::GDRECLIMain() {
-	//GDRESettings::get_singleton()->set_is_gui(false);
-	//gdres_singleton = memnew(GDRESettings);
 }
 GDRECLIMain::~GDRECLIMain() {
-	close_log();
-	//memdelete(gdres_singleton);
 }

--- a/utility/gdre_cli_main.h
+++ b/utility/gdre_cli_main.h
@@ -1,12 +1,14 @@
 #ifndef GDRE_CLI_MAIN_H
 #define GDRE_CLI_MAIN_H
 
-#include "core/object/ref_counted.h"
+#include "core/object/object.h"
 
 #include "gdre_settings.h"
-class GDRECLIMain : public RefCounted {
-	GDCLASS(GDRECLIMain, RefCounted);
+class GDRECLIMain : public Object {
+	GDCLASS(GDRECLIMain, Object);
 
+private:
+	static GDRECLIMain *singleton;
 	// private:
 	// 	GDRESettings *gdres_singleton;
 
@@ -14,6 +16,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	GDRECLIMain *get_singleton();
 	Error set_key(const String &key);
 	Error load_pack(const String &path);
 

--- a/utility/gdre_logger.cpp
+++ b/utility/gdre_logger.cpp
@@ -1,0 +1,76 @@
+#include "gdre_logger.h"
+#include "editor/gdre_editor.h"
+#include "gdre_settings.h"
+
+#include "core/io/dir_access.h"
+
+bool inGuiMode() {
+	//check if we are in GUI mode
+	if (GodotREEditor::get_singleton() && GDRESettings::get_singleton() && !GDRESettings::get_singleton()->is_headless()) {
+		return true;
+	}
+	return false;
+}
+
+void GDRELogger::logv(const char *p_format, va_list p_list, bool p_err) {
+	if (!should_log(p_err)) {
+		return;
+	}
+	if (file.is_valid() || inGuiMode()) {
+		const int static_buf_size = 512;
+		char static_buf[static_buf_size];
+		char *buf = static_buf;
+		va_list list_copy;
+		va_copy(list_copy, p_list);
+		int len = vsnprintf(buf, static_buf_size, p_format, p_list);
+		if (len >= static_buf_size) {
+			buf = (char *)Memory::alloc_static(len + 1);
+			vsnprintf(buf, len + 1, p_format, list_copy);
+		}
+		va_end(list_copy);
+
+		if (inGuiMode()) {
+			GodotREEditor::get_singleton()->call_deferred(SNAME("emit_signal"), "write_log_message", String(buf));
+		}
+		if (file.is_valid()) {
+			file->store_buffer((uint8_t *)buf, len);
+
+			if (p_err || _flush_stdout_on_print) {
+				// Don't always flush when printing stdout to avoid performance
+				// issues when `print()` is spammed in release builds.
+				file->flush();
+			}
+		}
+		if (len >= static_buf_size) {
+			Memory::free_static(buf);
+		}
+	}
+}
+
+Error GDRELogger::open_file(const String &p_base_path) {
+	if (file.is_valid()) {
+		return ERR_ALREADY_IN_USE;
+	}
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_USERDATA);
+	if (da.is_valid()) {
+		da->make_dir_recursive(p_base_path.get_base_dir());
+	}
+	Error err;
+	file = FileAccess::open(p_base_path, FileAccess::WRITE, &err);
+	ERR_FAIL_COND_V_MSG(file.is_null(), err, "Failed to open log file " + p_base_path + " for writing.");
+	base_path = p_base_path;
+	return OK;
+}
+
+void GDRELogger::close_file() {
+	if (file.is_valid()) {
+		file->flush();
+		file = Ref<FileAccess>();
+		base_path = "";
+	}
+}
+
+GDRELogger::GDRELogger() {}
+GDRELogger::~GDRELogger() {
+	close_file();
+}

--- a/utility/gdre_logger.h
+++ b/utility/gdre_logger.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "core/io/logger.h"
+
+class GDRELogger : public Logger {
+	Ref<FileAccess> file;
+	String base_path;
+
+public:
+	String get_path() { return base_path; };
+	GDRELogger();
+	Error open_file(const String &p_base_path);
+	void close_file();
+	virtual void logv(const char *p_format, va_list p_list, bool p_err) _PRINTF_FORMAT_ATTRIBUTE_2_0;
+
+	virtual ~GDRELogger();
+};

--- a/utility/gdre_packed_source.cpp
+++ b/utility/gdre_packed_source.cpp
@@ -2,6 +2,193 @@
 #include "core/io/file_access_encrypted.h"
 #include "gdre_settings.h"
 
+uint64_t get_offset_unix(const String &p_path) {
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
+
+	if (f.is_null()) {
+		return 0;
+	}
+
+	// Read and check ELF magic number.
+	{
+		uint32_t magic = f->get_32();
+		if (magic != 0x464c457f) { // 0x7F + "ELF"
+			return 0;
+		}
+	}
+
+	// Read program architecture bits from class field.
+	int bits = f->get_8() * 32;
+
+	// Get info about the section header table.
+	int64_t section_table_pos;
+	int64_t section_header_size;
+	if (bits == 32) {
+		section_header_size = 40;
+		f->seek(0x20);
+		section_table_pos = f->get_32();
+		f->seek(0x30);
+	} else { // 64
+		section_header_size = 64;
+		f->seek(0x28);
+		section_table_pos = f->get_64();
+		f->seek(0x3c);
+	}
+	int num_sections = f->get_16();
+	int string_section_idx = f->get_16();
+
+	// Load the strings table.
+	uint8_t *strings;
+	{
+		// Jump to the strings section header.
+		f->seek(section_table_pos + string_section_idx * section_header_size);
+
+		// Read strings data size and offset.
+		int64_t string_data_pos;
+		int64_t string_data_size;
+		if (bits == 32) {
+			f->seek(f->get_position() + 0x10);
+			string_data_pos = f->get_32();
+			string_data_size = f->get_32();
+		} else { // 64
+			f->seek(f->get_position() + 0x18);
+			string_data_pos = f->get_64();
+			string_data_size = f->get_64();
+		}
+
+		// Read strings data.
+		f->seek(string_data_pos);
+		strings = (uint8_t *)memalloc(string_data_size);
+		if (!strings) {
+			return 0;
+		}
+		f->get_buffer(strings, string_data_size);
+	}
+
+	// Search for the "pck" section.
+	int64_t off = 0;
+	for (int i = 0; i < num_sections; ++i) {
+		int64_t section_header_pos = section_table_pos + i * section_header_size;
+		f->seek(section_header_pos);
+
+		uint32_t name_offset = f->get_32();
+		if (strcmp((char *)strings + name_offset, "pck") == 0) {
+			if (bits == 32) {
+				f->seek(section_header_pos + 0x10);
+				off = f->get_32();
+			} else { // 64
+				f->seek(section_header_pos + 0x18);
+				off = f->get_64();
+			}
+			break;
+		}
+	}
+	memfree(strings);
+	return off;
+}
+
+uint64_t get_offset_windows(const String &p_path) {
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
+	if (f.is_null()) {
+		return 0;
+	}
+	// Process header.
+	{
+		f->seek(0x3c);
+		uint32_t pe_pos = f->get_32();
+
+		f->seek(pe_pos);
+		uint32_t magic = f->get_32();
+		if (magic != 0x00004550) {
+			return 0;
+		}
+	}
+
+	int num_sections;
+	{
+		int64_t header_pos = f->get_position();
+
+		f->seek(header_pos + 2);
+		num_sections = f->get_16();
+		f->seek(header_pos + 16);
+		uint16_t opt_header_size = f->get_16();
+
+		// Skip rest of header + optional header to go to the section headers.
+		f->seek(f->get_position() + 2 + opt_header_size);
+	}
+	int64_t section_table_pos = f->get_position();
+
+	// Search for the "pck" section.
+	int64_t off = 0;
+	for (int i = 0; i < num_sections; ++i) {
+		int64_t section_header_pos = section_table_pos + i * 40;
+		f->seek(section_header_pos);
+
+		uint8_t section_name[9];
+		f->get_buffer(section_name, 8);
+		section_name[8] = '\0';
+
+		if (strcmp((char *)section_name, "pck") == 0) {
+			f->seek(section_header_pos + 20);
+			off = f->get_32();
+			break;
+		}
+	}
+	return off;
+}
+
+bool seek_offset_from_exe(Ref<FileAccess> f, const String &p_path, uint64_t p_offset) {
+	uint64_t off = 0;
+	bool pck_header_found = false;
+	uint32_t magic = 0;
+	// Loading with offset feature not supported for self contained exe files.
+	if (p_offset != 0) {
+		ERR_FAIL_V_MSG(false, "Loading self-contained executable with offset not supported.");
+	}
+
+	int64_t pck_off = p_path.get_extension() == "exe" ? get_offset_windows(p_path) : get_offset_unix(p_path);
+	if (pck_off != 0) {
+		// Search for the header, in case PCK start and section have different alignment.
+		for (int i = 0; i < 8; i++) {
+			f->seek(pck_off);
+			magic = f->get_32();
+			if (magic == PACK_HEADER_MAGIC) {
+#ifdef DEBUG_ENABLED
+				print_verbose("PCK header found in executable pck section, loading from offset 0x" + String::num_int64(pck_off - 4, 16));
+#endif
+				return true;
+			}
+			pck_off++;
+		}
+	}
+
+	// Search for the header at the end of file - self contained executable.
+	if (!pck_header_found) {
+		// Loading with offset feature not supported for self contained exe files.
+		if (p_offset != 0) {
+			ERR_FAIL_V_MSG(false, "Loading self-contained executable with offset not supported.");
+		}
+
+		f->seek_end();
+		f->seek(f->get_position() - 4);
+		magic = f->get_32();
+
+		if (magic == PACK_HEADER_MAGIC) {
+			f->seek(f->get_position() - 12);
+			uint64_t ds = f->get_64();
+			f->seek(f->get_position() - ds - 8);
+			magic = f->get_32();
+			if (magic == PACK_HEADER_MAGIC) {
+#ifdef DEBUG_ENABLED
+				print_verbose("PCK header found at the end of executable, loading from offset 0x" + String::num_int64(f->get_position() - 4, 16));
+#endif
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 bool GDREPackedSource::try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) {
 	if (p_path.get_extension().to_lower() == "apk" || p_path.get_extension().to_lower() == "zip") {
 		return false;
@@ -18,25 +205,7 @@ bool GDREPackedSource::try_open_pack(const String &p_path, bool p_replace_files,
 	uint32_t magic = f->get_32();
 
 	if (magic != PACK_HEADER_MAGIC) {
-		// loading with offset feature not supported for self contained exe files
-		if (p_offset != 0) {
-			ERR_FAIL_V_MSG(false, "Loading self-contained executable with offset not supported.");
-		}
-
-		//maybe at the end.... self contained exe
-		f->seek_end();
-		f->seek(f->get_position() - 4);
-		magic = f->get_32();
-		if (magic != PACK_HEADER_MAGIC) {
-			return false;
-		}
-		f->seek(f->get_position() - 12);
-
-		uint64_t ds = f->get_64();
-		f->seek(f->get_position() - ds - 8);
-
-		magic = f->get_32();
-		if (magic != PACK_HEADER_MAGIC) {
+		if (!seek_offset_from_exe(f, p_path, p_offset)) {
 			return false;
 		}
 		is_exe = true;
@@ -107,7 +276,7 @@ bool GDREPackedSource::try_open_pack(const String &p_path, bool p_replace_files,
 		String path;
 		path.parse_utf8(cs.ptr());
 
-		ERR_FAIL_COND_V_MSG(path.get_file().find("gdre_") != -1, false, "Tried to load a gdre file?!?!");
+		ERR_FAIL_COND_V_MSG(path.get_file().find("gdre_") != -1, false, "Don't try to extract the GDRE pack files, just download the source from github.");
 
 		uint64_t ofs = file_base + f->get_64();
 		uint64_t size = f->get_64();

--- a/utility/gdre_packed_source.cpp
+++ b/utility/gdre_packed_source.cpp
@@ -14,6 +14,7 @@ bool GDREPackedSource::try_open_pack(const String &p_path, bool p_replace_files,
 
 	f->seek(p_offset);
 
+	bool is_exe = false;
 	uint32_t magic = f->get_32();
 
 	if (magic != PACK_HEADER_MAGIC) {
@@ -38,6 +39,7 @@ bool GDREPackedSource::try_open_pack(const String &p_path, bool p_replace_files,
 		if (magic != PACK_HEADER_MAGIC) {
 			return false;
 		}
+		is_exe = true;
 	}
 
 	uint32_t version = f->get_32();
@@ -92,7 +94,7 @@ bool GDREPackedSource::try_open_pack(const String &p_path, bool p_replace_files,
 	pckinfo.instantiate();
 	pckinfo->init(
 			pck_path, ver_major, ver_minor, ver_rev, version, pack_flags, file_base, file_count,
-			itos(ver_major) + "." + itos(ver_minor) + "." + itos(ver_rev), GDRESettings::PackInfo::PCK);
+			itos(ver_major) + "." + itos(ver_minor) + "." + itos(ver_rev), is_exe ? GDRESettings::PackInfo::EXE : GDRESettings::PackInfo::PCK);
 	GDRESettings::get_singleton()->add_pack_info(pckinfo);
 
 	for (uint32_t i = 0; i < file_count; i++) {

--- a/utility/gdre_packed_source.cpp
+++ b/utility/gdre_packed_source.cpp
@@ -1,0 +1,139 @@
+#include "gdre_packed_source.h"
+#include "core/io/file_access_encrypted.h"
+#include "gdre_settings.h"
+
+bool GDREPackedSource::try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) {
+	if (p_path.get_extension().to_lower() == "apk") {
+		return false;
+	}
+	String pck_path = p_path.replace("_GDRE_a_really_dumb_hack", "");
+	Ref<FileAccess> f = FileAccess::open(pck_path, FileAccess::READ);
+	if (f.is_null()) {
+		return false;
+	}
+
+	f->seek(p_offset);
+
+	uint32_t magic = f->get_32();
+
+	if (magic != PACK_HEADER_MAGIC) {
+		// loading with offset feature not supported for self contained exe files
+		if (p_offset != 0) {
+			ERR_FAIL_V_MSG(false, "Loading self-contained executable with offset not supported.");
+		}
+
+		//maybe at the end.... self contained exe
+		f->seek_end();
+		f->seek(f->get_position() - 4);
+		magic = f->get_32();
+		if (magic != PACK_HEADER_MAGIC) {
+			return false;
+		}
+		f->seek(f->get_position() - 12);
+
+		uint64_t ds = f->get_64();
+		f->seek(f->get_position() - ds - 8);
+
+		magic = f->get_32();
+		if (magic != PACK_HEADER_MAGIC) {
+			return false;
+		}
+	}
+
+	uint32_t version = f->get_32();
+	uint32_t ver_major = f->get_32();
+	uint32_t ver_minor = f->get_32();
+	uint32_t ver_rev = f->get_32(); // patch number, not used for validation.
+
+	if (version > PACK_FORMAT_VERSION) {
+		ERR_FAIL_V_MSG(false, "Pack version unsupported: " + itos(version) + ".");
+	}
+
+	uint32_t pack_flags = 0;
+	uint64_t file_base = 0;
+
+	if (version == 2) {
+		pack_flags = f->get_32();
+		file_base = f->get_64();
+	}
+
+	bool enc_directory = (pack_flags & PACK_DIR_ENCRYPTED);
+
+	for (int i = 0; i < 16; i++) {
+		//reserved
+		f->get_32();
+	}
+
+	uint32_t file_count = f->get_32();
+
+	if (enc_directory) {
+		Ref<FileAccessEncrypted> fae = memnew(FileAccessEncrypted);
+		if (fae.is_null()) {
+			GDRESettings::get_singleton()->_set_error_encryption(true);
+			ERR_FAIL_V_MSG(false, "Can't open encrypted pack directory.");
+		}
+
+		Vector<uint8_t> key;
+		key.resize(32);
+		for (int i = 0; i < key.size(); i++) {
+			key.write[i] = script_encryption_key[i];
+		}
+
+		Error err = fae->open_and_parse(f, key, FileAccessEncrypted::MODE_READ, false);
+		if (err) {
+			GDRESettings::get_singleton()->_set_error_encryption(true);
+			ERR_FAIL_V_MSG(false, "Can't open encrypted pack directory.");
+		}
+		f = fae;
+	}
+
+	// Everything worked, now set the data
+	Ref<GDRESettings::PackInfo> pckinfo;
+	pckinfo.instantiate();
+	pckinfo->init(
+			pck_path, ver_major, ver_minor, ver_rev, version, pack_flags, file_base, file_count,
+			itos(ver_major) + "." + itos(ver_minor) + "." + itos(ver_rev), GDRESettings::PackInfo::PCK);
+	GDRESettings::get_singleton()->add_pack_info(pckinfo);
+
+	for (uint32_t i = 0; i < file_count; i++) {
+		uint32_t sl = f->get_32();
+		CharString cs;
+		cs.resize(sl + 1);
+		f->get_buffer((uint8_t *)cs.ptr(), sl);
+		cs[sl] = 0;
+
+		String path;
+		path.parse_utf8(cs.ptr());
+
+		ERR_FAIL_COND_V_MSG(path.get_file().find("gdre_") != -1, false, "Tried to load a gdre file?!?!");
+
+		uint64_t ofs = file_base + f->get_64();
+		uint64_t size = f->get_64();
+		uint8_t md5[16];
+		uint32_t flags = 0;
+		f->get_buffer(md5, 16);
+		if (version == 2) {
+			flags = f->get_32();
+		}
+		// add the file info to settings
+		PackedData::PackedFile pf;
+		pf.offset = ofs + p_offset;
+		memcpy(pf.md5, md5, 16);
+		pf.size = size;
+		pf.encrypted = flags & PACK_FILE_ENCRYPTED;
+		pf.pack = p_path;
+		pf.src = this;
+		Ref<PackedFileInfo> pf_info;
+		pf_info.instantiate();
+		pf_info->init(path, &pf);
+		GDRESettings::get_singleton()->add_pack_file(pf_info);
+		// use the corrected path, not the raw path
+		path = pf_info->get_path();
+		PackedData::get_singleton()->add_path(pck_path, path, ofs + p_offset, size, md5, this, p_replace_files, (flags & PACK_FILE_ENCRYPTED));
+	}
+
+	return true;
+}
+Ref<FileAccess> GDREPackedSource::get_file(const String &p_path, PackedData::PackedFile *p_file) {
+	return memnew(FileAccessPack(p_path, *p_file));
+}

--- a/utility/gdre_packed_source.cpp
+++ b/utility/gdre_packed_source.cpp
@@ -3,7 +3,7 @@
 #include "gdre_settings.h"
 
 bool GDREPackedSource::try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) {
-	if (p_path.get_extension().to_lower() == "apk") {
+	if (p_path.get_extension().to_lower() == "apk" || p_path.get_extension().to_lower() == "zip") {
 		return false;
 	}
 	String pck_path = p_path.replace("_GDRE_a_really_dumb_hack", "");

--- a/utility/gdre_packed_source.h
+++ b/utility/gdre_packed_source.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "core/io/file_access_pack.h"
+
+class GDREPackedSource : public PackSource {
+public:
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset);
+	virtual Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file);
+};

--- a/utility/gdre_settings.cpp
+++ b/utility/gdre_settings.cpp
@@ -2,6 +2,8 @@
 #include "editor/gdre_editor.h"
 #include "editor/gdre_version.gen.h"
 #include "file_access_apk.h"
+#include "gdre_logger.h"
+#include "gdre_packed_source.h"
 #include "util_functions.h"
 
 #include "core/config/engine.h"
@@ -150,6 +152,7 @@ GDRESettings *GDRESettings::get_singleton() {
 void addCompatibilityClasses() {
 	ClassDB::add_compatibility_class("PHashTranslation", "OptimizedTranslation");
 }
+
 GDRESettings::GDRESettings() {
 	singleton = this;
 	addCompatibilityClasses();
@@ -829,49 +832,6 @@ String GDRESettings::get_project_config_path() {
 	return current_pack->pcfg->get_cfg_path();
 }
 
-bool inGuiMode() {
-	//check if we are in GUI mode
-	if (GodotREEditor::get_singleton() && GDRESettings::get_singleton() && !GDRESettings::get_singleton()->is_headless()) {
-		return true;
-	}
-	return false;
-}
-
-void GDRELogger::logv(const char *p_format, va_list p_list, bool p_err) {
-	if (!should_log(p_err)) {
-		return;
-	}
-	if (file.is_valid() || inGuiMode()) {
-		const int static_buf_size = 512;
-		char static_buf[static_buf_size];
-		char *buf = static_buf;
-		va_list list_copy;
-		va_copy(list_copy, p_list);
-		int len = vsnprintf(buf, static_buf_size, p_format, p_list);
-		if (len >= static_buf_size) {
-			buf = (char *)Memory::alloc_static(len + 1);
-			vsnprintf(buf, len + 1, p_format, list_copy);
-		}
-		va_end(list_copy);
-
-		if (inGuiMode()) {
-			GodotREEditor::get_singleton()->call_deferred(SNAME("emit_signal"), "write_log_message", String(buf));
-		}
-		if (file.is_valid()) {
-			file->store_buffer((uint8_t *)buf, len);
-
-			if (p_err || _flush_stdout_on_print) {
-				// Don't always flush when printing stdout to avoid performance
-				// issues when `print()` is spammed in release builds.
-				file->flush();
-			}
-		}
-		if (len >= static_buf_size) {
-			Memory::free_static(buf);
-		}
-	}
-}
-
 String GDRESettings::get_log_file_path() {
 	if (!logger) {
 		return "";
@@ -910,34 +870,6 @@ Error GDRESettings::open_log_file(const String &output_dir) {
 Error GDRESettings::close_log_file() {
 	logger->close_file();
 	return OK;
-}
-
-Error GDRELogger::open_file(const String &p_base_path) {
-	if (file.is_valid()) {
-		return ERR_ALREADY_IN_USE;
-	}
-	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_USERDATA);
-	if (da.is_valid()) {
-		da->make_dir_recursive(p_base_path.get_base_dir());
-	}
-	Error err;
-	file = FileAccess::open(p_base_path, FileAccess::WRITE, &err);
-	ERR_FAIL_COND_V_MSG(file.is_null(), err, "Failed to open log file " + p_base_path + " for writing.");
-	base_path = p_base_path;
-	return OK;
-}
-
-void GDRELogger::close_file() {
-	if (file.is_valid()) {
-		file->flush();
-		file = Ref<FileAccess>();
-		base_path = "";
-	}
-}
-
-GDRELogger::GDRELogger() {}
-GDRELogger::~GDRELogger() {
-	close_file();
 }
 
 Array GDRESettings::get_import_files(bool copy) {
@@ -1081,142 +1013,6 @@ Ref<ImportInfo> GDRESettings::get_import_info(const String &p_path) {
 
 Vector<String> GDRESettings::get_code_files() {
 	return code_files;
-}
-
-bool GDREPackedSource::try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) {
-	if (p_path.get_extension().to_lower() == "apk") {
-		return false;
-	}
-	String pck_path = p_path.replace("_GDRE_a_really_dumb_hack", "");
-	Ref<FileAccess> f = FileAccess::open(pck_path, FileAccess::READ);
-	if (f.is_null()) {
-		return false;
-	}
-
-	f->seek(p_offset);
-
-	uint32_t magic = f->get_32();
-
-	if (magic != PACK_HEADER_MAGIC) {
-		// loading with offset feature not supported for self contained exe files
-		if (p_offset != 0) {
-			ERR_FAIL_V_MSG(false, "Loading self-contained executable with offset not supported.");
-		}
-
-		//maybe at the end.... self contained exe
-		f->seek_end();
-		f->seek(f->get_position() - 4);
-		magic = f->get_32();
-		if (magic != PACK_HEADER_MAGIC) {
-			return false;
-		}
-		f->seek(f->get_position() - 12);
-
-		uint64_t ds = f->get_64();
-		f->seek(f->get_position() - ds - 8);
-
-		magic = f->get_32();
-		if (magic != PACK_HEADER_MAGIC) {
-			return false;
-		}
-	}
-
-	uint32_t version = f->get_32();
-	uint32_t ver_major = f->get_32();
-	uint32_t ver_minor = f->get_32();
-	uint32_t ver_rev = f->get_32(); // patch number, not used for validation.
-
-	if (version > PACK_FORMAT_VERSION) {
-		ERR_FAIL_V_MSG(false, "Pack version unsupported: " + itos(version) + ".");
-	}
-
-	uint32_t pack_flags = 0;
-	uint64_t file_base = 0;
-
-	if (version == 2) {
-		pack_flags = f->get_32();
-		file_base = f->get_64();
-	}
-
-	bool enc_directory = (pack_flags & PACK_DIR_ENCRYPTED);
-
-	for (int i = 0; i < 16; i++) {
-		//reserved
-		f->get_32();
-	}
-
-	uint32_t file_count = f->get_32();
-
-	if (enc_directory) {
-		Ref<FileAccessEncrypted> fae = memnew(FileAccessEncrypted);
-		if (fae.is_null()) {
-			GDRESettings::get_singleton()->_set_error_encryption(true);
-			ERR_FAIL_V_MSG(false, "Can't open encrypted pack directory.");
-		}
-
-		Vector<uint8_t> key;
-		key.resize(32);
-		for (int i = 0; i < key.size(); i++) {
-			key.write[i] = script_encryption_key[i];
-		}
-
-		Error err = fae->open_and_parse(f, key, FileAccessEncrypted::MODE_READ, false);
-		if (err) {
-			GDRESettings::get_singleton()->_set_error_encryption(true);
-			ERR_FAIL_V_MSG(false, "Can't open encrypted pack directory.");
-		}
-		f = fae;
-	}
-
-	// Everything worked, now set the data
-	Ref<GDRESettings::PackInfo> pckinfo;
-	pckinfo.instantiate();
-	pckinfo->init(
-			pck_path, ver_major, ver_minor, ver_rev, version, pack_flags, file_base, file_count,
-			itos(ver_major) + "." + itos(ver_minor) + "." + itos(ver_rev), GDRESettings::PackInfo::PCK);
-	GDRESettings::get_singleton()->add_pack_info(pckinfo);
-
-	for (uint32_t i = 0; i < file_count; i++) {
-		uint32_t sl = f->get_32();
-		CharString cs;
-		cs.resize(sl + 1);
-		f->get_buffer((uint8_t *)cs.ptr(), sl);
-		cs[sl] = 0;
-
-		String path;
-		path.parse_utf8(cs.ptr());
-
-		ERR_FAIL_COND_V_MSG(path.get_file().find("gdre_") != -1, false, "Tried to load a gdre file?!?!");
-
-		uint64_t ofs = file_base + f->get_64();
-		uint64_t size = f->get_64();
-		uint8_t md5[16];
-		uint32_t flags = 0;
-		f->get_buffer(md5, 16);
-		if (version == 2) {
-			flags = f->get_32();
-		}
-		// add the file info to settings
-		PackedData::PackedFile pf;
-		pf.offset = ofs + p_offset;
-		memcpy(pf.md5, md5, 16);
-		pf.size = size;
-		pf.encrypted = flags & PACK_FILE_ENCRYPTED;
-		pf.pack = p_path;
-		pf.src = this;
-		Ref<PackedFileInfo> pf_info;
-		pf_info.instantiate();
-		pf_info->init(path, &pf);
-		GDRESettings::get_singleton()->add_pack_file(pf_info);
-		// use the corrected path, not the raw path
-		path = pf_info->get_path();
-		PackedData::get_singleton()->add_path(pck_path, path, ofs + p_offset, size, md5, this, p_replace_files, (flags & PACK_FILE_ENCRYPTED));
-	}
-
-	return true;
-}
-Ref<FileAccess> GDREPackedSource::get_file(const String &p_path, PackedData::PackedFile *p_file) {
-	return memnew(FileAccessPack(p_path, *p_file));
 }
 
 // This is at the bottom to account for the platform header files pulling in their respective OS headers and creating all sorts of issues

--- a/utility/gdre_settings.cpp
+++ b/utility/gdre_settings.cpp
@@ -204,7 +204,7 @@ GDRESettings::PackInfo::PackType GDRESettings::get_pack_type() {
 String GDRESettings::get_pack_path() {
 	return is_pack_loaded() ? current_pack->pack_file : "";
 }
-uint32_t GDRESettings::get_pack_version() {
+uint32_t GDRESettings::get_pack_format() {
 	return is_pack_loaded() ? current_pack->fmt_version : 0;
 }
 String GDRESettings::get_version_string() {

--- a/utility/gdre_settings.cpp
+++ b/utility/gdre_settings.cpp
@@ -120,7 +120,7 @@ bool GDRESettings::check_if_dir_is_v3() {
 
 bool GDRESettings::check_if_dir_is_v2() {
 	// these are files that will only show up in version 2
-	static const Vector<String> wildcards = { "*.converted.*", "*.tex" };
+	static const Vector<String> wildcards = { "*.tex" };
 	if (get_file_list(wildcards).size() > 0) {
 		return true;
 	} else {

--- a/utility/gdre_settings.h
+++ b/utility/gdre_settings.h
@@ -27,26 +27,8 @@ public:
 		resource_path = p_path;
 	}
 };
-class GDRELogger : public Logger {
-	Ref<FileAccess> file;
-	String base_path;
 
-public:
-	String get_path() { return base_path; };
-	GDRELogger();
-	Error open_file(const String &p_base_path);
-	void close_file();
-	virtual void logv(const char *p_format, va_list p_list, bool p_err) _PRINTF_FORMAT_ATTRIBUTE_2_0;
-
-	virtual ~GDRELogger();
-};
-
-class GDREPackedSource : public PackSource {
-public:
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset);
-	virtual Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file);
-};
-
+class GDRELogger;
 class GDRESettings : public Object {
 	GDCLASS(GDRESettings, Object);
 	_THREAD_SAFE_CLASS_

--- a/utility/gdre_settings.h
+++ b/utility/gdre_settings.h
@@ -115,10 +115,10 @@ private:
 	bool check_if_dir_is_v2();
 	int get_ver_major_from_dir();
 	Error _load_import_file(const String &p_path, bool should_load_md5);
-
-public:
 	Error load_dir(const String &p_path);
 	Error unload_dir();
+
+public:
 	Error load_pack(const String &p_path);
 	Error unload_pack();
 	String get_gdre_resource_path() const;

--- a/utility/gdre_settings.h
+++ b/utility/gdre_settings.h
@@ -44,6 +44,7 @@ public:
 			APK,
 			ZIP,
 			DIR,
+			EXE,
 			UNKNOWN
 		};
 
@@ -138,7 +139,7 @@ public:
 	Vector<Ref<PackedFileInfo>> get_file_info_list(const Vector<String> &filters = Vector<String>());
 	PackInfo::PackType get_pack_type();
 	String get_pack_path();
-	uint32_t get_pack_version();
+	uint32_t get_pack_format();
 	String get_version_string();
 	uint32_t get_ver_major();
 	uint32_t get_ver_minor();

--- a/utility/gdre_settings.h
+++ b/utility/gdre_settings.h
@@ -176,6 +176,7 @@ public:
 	String get_sys_info_string() const;
 	Error load_project_config();
 	Error save_project_config(const String &p_out_dir);
+	bool pack_has_project_config();
 
 	static GDRESettings *get_singleton();
 	GDRESettings();

--- a/utility/import_exporter.cpp
+++ b/utility/import_exporter.cpp
@@ -161,8 +161,8 @@ Error ImportExporter::_export_imports(const String &p_out_dir, const Vector<Stri
 				// (opt_bin2text && iinfo->get_importer() == "scene" && iinfo->get_source_file().get_extension() == "tscn")
 		) {
 			err = convert_res_bin_2_txt(output_dir, iinfo->get_path(), iinfo->get_export_dest());
-			// for v2 projects, remove the autoconverted file in the project path
-			if (get_ver_major() == 2 && !err) {
+			// v2-v3 export left the autoconverted resource in the main path, remove it
+			if (get_ver_major() <= 3 && !err) {
 				dir->remove(iinfo->get_path().replace("res://", ""));
 			}
 		} else if (importer == "scene" && !iinfo->is_auto_converted()) {


### PR DESCRIPTION
* Fixed packed scene conversion for auto-converted scenes (packed scenes do not always have "_bundled" as the last property)
  * Fixes #119
* Fix version detection from directory (3.x resources also have ".converted." resources, so we can't use that to determine the version number)
* Skip MD5 hash checking if MD5 field is empty (all 0s)
* Make project config loading optional during pack loading (some games have chained packs that do not have them)
* fix removal of .converted. resources for v3 projects
* Improve finding the offset for embedded PCK files in executables
* Misc. refactoring