### PR TITLE
Fix GDScript decompilation for Godot versions 2.1, 3.1, and 3.5

### DIFF
--- a/BYTECODE_HISTORY.md
+++ b/BYTECODE_HISTORY.md
@@ -92,6 +92,12 @@
 |                           | [6694c11](https://github.com/godotengine/godot/commit/6694c11) | `2019.07.20` | 13               | Added `lerp_angle` function                                     |
 | **3.2**                   | [5565f55](https://github.com/godotengine/godot/commit/5565f55) | `2019.08.26` | 13               | Added `ord` function                                            |
 | *4.0 branch diverge*      |                                                                |              |                  |                                                                 |
+| *3.5 branch diverge*      |                                                                |              |                  |                                                                 |
+
+### Branch 3.5
+| Release                   | Commit                                                         | Date         | Bytecode         | Changes                                                         |
+| ------------------------- | -------------------------------------------------------------- | ------------ | ---------------- | --------------------------------------------------------------- |
+| **3.5**                   | [a7aad78](https://github.com/godotengine/godot/commit/a7aad78) | `2020.10.07` | 13               | added `deep_equal` function (never added to 4. x)               |
 
 ### Branch 4.0 (master)
 

--- a/bytecode/bytecode_015d36d.cpp
+++ b/bytecode/bytecode_015d36d.cpp
@@ -82,6 +82,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -296,6 +298,7 @@ Error GDScriptDecomp_015d36d::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_015d36d.h
+++ b/bytecode/bytecode_015d36d.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_015d36d() {
+		bytecode_rev = 0x015d36d;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_015d36d.h
+++ b/bytecode/bytecode_015d36d.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_015d36d() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_054a2ac.cpp
+++ b/bytecode/bytecode_054a2ac.cpp
@@ -89,6 +89,8 @@ static const char *func_names[] = {
 	"len",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -304,6 +306,7 @@ Error GDScriptDecomp_054a2ac::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_054a2ac.h
+++ b/bytecode/bytecode_054a2ac.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_054a2ac() {
+		bytecode_rev = 0x054a2ac;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_054a2ac.h
+++ b/bytecode/bytecode_054a2ac.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_054a2ac() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_0b806ee.cpp
+++ b/bytecode/bytecode_0b806ee.cpp
@@ -65,6 +65,8 @@ static const char *func_names[] = {
 	"print_stack",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -261,6 +263,7 @@ Error GDScriptDecomp_0b806ee::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_0b806ee.h
+++ b/bytecode/bytecode_0b806ee.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_0b806ee() {
+		bytecode_rev = 0x0b806ee;
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2
 	}

--- a/bytecode/bytecode_0b806ee.h
+++ b/bytecode/bytecode_0b806ee.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_0b806ee() {
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2

--- a/bytecode/bytecode_1a36141.cpp
+++ b/bytecode/bytecode_1a36141.cpp
@@ -94,6 +94,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -314,6 +316,7 @@ Error GDScriptDecomp_1a36141::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_1a36141.cpp
+++ b/bytecode/bytecode_1a36141.cpp
@@ -671,3 +671,122 @@ Error GDScriptDecomp_1a36141::decompile_buffer(Vector<uint8_t> p_buffer) {
 
 	return OK;
 }
+namespace {
+
+// TODO: Refactor bytecode classes so that this can be moved to bytecode base
+// we should be after the open parenthesis, which has already been checked
+bool test_built_in_func_arg_count(const Vector<uint32_t> &tokens, Pair<int, int> arg_count, int &curr_pos) {
+	int pos = curr_pos;
+	int comma_count = 0;
+	int min_args = arg_count.first;
+	int max_args = arg_count.second;
+	uint32_t t = tokens[pos] & 255; // TOKEN_MASK for all revisions
+	int bracket_open = 0;
+
+	if (min_args == 0 && max_args == 0) {
+		for (; pos < tokens.size(); pos++, t = tokens[pos] & 255) {
+			if (t == TK_PARENTHESIS_CLOSE) {
+				break;
+			} else if (t != TK_NEWLINE) {
+				return false;
+			}
+		}
+		// if we didn't find a close parenthesis, then we have an error
+		if (pos == tokens.size()) {
+			return false;
+		}
+		curr_pos = pos;
+		return true;
+	}
+	// count the commas
+	// at least in 3.x and below, the only time commas are allowed in function args are other expressions
+	// this is not the case for GDScript 2.0 (4.x), due to lambdas, but that doesn't have a compiled version yet
+	for (; pos < tokens.size(); pos++, t = tokens[pos] & 255) {
+		switch (t) {
+			case TK_BRACKET_OPEN:
+			case TK_CURLY_BRACKET_OPEN:
+			case TK_PARENTHESIS_OPEN:
+				bracket_open++;
+				break;
+			case TK_BRACKET_CLOSE:
+			case TK_CURLY_BRACKET_CLOSE:
+			case TK_PARENTHESIS_CLOSE:
+				bracket_open--;
+				break;
+			case TK_COMMA:
+				if (bracket_open == 0) {
+					comma_count++;
+				}
+				break;
+			default:
+				break;
+		}
+		if (bracket_open == -1) {
+			break;
+		}
+	}
+	// trailing commas are not allowed after the last argument
+	if (pos == tokens.size() || t != TK_PARENTHESIS_CLOSE || comma_count < min_args - 1 || comma_count > max_args - 1) {
+		return false;
+	}
+	curr_pos = pos;
+	return true;
+}
+} //anonymous namespace
+
+// check for DO, CASE, SWITCH tokens, check for function shift caused by added smoothstep in the next revision
+// NOTE: This only considers 3.1.x beta/release bytecode 13 revisions for its pass case, not any dev revisions or 3.2.x or 3.5.x
+GDScriptDecomp::BYTECODE_TEST_RESULT GDScriptDecomp_1a36141::test_bytecode(Vector<uint8_t> buffer) {
+	Vector<StringName> identifiers;
+	Vector<Variant> constants;
+	Vector<uint32_t> tokens;
+	Error err = get_ids_consts_tokens(buffer, bytecode_version, identifiers, constants, tokens);
+	ERR_FAIL_COND_V_MSG(err != OK, BYTECODE_TEST_RESULT::BYTECODE_TEST_CORRUPT, "Failed to get identifiers, constants, and tokens from bytecode.");
+
+	// pass case: built-in function shift caused by smoothstep is tested
+	bool tested_smoothstep_shift = false;
+	int token_count = tokens.size();
+	for (int i = 0; i < token_count; i++) {
+		if ((tokens[i] & TOKEN_MASK) == TK_BUILT_IN_FUNC) { // ignore all tokens until we find TK_BUILT_IN_FUNC
+			int func_id = tokens[i] >> TOKEN_BITS;
+
+			// if the func_id is >= size of func_names, this is another version 13 revision
+			if (func_id >= FUNC_MAX) {
+				return BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL;
+			}
+			// All bytecode 13 revisions had the same position for TK_BUILT_IN_FUNC; if this check fails, then the bytecode is corrupt
+			if (i + 2 >= token_count) {
+				return BYTECODE_TEST_RESULT::BYTECODE_TEST_CORRUPT;
+			}
+			i++;
+			if (tokens[i] != TK_PARENTHESIS_OPEN) {
+				// 3.1 beta still had the DO, CASE, and SWITCH tokens, which were before TK_PARENTHESIS_OPEN.
+				// this resulted in the token id for TK_PARENTHESIS_OPEN being shifted lower by 3 in the 3.1.x releases.
+				// this is probably 3.1 beta, fail.
+				return BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL;
+			}
+			i++;
+
+			auto arg_count = get_arg_count_for_builtin(func_names[func_id]);
+			if (!tested_smoothstep_shift && func_id > 29) {
+				// smoothstep is added to position 29 in the next rev,
+				// all functions in the next rev are shifted up by one vs. this rev.
+				// if the previous function has a different arg count than the current one, then we have a potential pass case
+				auto prev_arg_count = get_arg_count_for_builtin(func_names[func_id - 1]);
+				// require both min and max args to be different, also don't count testing var args as a potential pass case.
+				if (arg_count.first != prev_arg_count.first && arg_count.second != prev_arg_count.second &&
+						arg_count.first == arg_count.second && prev_arg_count.first == prev_arg_count.second) {
+					tested_smoothstep_shift = true;
+				}
+			}
+			if (!test_built_in_func_arg_count(tokens, arg_count, i)) {
+				return BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL;
+			};
+			// we keep going until the end for func arg count checking
+		}
+	}
+	if (tested_smoothstep_shift) {
+		return BYTECODE_TEST_RESULT::BYTECODE_TEST_PASS;
+	}
+	return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN;
+}

--- a/bytecode/bytecode_1a36141.h
+++ b/bytecode/bytecode_1a36141.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override;
 	GDScriptDecomp_1a36141() {
 		bytecode_rev = 0x1a36141;
 		engine_ver_major = 3;

--- a/bytecode/bytecode_1a36141.h
+++ b/bytecode/bytecode_1a36141.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_1a36141() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_1a36141.h
+++ b/bytecode/bytecode_1a36141.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_1a36141() {
+		bytecode_rev = 0x1a36141;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_1add52b.cpp
+++ b/bytecode/bytecode_1add52b.cpp
@@ -77,6 +77,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -284,6 +286,7 @@ Error GDScriptDecomp_1add52b::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_1add52b.h
+++ b/bytecode/bytecode_1add52b.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_1add52b() {
 		engine_ver_major = 3;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_1add52b.h
+++ b/bytecode/bytecode_1add52b.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_1add52b() {
+		bytecode_rev = 0x1add52b;
 		engine_ver_major = 3;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_1ca61a3.cpp
+++ b/bytecode/bytecode_1ca61a3.cpp
@@ -94,6 +94,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -317,6 +319,7 @@ Error GDScriptDecomp_1ca61a3::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_1ca61a3.h
+++ b/bytecode/bytecode_1ca61a3.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_1ca61a3() {
+		bytecode_rev = 0x1ca61a3;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_1ca61a3.h
+++ b/bytecode/bytecode_1ca61a3.h
@@ -26,7 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
-	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override;
 	GDScriptDecomp_1ca61a3() {
 		bytecode_rev = 0x1ca61a3;
 		engine_ver_major = 3;

--- a/bytecode/bytecode_1ca61a3.h
+++ b/bytecode/bytecode_1ca61a3.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_1ca61a3() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_216a8aa.cpp
+++ b/bytecode/bytecode_216a8aa.cpp
@@ -87,6 +87,8 @@ static const char *func_names[] = {
 	"len",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -301,6 +303,7 @@ Error GDScriptDecomp_216a8aa::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_216a8aa.h
+++ b/bytecode/bytecode_216a8aa.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_216a8aa() {
+		bytecode_rev = 0x216a8aa;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_216a8aa.h
+++ b/bytecode/bytecode_216a8aa.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_216a8aa() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_2185c01.cpp
+++ b/bytecode/bytecode_2185c01.cpp
@@ -70,6 +70,8 @@ static const char *func_names[] = {
 	"print_stack",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -269,6 +271,7 @@ Error GDScriptDecomp_2185c01::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_2185c01.h
+++ b/bytecode/bytecode_2185c01.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_2185c01() {
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2

--- a/bytecode/bytecode_2185c01.h
+++ b/bytecode/bytecode_2185c01.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_2185c01() {
+		bytecode_rev = 0x2185c01;
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2
 	}

--- a/bytecode/bytecode_23381a5.cpp
+++ b/bytecode/bytecode_23381a5.cpp
@@ -79,6 +79,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -287,6 +289,7 @@ Error GDScriptDecomp_23381a5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_23381a5.h
+++ b/bytecode/bytecode_23381a5.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_23381a5() {
+		bytecode_rev = 0x23381a5;
 		engine_ver_major = 3;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_23381a5.h
+++ b/bytecode/bytecode_23381a5.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_23381a5() {
 		engine_ver_major = 3;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_23441ec.cpp
+++ b/bytecode/bytecode_23441ec.cpp
@@ -76,6 +76,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -279,6 +281,7 @@ Error GDScriptDecomp_23441ec::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_23441ec.h
+++ b/bytecode/bytecode_23441ec.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_23441ec() {
+		bytecode_rev = 0x23441ec;
 		engine_ver_major = 2;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_23441ec.h
+++ b/bytecode/bytecode_23441ec.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_23441ec() {
 		engine_ver_major = 2;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_30c1229.cpp
+++ b/bytecode/bytecode_30c1229.cpp
@@ -73,6 +73,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -274,6 +276,7 @@ Error GDScriptDecomp_30c1229::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_30c1229.h
+++ b/bytecode/bytecode_30c1229.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_30c1229() {
+		bytecode_rev = 0x30c1229;
 		engine_ver_major = 2;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_30c1229.h
+++ b/bytecode/bytecode_30c1229.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_30c1229() {
 		engine_ver_major = 2;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_31ce3c5.cpp
+++ b/bytecode/bytecode_31ce3c5.cpp
@@ -67,6 +67,8 @@ static const char *func_names[] = {
 	"print_stack",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -263,6 +265,7 @@ Error GDScriptDecomp_31ce3c5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_31ce3c5.h
+++ b/bytecode/bytecode_31ce3c5.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_31ce3c5() {
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2

--- a/bytecode/bytecode_31ce3c5.h
+++ b/bytecode/bytecode_31ce3c5.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_31ce3c5() {
+		bytecode_rev = 0x31ce3c5;
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2
 	}

--- a/bytecode/bytecode_3ea6d9f.cpp
+++ b/bytecode/bytecode_3ea6d9f.cpp
@@ -92,6 +92,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -307,6 +309,7 @@ Error GDScriptDecomp_3ea6d9f::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_3ea6d9f.h
+++ b/bytecode/bytecode_3ea6d9f.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_3ea6d9f() {
+		bytecode_rev = 0x3ea6d9f;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_3ea6d9f.h
+++ b/bytecode/bytecode_3ea6d9f.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_3ea6d9f() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_48f1d02.cpp
+++ b/bytecode/bytecode_48f1d02.cpp
@@ -73,6 +73,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -273,6 +275,7 @@ Error GDScriptDecomp_48f1d02::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_48f1d02.h
+++ b/bytecode/bytecode_48f1d02.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_48f1d02() {
+		bytecode_rev = 0x48f1d02;
 		engine_ver_major = 2;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_48f1d02.h
+++ b/bytecode/bytecode_48f1d02.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_48f1d02() {
 		engine_ver_major = 2;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_4ee82a2.cpp
+++ b/bytecode/bytecode_4ee82a2.cpp
@@ -77,6 +77,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -285,6 +287,7 @@ Error GDScriptDecomp_4ee82a2::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_4ee82a2.h
+++ b/bytecode/bytecode_4ee82a2.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_4ee82a2() {
+		bytecode_rev = 0x4ee82a2;
 		engine_ver_major = 3;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_4ee82a2.h
+++ b/bytecode/bytecode_4ee82a2.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_4ee82a2() {
 		engine_ver_major = 3;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_506df14.cpp
+++ b/bytecode/bytecode_506df14.cpp
@@ -101,6 +101,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -321,6 +323,7 @@ Error GDScriptDecomp_506df14::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_506df14.h
+++ b/bytecode/bytecode_506df14.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_506df14() {
 		engine_ver_major = 4;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_506df14.h
+++ b/bytecode/bytecode_506df14.h
@@ -27,6 +27,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_506df14() {
+		bytecode_rev = 0x506df14;
 		engine_ver_major = 4;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_513c026.cpp
+++ b/bytecode/bytecode_513c026.cpp
@@ -78,6 +78,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -286,6 +288,7 @@ Error GDScriptDecomp_513c026::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_513c026.h
+++ b/bytecode/bytecode_513c026.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_513c026() {
 		engine_ver_major = 3;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_513c026.h
+++ b/bytecode/bytecode_513c026.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_513c026() {
+		bytecode_rev = 0x513c026;
 		engine_ver_major = 3;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_514a3fb.cpp
+++ b/bytecode/bytecode_514a3fb.cpp
@@ -95,6 +95,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -315,6 +317,7 @@ Error GDScriptDecomp_514a3fb::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_514a3fb.h
+++ b/bytecode/bytecode_514a3fb.h
@@ -27,6 +27,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override;
 	GDScriptDecomp_514a3fb() {
+		bytecode_rev = 0x514a3fb;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_514a3fb.h
+++ b/bytecode/bytecode_514a3fb.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override;
 	GDScriptDecomp_514a3fb() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_5565f55.cpp
+++ b/bytecode/bytecode_5565f55.cpp
@@ -102,6 +102,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -322,6 +324,7 @@ Error GDScriptDecomp_5565f55::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_5565f55.h
+++ b/bytecode/bytecode_5565f55.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_5565f55() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_5565f55.h
+++ b/bytecode/bytecode_5565f55.h
@@ -27,6 +27,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_5565f55() {
+		bytecode_rev = 0x5565f55;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_5e938f0.cpp
+++ b/bytecode/bytecode_5e938f0.cpp
@@ -82,6 +82,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -295,6 +297,7 @@ Error GDScriptDecomp_5e938f0::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_5e938f0.h
+++ b/bytecode/bytecode_5e938f0.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_5e938f0() {
 		engine_ver_major = 3;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_5e938f0.h
+++ b/bytecode/bytecode_5e938f0.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_5e938f0() {
+		bytecode_rev = 0x5e938f0;
 		engine_ver_major = 3;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_6174585.cpp
+++ b/bytecode/bytecode_6174585.cpp
@@ -74,6 +74,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -277,6 +279,7 @@ Error GDScriptDecomp_6174585::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_6174585.h
+++ b/bytecode/bytecode_6174585.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_6174585() {
+		bytecode_rev = 0x6174585;
 		engine_ver_major = 2;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_6174585.h
+++ b/bytecode/bytecode_6174585.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_6174585() {
 		engine_ver_major = 2;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_620ec47.cpp
+++ b/bytecode/bytecode_620ec47.cpp
@@ -98,6 +98,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -318,6 +320,7 @@ Error GDScriptDecomp_620ec47::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_620ec47.h
+++ b/bytecode/bytecode_620ec47.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_620ec47() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_620ec47.h
+++ b/bytecode/bytecode_620ec47.h
@@ -27,6 +27,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_620ec47() {
+		bytecode_rev = 0x620ec47;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_62273e5.cpp
+++ b/bytecode/bytecode_62273e5.cpp
@@ -82,6 +82,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -291,6 +293,7 @@ Error GDScriptDecomp_62273e5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_62273e5.h
+++ b/bytecode/bytecode_62273e5.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_62273e5() {
+		bytecode_rev = 0x62273e5;
 		engine_ver_major = 3;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_62273e5.h
+++ b/bytecode/bytecode_62273e5.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_62273e5() {
 		engine_ver_major = 3;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_64872ca.cpp
+++ b/bytecode/bytecode_64872ca.cpp
@@ -74,6 +74,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -276,6 +278,7 @@ Error GDScriptDecomp_64872ca::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_64872ca.h
+++ b/bytecode/bytecode_64872ca.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_64872ca() {
 		engine_ver_major = 2;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_64872ca.h
+++ b/bytecode/bytecode_64872ca.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_64872ca() {
+		bytecode_rev = 0x64872ca;
 		engine_ver_major = 2;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_65d48d6.cpp
+++ b/bytecode/bytecode_65d48d6.cpp
@@ -73,6 +73,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -272,6 +274,7 @@ Error GDScriptDecomp_65d48d6::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_65d48d6.h
+++ b/bytecode/bytecode_65d48d6.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_65d48d6() {
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2

--- a/bytecode/bytecode_65d48d6.h
+++ b/bytecode/bytecode_65d48d6.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_65d48d6() {
+		bytecode_rev = 0x65d48d6;
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2
 	}

--- a/bytecode/bytecode_6694c11.cpp
+++ b/bytecode/bytecode_6694c11.cpp
@@ -101,6 +101,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -321,6 +323,7 @@ Error GDScriptDecomp_6694c11::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_6694c11.h
+++ b/bytecode/bytecode_6694c11.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_6694c11() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_6694c11.h
+++ b/bytecode/bytecode_6694c11.h
@@ -27,6 +27,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_6694c11() {
+		bytecode_rev = 0x6694c11;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_703004f.cpp
+++ b/bytecode/bytecode_703004f.cpp
@@ -68,6 +68,8 @@ static const char *func_names[] = {
 	"print_stack",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -264,6 +266,7 @@ Error GDScriptDecomp_703004f::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_703004f.h
+++ b/bytecode/bytecode_703004f.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_703004f() {
+		bytecode_rev = 0x703004f;
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2
 	}

--- a/bytecode/bytecode_703004f.h
+++ b/bytecode/bytecode_703004f.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_703004f() {
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2

--- a/bytecode/bytecode_7124599.cpp
+++ b/bytecode/bytecode_7124599.cpp
@@ -77,6 +77,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -280,6 +282,7 @@ Error GDScriptDecomp_7124599::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_7124599.h
+++ b/bytecode/bytecode_7124599.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override;
 	GDScriptDecomp_7124599() {
 		engine_ver_major = 2;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_7124599.h
+++ b/bytecode/bytecode_7124599.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override;
 	GDScriptDecomp_7124599() {
+		bytecode_rev = 0x7124599;
 		engine_ver_major = 2;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_7d2d144.cpp
+++ b/bytecode/bytecode_7d2d144.cpp
@@ -73,6 +73,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -275,6 +277,7 @@ Error GDScriptDecomp_7d2d144::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_7d2d144.h
+++ b/bytecode/bytecode_7d2d144.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_7d2d144() {
+		bytecode_rev = 0x7d2d144;
 		engine_ver_major = 2;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_7d2d144.h
+++ b/bytecode/bytecode_7d2d144.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_7d2d144() {
 		engine_ver_major = 2;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_7f7d97f.cpp
+++ b/bytecode/bytecode_7f7d97f.cpp
@@ -97,6 +97,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -317,6 +319,7 @@ Error GDScriptDecomp_7f7d97f::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_7f7d97f.h
+++ b/bytecode/bytecode_7f7d97f.h
@@ -27,6 +27,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_7f7d97f() {
+		bytecode_rev = 0x7f7d97f;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_7f7d97f.h
+++ b/bytecode/bytecode_7f7d97f.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_7f7d97f() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_85585c7.cpp
+++ b/bytecode/bytecode_85585c7.cpp
@@ -78,6 +78,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -281,6 +283,7 @@ Error GDScriptDecomp_85585c7::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_85585c7.h
+++ b/bytecode/bytecode_85585c7.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override;
 	GDScriptDecomp_85585c7() {
+		bytecode_rev = 0x85585c7;
 		engine_ver_major = 2;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_85585c7.h
+++ b/bytecode/bytecode_85585c7.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override;
 	GDScriptDecomp_85585c7() {
 		engine_ver_major = 2;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_8aab9a0.cpp
+++ b/bytecode/bytecode_8aab9a0.cpp
@@ -92,6 +92,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -314,6 +316,7 @@ Error GDScriptDecomp_8aab9a0::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_8aab9a0.h
+++ b/bytecode/bytecode_8aab9a0.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_8aab9a0() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_8aab9a0.h
+++ b/bytecode/bytecode_8aab9a0.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_8aab9a0() {
+		bytecode_rev = 0x8aab9a0;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_8b912d1.cpp
+++ b/bytecode/bytecode_8b912d1.cpp
@@ -79,6 +79,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -288,6 +290,7 @@ Error GDScriptDecomp_8b912d1::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_8b912d1.h
+++ b/bytecode/bytecode_8b912d1.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_8b912d1() {
+		bytecode_rev = 0x8b912d1;
 		engine_ver_major = 3;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_8b912d1.h
+++ b/bytecode/bytecode_8b912d1.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_8b912d1() {
 		engine_ver_major = 3;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_8c1731b.cpp
+++ b/bytecode/bytecode_8c1731b.cpp
@@ -66,6 +66,8 @@ static const char *func_names[] = {
 	"print_stack",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -262,6 +264,7 @@ Error GDScriptDecomp_8c1731b::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_8c1731b.h
+++ b/bytecode/bytecode_8c1731b.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_8c1731b() {
+		bytecode_rev = 0x8c1731b;
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2
 	}

--- a/bytecode/bytecode_8c1731b.h
+++ b/bytecode/bytecode_8c1731b.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_8c1731b() {
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2

--- a/bytecode/bytecode_8cab401.cpp
+++ b/bytecode/bytecode_8cab401.cpp
@@ -68,6 +68,8 @@ static const char *func_names[] = {
 	"print_stack",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -265,6 +267,7 @@ Error GDScriptDecomp_8cab401::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_8cab401.h
+++ b/bytecode/bytecode_8cab401.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_8cab401() {
+		bytecode_rev = 0x8cab401;
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2
 	}

--- a/bytecode/bytecode_8cab401.h
+++ b/bytecode/bytecode_8cab401.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_8cab401() {
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2

--- a/bytecode/bytecode_8e35d93.cpp
+++ b/bytecode/bytecode_8e35d93.cpp
@@ -92,6 +92,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -310,6 +312,7 @@ Error GDScriptDecomp_8e35d93::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_8e35d93.h
+++ b/bytecode/bytecode_8e35d93.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_8e35d93() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_8e35d93.h
+++ b/bytecode/bytecode_8e35d93.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_8e35d93() {
+		bytecode_rev = 0x8e35d93;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_91ca725.cpp
+++ b/bytecode/bytecode_91ca725.cpp
@@ -87,6 +87,8 @@ static const char *func_names[] = {
 	"len",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -302,6 +304,7 @@ Error GDScriptDecomp_91ca725::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_91ca725.h
+++ b/bytecode/bytecode_91ca725.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_91ca725() {
+		bytecode_rev = 0x91ca725;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_91ca725.h
+++ b/bytecode/bytecode_91ca725.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_91ca725() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_97f34a1.cpp
+++ b/bytecode/bytecode_97f34a1.cpp
@@ -72,6 +72,8 @@ static const char *func_names[] = {
 	"get_inst",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -271,6 +273,7 @@ Error GDScriptDecomp_97f34a1::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_97f34a1.h
+++ b/bytecode/bytecode_97f34a1.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_97f34a1() {
+		bytecode_rev = 0x97f34a1;
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2
 	}

--- a/bytecode/bytecode_97f34a1.h
+++ b/bytecode/bytecode_97f34a1.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_97f34a1() {
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2

--- a/bytecode/bytecode_a3f1ee5.cpp
+++ b/bytecode/bytecode_a3f1ee5.cpp
@@ -92,6 +92,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -311,6 +313,7 @@ Error GDScriptDecomp_a3f1ee5::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_a3f1ee5.h
+++ b/bytecode/bytecode_a3f1ee5.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_a3f1ee5() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_a3f1ee5.h
+++ b/bytecode/bytecode_a3f1ee5.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_a3f1ee5() {
+		bytecode_rev = 0xa3f1ee5;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_a56d6ff.cpp
+++ b/bytecode/bytecode_a56d6ff.cpp
@@ -91,6 +91,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -306,6 +308,7 @@ Error GDScriptDecomp_a56d6ff::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_a56d6ff.h
+++ b/bytecode/bytecode_a56d6ff.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_a56d6ff() {
+		bytecode_rev = 0xa56d6ff;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_a56d6ff.h
+++ b/bytecode/bytecode_a56d6ff.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_a56d6ff() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_a60f242.cpp
+++ b/bytecode/bytecode_a60f242.cpp
@@ -100,6 +100,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -320,6 +322,7 @@ Error GDScriptDecomp_a60f242::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_a60f242.h
+++ b/bytecode/bytecode_a60f242.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_a60f242() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_a60f242.h
+++ b/bytecode/bytecode_a60f242.h
@@ -27,6 +27,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_a60f242() {
+		bytecode_rev = 0xa60f242;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_a7aad78.cpp
+++ b/bytecode/bytecode_a7aad78.cpp
@@ -1,0 +1,679 @@
+/*************************************************************************/
+/*  bytecode_a7aad78.cpp                                                 */
+/*************************************************************************/
+
+#include "core/io/marshalls.h"
+#include "core/string/print_string.h"
+#include "core/templates/rb_map.h"
+
+#include "bytecode_a7aad78.h"
+
+static const char *func_names[] = {
+
+	"sin",
+	"cos",
+	"tan",
+	"sinh",
+	"cosh",
+	"tanh",
+	"asin",
+	"acos",
+	"atan",
+	"atan2",
+	"sqrt",
+	"fmod",
+	"fposmod",
+	"posmod",
+	"floor",
+	"ceil",
+	"round",
+	"abs",
+	"sign",
+	"pow",
+	"log",
+	"exp",
+	"is_nan",
+	"is_inf",
+	"is_equal_approx",
+	"is_zero_approx",
+	"ease",
+	"decimals",
+	"step_decimals",
+	"stepify",
+	"lerp",
+	"lerp_angle",
+	"inverse_lerp",
+	"range_lerp",
+	"smoothstep",
+	"move_toward",
+	"dectime",
+	"randomize",
+	"randi",
+	"randf",
+	"rand_range",
+	"seed",
+	"rand_seed",
+	"deg2rad",
+	"rad2deg",
+	"linear2db",
+	"db2linear",
+	"polar2cartesian",
+	"cartesian2polar",
+	"wrapi",
+	"wrapf",
+	"max",
+	"min",
+	"clamp",
+	"nearest_po2",
+	"weakref",
+	"funcref",
+	"convert",
+	"typeof",
+	"type_exists",
+	"char",
+	"ord",
+	"str",
+	"print",
+	"printt",
+	"prints",
+	"printerr",
+	"printraw",
+	"print_debug",
+	"push_error",
+	"push_warning",
+	"var2str",
+	"str2var",
+	"var2bytes",
+	"bytes2var",
+	"range",
+	"load",
+	"inst2dict",
+	"dict2inst",
+	"validate_json",
+	"parse_json",
+	"to_json",
+	"hash",
+	"Color8",
+	"ColorN",
+	"print_stack",
+	"get_stack",
+	"instance_from_id",
+	"len",
+	"is_instance_valid",
+	"deep_equal"
+};
+
+enum Token {
+
+	TK_EMPTY,
+	TK_IDENTIFIER,
+	TK_CONSTANT,
+	TK_SELF,
+	TK_BUILT_IN_TYPE,
+	TK_BUILT_IN_FUNC,
+	TK_OP_IN,
+	TK_OP_EQUAL,
+	TK_OP_NOT_EQUAL,
+	TK_OP_LESS,
+	TK_OP_LESS_EQUAL,
+	TK_OP_GREATER,
+	TK_OP_GREATER_EQUAL,
+	TK_OP_AND,
+	TK_OP_OR,
+	TK_OP_NOT,
+	TK_OP_ADD,
+	TK_OP_SUB,
+	TK_OP_MUL,
+	TK_OP_DIV,
+	TK_OP_MOD,
+	TK_OP_SHIFT_LEFT,
+	TK_OP_SHIFT_RIGHT,
+	TK_OP_ASSIGN,
+	TK_OP_ASSIGN_ADD,
+	TK_OP_ASSIGN_SUB,
+	TK_OP_ASSIGN_MUL,
+	TK_OP_ASSIGN_DIV,
+	TK_OP_ASSIGN_MOD,
+	TK_OP_ASSIGN_SHIFT_LEFT,
+	TK_OP_ASSIGN_SHIFT_RIGHT,
+	TK_OP_ASSIGN_BIT_AND,
+	TK_OP_ASSIGN_BIT_OR,
+	TK_OP_ASSIGN_BIT_XOR,
+	TK_OP_BIT_AND,
+	TK_OP_BIT_OR,
+	TK_OP_BIT_XOR,
+	TK_OP_BIT_INVERT,
+	//TK_OP_PLUS_PLUS,
+	//TK_OP_MINUS_MINUS,
+	TK_CF_IF,
+	TK_CF_ELIF,
+	TK_CF_ELSE,
+	TK_CF_FOR,
+	TK_CF_WHILE,
+	TK_CF_BREAK,
+	TK_CF_CONTINUE,
+	TK_CF_PASS,
+	TK_CF_RETURN,
+	TK_CF_MATCH,
+	TK_PR_FUNCTION,
+	TK_PR_CLASS,
+	TK_PR_CLASS_NAME,
+	TK_PR_EXTENDS,
+	TK_PR_IS,
+	TK_PR_ONREADY,
+	TK_PR_TOOL,
+	TK_PR_STATIC,
+	TK_PR_EXPORT,
+	TK_PR_SETGET,
+	TK_PR_CONST,
+	TK_PR_VAR,
+	TK_PR_AS,
+	TK_PR_VOID,
+	TK_PR_ENUM,
+	TK_PR_PRELOAD,
+	TK_PR_ASSERT,
+	TK_PR_YIELD,
+	TK_PR_SIGNAL,
+	TK_PR_BREAKPOINT,
+	TK_PR_REMOTE,
+	TK_PR_SYNC,
+	TK_PR_MASTER,
+	TK_PR_SLAVE, //Deprecated by TK_PR_PUPPET, to remove in 4.0
+	TK_PR_PUPPET,
+	TK_PR_REMOTESYNC,
+	TK_PR_MASTERSYNC,
+	TK_PR_PUPPETSYNC,
+	TK_BRACKET_OPEN,
+	TK_BRACKET_CLOSE,
+	TK_CURLY_BRACKET_OPEN,
+	TK_CURLY_BRACKET_CLOSE,
+	TK_PARENTHESIS_OPEN,
+	TK_PARENTHESIS_CLOSE,
+	TK_COMMA,
+	TK_SEMICOLON,
+	TK_PERIOD,
+	TK_QUESTION_MARK,
+	TK_COLON,
+	TK_DOLLAR,
+	TK_FORWARD_ARROW,
+	TK_NEWLINE,
+	TK_CONST_PI,
+	TK_CONST_TAU,
+	TK_WILDCARD,
+	TK_CONST_INF,
+	TK_CONST_NAN,
+	TK_ERROR,
+	TK_EOF,
+	TK_CURSOR, //used for code completion
+	TK_MAX
+};
+
+Error GDScriptDecomp_a7aad78::decompile_buffer(Vector<uint8_t> p_buffer) {
+	//Cleanup
+	script_text = String();
+
+	//Load bytecode
+	Vector<StringName> identifiers;
+	Vector<Variant> constants;
+	VMap<uint32_t, uint32_t> lines;
+	Vector<uint32_t> tokens;
+
+	const uint8_t *buf = p_buffer.ptr();
+	int total_len = p_buffer.size();
+	ERR_FAIL_COND_V(p_buffer.size() < 24 || p_buffer[0] != 'G' || p_buffer[1] != 'D' || p_buffer[2] != 'S' || p_buffer[3] != 'C', ERR_INVALID_DATA);
+
+	int version = decode_uint32(&buf[4]);
+	if (version != bytecode_version) {
+		ERR_FAIL_COND_V(version > bytecode_version, ERR_INVALID_DATA);
+	}
+	int identifier_count = decode_uint32(&buf[8]);
+	int constant_count = decode_uint32(&buf[12]);
+	int line_count = decode_uint32(&buf[16]);
+	int token_count = decode_uint32(&buf[20]);
+
+	const uint8_t *b = &buf[24];
+	total_len -= 24;
+
+	identifiers.resize(identifier_count);
+	for (int i = 0; i < identifier_count; i++) {
+		int len = decode_uint32(b);
+		ERR_FAIL_COND_V(len > total_len, ERR_INVALID_DATA);
+		b += 4;
+		Vector<uint8_t> cs;
+		cs.resize(len);
+		for (int j = 0; j < len; j++) {
+			cs.write[j] = b[j] ^ 0xb6;
+		}
+
+		cs.write[cs.size() - 1] = 0;
+		String s;
+		s.parse_utf8((const char *)cs.ptr());
+		b += len;
+		total_len -= len + 4;
+		identifiers.write[i] = s;
+	}
+
+	constants.resize(constant_count);
+	for (int i = 0; i < constant_count; i++) {
+		Variant v;
+		int len;
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
+		if (err) {
+			error_message = RTR("Invalid constant");
+			return err;
+		}
+		b += len;
+		total_len -= len;
+		constants.write[i] = v;
+	}
+
+	ERR_FAIL_COND_V(line_count * 8 > total_len, ERR_INVALID_DATA);
+
+	for (int i = 0; i < line_count; i++) {
+		uint32_t token = decode_uint32(b);
+		b += 4;
+		uint32_t linecol = decode_uint32(b);
+		b += 4;
+
+		lines.insert(token, linecol);
+		total_len -= 8;
+	}
+
+	tokens.resize(token_count);
+
+	for (int i = 0; i < token_count; i++) {
+		ERR_FAIL_COND_V(total_len < 1, ERR_INVALID_DATA);
+
+		if ((*b) & TOKEN_BYTE_MASK) { //little endian always
+			ERR_FAIL_COND_V(total_len < 4, ERR_INVALID_DATA);
+
+			tokens.write[i] = decode_uint32(b) & ~TOKEN_BYTE_MASK;
+			b += 4;
+		} else {
+			tokens.write[i] = *b;
+			b += 1;
+			total_len--;
+		}
+	}
+
+	//Decompile script
+	String line;
+	int indent = 0;
+
+	Token prev_token = TK_NEWLINE;
+	for (int i = 0; i < tokens.size(); i++) {
+		switch (Token(tokens[i] & TOKEN_MASK)) {
+			case TK_EMPTY: {
+				//skip
+			} break;
+			case TK_IDENTIFIER: {
+				uint32_t identifier = tokens[i] >> TOKEN_BITS;
+				ERR_FAIL_COND_V(identifier >= (uint32_t)identifiers.size(), ERR_INVALID_DATA);
+				line += String(identifiers[identifier]);
+			} break;
+			case TK_CONSTANT: {
+				uint32_t constant = tokens[i] >> TOKEN_BITS;
+				ERR_FAIL_COND_V(constant >= (uint32_t)constants.size(), ERR_INVALID_DATA);
+				line += get_constant_string(constants, constant);
+			} break;
+			case TK_SELF: {
+				line += "self";
+			} break;
+			case TK_BUILT_IN_TYPE: {
+				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
+			} break;
+			case TK_BUILT_IN_FUNC: {
+				line += func_names[tokens[i] >> TOKEN_BITS];
+			} break;
+			case TK_OP_IN: {
+				_ensure_space(line);
+				line += "in ";
+			} break;
+			case TK_OP_EQUAL: {
+				_ensure_space(line);
+				line += "== ";
+			} break;
+			case TK_OP_NOT_EQUAL: {
+				_ensure_space(line);
+				line += "!= ";
+			} break;
+			case TK_OP_LESS: {
+				_ensure_space(line);
+				line += "< ";
+			} break;
+			case TK_OP_LESS_EQUAL: {
+				_ensure_space(line);
+				line += "<= ";
+			} break;
+			case TK_OP_GREATER: {
+				_ensure_space(line);
+				line += "> ";
+			} break;
+			case TK_OP_GREATER_EQUAL: {
+				_ensure_space(line);
+				line += ">= ";
+			} break;
+			case TK_OP_AND: {
+				_ensure_space(line);
+				line += "and ";
+			} break;
+			case TK_OP_OR: {
+				_ensure_space(line);
+				line += "or ";
+			} break;
+			case TK_OP_NOT: {
+				_ensure_space(line);
+				line += "not ";
+			} break;
+			case TK_OP_ADD: {
+				_ensure_space(line);
+				line += "+ ";
+			} break;
+			case TK_OP_SUB: {
+				if (prev_token != TK_NEWLINE)
+					_ensure_space(line);
+				line += "- ";
+				//TODO: do not add space after unary "-"
+			} break;
+			case TK_OP_MUL: {
+				_ensure_space(line);
+				line += "* ";
+			} break;
+			case TK_OP_DIV: {
+				_ensure_space(line);
+				line += "/ ";
+			} break;
+			case TK_OP_MOD: {
+				_ensure_space(line);
+				line += "% ";
+			} break;
+			case TK_OP_SHIFT_LEFT: {
+				_ensure_space(line);
+				line += "<< ";
+			} break;
+			case TK_OP_SHIFT_RIGHT: {
+				_ensure_space(line);
+				line += ">> ";
+			} break;
+			case TK_OP_ASSIGN: {
+				_ensure_space(line);
+				line += "= ";
+			} break;
+			case TK_OP_ASSIGN_ADD: {
+				_ensure_space(line);
+				line += "+= ";
+			} break;
+			case TK_OP_ASSIGN_SUB: {
+				_ensure_space(line);
+				line += "-= ";
+			} break;
+			case TK_OP_ASSIGN_MUL: {
+				_ensure_space(line);
+				line += "*= ";
+			} break;
+			case TK_OP_ASSIGN_DIV: {
+				_ensure_space(line);
+				line += "/= ";
+			} break;
+			case TK_OP_ASSIGN_MOD: {
+				_ensure_space(line);
+				line += "%= ";
+			} break;
+			case TK_OP_ASSIGN_SHIFT_LEFT: {
+				_ensure_space(line);
+				line += "<<= ";
+			} break;
+			case TK_OP_ASSIGN_SHIFT_RIGHT: {
+				_ensure_space(line);
+				line += ">>= ";
+			} break;
+			case TK_OP_ASSIGN_BIT_AND: {
+				_ensure_space(line);
+				line += "&= ";
+			} break;
+			case TK_OP_ASSIGN_BIT_OR: {
+				_ensure_space(line);
+				line += "|= ";
+			} break;
+			case TK_OP_ASSIGN_BIT_XOR: {
+				_ensure_space(line);
+				line += "^= ";
+			} break;
+			case TK_OP_BIT_AND: {
+				_ensure_space(line);
+				line += "& ";
+			} break;
+			case TK_OP_BIT_OR: {
+				_ensure_space(line);
+				line += "| ";
+			} break;
+			case TK_OP_BIT_XOR: {
+				_ensure_space(line);
+				line += "^ ";
+			} break;
+			case TK_OP_BIT_INVERT: {
+				_ensure_space(line);
+				line += "~ ";
+			} break;
+			//case TK_OP_PLUS_PLUS: {
+			//	line += "++";
+			//} break;
+			//case TK_OP_MINUS_MINUS: {
+			//	line += "--";
+			//} break;
+			case TK_CF_IF: {
+				if (prev_token != TK_NEWLINE)
+					_ensure_space(line);
+				line += "if ";
+			} break;
+			case TK_CF_ELIF: {
+				line += "elif ";
+			} break;
+			case TK_CF_ELSE: {
+				if (prev_token != TK_NEWLINE)
+					_ensure_space(line);
+				line += "else ";
+			} break;
+			case TK_CF_FOR: {
+				line += "for ";
+			} break;
+			case TK_CF_WHILE: {
+				line += "while ";
+			} break;
+			case TK_CF_BREAK: {
+				line += "break";
+			} break;
+			case TK_CF_CONTINUE: {
+				line += "continue";
+			} break;
+			case TK_CF_PASS: {
+				line += "pass";
+			} break;
+			case TK_CF_RETURN: {
+				line += "return ";
+			} break;
+			case TK_CF_MATCH: {
+				line += "match ";
+			} break;
+			case TK_PR_FUNCTION: {
+				line += "func ";
+			} break;
+			case TK_PR_CLASS: {
+				line += "class ";
+			} break;
+			case TK_PR_CLASS_NAME: {
+				line += "class_name ";
+			} break;
+			case TK_PR_EXTENDS: {
+				if (prev_token != TK_NEWLINE)
+					_ensure_space(line);
+				line += "extends ";
+			} break;
+			case TK_PR_IS: {
+				_ensure_space(line);
+				line += "is ";
+			} break;
+			case TK_PR_ONREADY: {
+				line += "onready ";
+			} break;
+			case TK_PR_TOOL: {
+				line += "tool ";
+			} break;
+			case TK_PR_STATIC: {
+				line += "static ";
+			} break;
+			case TK_PR_EXPORT: {
+				line += "export ";
+			} break;
+			case TK_PR_SETGET: {
+				line += " setget ";
+			} break;
+			case TK_PR_CONST: {
+				line += "const ";
+			} break;
+			case TK_PR_VAR: {
+				if (line != String() && prev_token != TK_PR_ONREADY)
+					line += " ";
+				line += "var ";
+			} break;
+			case TK_PR_AS: {
+				_ensure_space(line);
+				line += "as ";
+			} break;
+			case TK_PR_VOID: {
+				line += "void ";
+			} break;
+			case TK_PR_ENUM: {
+				line += "enum ";
+			} break;
+			case TK_PR_PRELOAD: {
+				line += "preload";
+			} break;
+			case TK_PR_ASSERT: {
+				line += "assert ";
+			} break;
+			case TK_PR_YIELD: {
+				line += "yield ";
+			} break;
+			case TK_PR_SIGNAL: {
+				line += "signal ";
+			} break;
+			case TK_PR_BREAKPOINT: {
+				line += "breakpoint ";
+			} break;
+			case TK_PR_REMOTE: {
+				line += "remote ";
+			} break;
+			case TK_PR_SYNC: {
+				line += "sync ";
+			} break;
+			case TK_PR_MASTER: {
+				line += "master ";
+			} break;
+			case TK_PR_SLAVE: {
+				line += "slave ";
+			} break;
+			case TK_PR_PUPPET: {
+				line += "puppet ";
+			} break;
+			case TK_PR_REMOTESYNC: {
+				line += "remotesync ";
+			} break;
+			case TK_PR_MASTERSYNC: {
+				line += "mastersync ";
+			} break;
+			case TK_PR_PUPPETSYNC: {
+				line += "puppetsync ";
+			} break;
+			case TK_BRACKET_OPEN: {
+				line += "[";
+			} break;
+			case TK_BRACKET_CLOSE: {
+				line += "]";
+			} break;
+			case TK_CURLY_BRACKET_OPEN: {
+				line += "{";
+			} break;
+			case TK_CURLY_BRACKET_CLOSE: {
+				line += "}";
+			} break;
+			case TK_PARENTHESIS_OPEN: {
+				line += "(";
+			} break;
+			case TK_PARENTHESIS_CLOSE: {
+				line += ")";
+			} break;
+			case TK_COMMA: {
+				line += ", ";
+			} break;
+			case TK_SEMICOLON: {
+				line += ";";
+			} break;
+			case TK_PERIOD: {
+				line += ".";
+			} break;
+			case TK_QUESTION_MARK: {
+				line += "?";
+			} break;
+			case TK_COLON: {
+				line += ":";
+			} break;
+			case TK_DOLLAR: {
+				line += "$";
+			} break;
+			case TK_FORWARD_ARROW: {
+				line += "->";
+			} break;
+			case TK_NEWLINE: {
+				for (int j = 0; j < indent; j++) {
+					script_text += "\t";
+				}
+				script_text += line + "\n";
+				line = String();
+				indent = tokens[i] >> TOKEN_BITS;
+			} break;
+			case TK_CONST_PI: {
+				line += "PI";
+			} break;
+			case TK_CONST_TAU: {
+				line += "TAU";
+			} break;
+			case TK_WILDCARD: {
+				line += "_";
+			} break;
+			case TK_CONST_INF: {
+				line += "INF";
+			} break;
+			case TK_CONST_NAN: {
+				line += "NAN";
+			} break;
+			case TK_ERROR: {
+				//skip - invalid
+			} break;
+			case TK_EOF: {
+				//skip - invalid
+			} break;
+			case TK_CURSOR: {
+				//skip - invalid
+			} break;
+			case TK_MAX: {
+				//skip - invalid
+			} break;
+		}
+		prev_token = Token(tokens[i] & TOKEN_MASK);
+	}
+
+	if (!line.is_empty()) {
+		for (int j = 0; j < indent; j++) {
+			script_text += "\t";
+		}
+		script_text += line + "\n";
+	}
+
+	if (script_text == String()) {
+		error_message = RTR("Invalid token");
+		return ERR_INVALID_DATA;
+	}
+
+	return OK;
+}

--- a/bytecode/bytecode_a7aad78.cpp
+++ b/bytecode/bytecode_a7aad78.cpp
@@ -103,6 +103,8 @@ static const char *func_names[] = {
 	"deep_equal"
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -323,6 +325,7 @@ Error GDScriptDecomp_a7aad78::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_a7aad78.h
+++ b/bytecode/bytecode_a7aad78.h
@@ -27,6 +27,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_a7aad78() {
+		bytecode_rev = 0xa7aad78;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_a7aad78.h
+++ b/bytecode/bytecode_a7aad78.h
@@ -1,0 +1,35 @@
+/*************************************************************************/
+/*  bytecode_a7aad78.h                                                   */
+/*************************************************************************/
+
+#ifndef GDSCRIPT_DECOMP_A7AAD78_H
+#define GDSCRIPT_DECOMP_A7AAD78_H
+
+#include "bytecode_base.h"
+
+class GDScriptDecomp_a7aad78 : public GDScriptDecomp {
+	GDCLASS(GDScriptDecomp_a7aad78, GDScriptDecomp);
+
+protected:
+	static void _bind_methods(){};
+
+	static const int bytecode_version = 13;
+
+	enum {
+		TOKEN_BYTE_MASK = 0x80,
+		TOKEN_BITS = 8,
+		TOKEN_MASK = (1 << TOKEN_BITS) - 1,
+		TOKEN_LINE_BITS = 24,
+		TOKEN_LINE_MASK = (1 << TOKEN_LINE_BITS) - 1,
+	};
+
+public:
+	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
+	GDScriptDecomp_a7aad78() {
+		engine_ver_major = 3;
+		variant_ver_major = 3;
+	}
+};
+
+#endif

--- a/bytecode/bytecode_base.cpp
+++ b/bytecode/bytecode_base.cpp
@@ -28,6 +28,137 @@ void GDScriptDecomp::_ensure_space(String &p_code) {
 	}
 }
 
+static const Pair<String, Pair<int, int>> builtin_func_arg_elements[] = {
+	{ "sin", Pair<int, int>(1, 1) },
+	{ "cos", Pair<int, int>(1, 1) },
+	{ "tan", Pair<int, int>(1, 1) },
+	{ "sinh", Pair<int, int>(1, 1) },
+	{ "cosh", Pair<int, int>(1, 1) },
+	{ "tanh", Pair<int, int>(1, 1) },
+	{ "asin", Pair<int, int>(1, 1) },
+	{ "acos", Pair<int, int>(1, 1) },
+	{ "atan", Pair<int, int>(1, 1) },
+	{ "atan2", Pair<int, int>(2, 2) },
+	{ "sqrt", Pair<int, int>(1, 1) },
+	{ "fmod", Pair<int, int>(2, 2) },
+	{ "fposmod", Pair<int, int>(2, 2) },
+	{ "posmod", Pair<int, int>(2, 2) },
+	{ "floor", Pair<int, int>(1, 1) },
+	{ "ceil", Pair<int, int>(1, 1) },
+	{ "round", Pair<int, int>(1, 1) },
+	{ "abs", Pair<int, int>(1, 1) },
+	{ "sign", Pair<int, int>(1, 1) },
+	{ "pow", Pair<int, int>(2, 2) },
+	{ "log", Pair<int, int>(1, 1) },
+	{ "exp", Pair<int, int>(1, 1) },
+	{ "is_nan", Pair<int, int>(1, 1) },
+	{ "is_inf", Pair<int, int>(1, 1) },
+	{ "is_equal_approx", Pair<int, int>(2, 2) },
+	{ "is_zero_approx", Pair<int, int>(1, 1) },
+	{ "ease", Pair<int, int>(2, 2) },
+	{ "decimals", Pair<int, int>(1, 1) },
+	{ "step_decimals", Pair<int, int>(1, 1) },
+	{ "stepify", Pair<int, int>(2, 2) },
+	{ "lerp", Pair<int, int>(3, 3) },
+	{ "lerp_angle", Pair<int, int>(3, 3) },
+	{ "inverse_lerp", Pair<int, int>(3, 3) },
+	{ "range_lerp", Pair<int, int>(5, 5) },
+	{ "smoothstep", Pair<int, int>(3, 3) },
+	{ "move_toward", Pair<int, int>(3, 3) },
+	{ "dectime", Pair<int, int>(3, 3) },
+	{ "randomize", Pair<int, int>(0, 0) },
+	{ "randi", Pair<int, int>(0, 0) },
+	{ "randf", Pair<int, int>(0, 0) },
+	{ "rand_range", Pair<int, int>(2, 2) },
+	{ "seed", Pair<int, int>(1, 1) },
+	{ "rand_seed", Pair<int, int>(1, 1) },
+	{ "deg2rad", Pair<int, int>(1, 1) },
+	{ "rad2deg", Pair<int, int>(1, 1) },
+	{ "linear2db", Pair<int, int>(1, 1) },
+	{ "db2linear", Pair<int, int>(1, 1) },
+	{ "polar2cartesian", Pair<int, int>(2, 2) },
+	{ "cartesian2polar", Pair<int, int>(2, 2) },
+	{ "wrapi", Pair<int, int>(3, 3) },
+	{ "wrapf", Pair<int, int>(3, 3) },
+	{ "max", Pair<int, int>(2, 2) },
+	{ "min", Pair<int, int>(2, 2) },
+	{ "clamp", Pair<int, int>(3, 3) },
+	{ "nearest_po2", Pair<int, int>(1, 1) },
+	{ "weakref", Pair<int, int>(1, 1) },
+	{ "funcref", Pair<int, int>(2, 2) },
+	{ "convert", Pair<int, int>(2, 2) },
+	{ "typeof", Pair<int, int>(1, 1) },
+	{ "type_exists", Pair<int, int>(1, 1) },
+	{ "char", Pair<int, int>(1, 1) },
+	{ "ord", Pair<int, int>(1, 1) },
+	{ "str", Pair<int, int>(1, INT_MAX) },
+	{ "print", Pair<int, int>(0, INT_MAX) },
+	{ "printt", Pair<int, int>(0, INT_MAX) },
+	{ "prints", Pair<int, int>(0, INT_MAX) },
+	{ "printerr", Pair<int, int>(0, INT_MAX) },
+	{ "printraw", Pair<int, int>(0, INT_MAX) },
+	{ "print_debug", Pair<int, int>(0, INT_MAX) },
+	{ "push_error", Pair<int, int>(1, 1) },
+	{ "push_warning", Pair<int, int>(1, 1) },
+	{ "var2str", Pair<int, int>(1, 1) },
+	{ "str2var", Pair<int, int>(1, 1) },
+	{ "var2bytes", Pair<int, int>(1, 1) }, // 3.1.1 onwards added an optional 2nd argument, handled below
+	{ "bytes2var", Pair<int, int>(1, 1) }, // 3.1.1 onwards added an optional 2nd argument, handled below
+	{ "range", Pair<int, int>(1, 3) },
+	{ "load", Pair<int, int>(1, 1) },
+	{ "inst2dict", Pair<int, int>(1, 1) },
+	{ "dict2inst", Pair<int, int>(1, 1) },
+	{ "validate_json", Pair<int, int>(1, 1) },
+	{ "parse_json", Pair<int, int>(1, 1) },
+	{ "to_json", Pair<int, int>(1, 1) },
+	{ "hash", Pair<int, int>(1, 1) },
+	{ "Color8", Pair<int, int>(3, 3) },
+	{ "ColorN", Pair<int, int>(1, 2) },
+	{ "print_stack", Pair<int, int>(0, 0) },
+	{ "get_stack", Pair<int, int>(0, 0) },
+	{ "instance_from_id", Pair<int, int>(1, 1) },
+	{ "len", Pair<int, int>(1, 1) },
+	{ "is_instance_valid", Pair<int, int>(1, 1) },
+	{ "deep_equal", Pair<int, int>(2, 2) },
+	{ "get_inst", Pair<int, int>(1, 1) } // rename of instance_from_id
+};
+static constexpr int BUILTIN_FUNC_ARG_ELEMENTS_MAX = sizeof(builtin_func_arg_elements) / sizeof(builtin_func_arg_elements[0]);
+
+HashMap<String, Pair<int, int>> _inithashmap() {
+	HashMap<String, Pair<int, int>> hm;
+	for (int i = 0; i < BUILTIN_FUNC_ARG_ELEMENTS_MAX; i++) {
+		hm[builtin_func_arg_elements[i].first] = builtin_func_arg_elements[i].second;
+	}
+	return hm;
+}
+
+static const HashMap<String, Pair<int, int>> builtin_func_arg_map = _inithashmap();
+
+Pair<int, int> GDScriptDecomp::get_arg_count_for_builtin(String builtin_func_name) {
+	if (!builtin_func_arg_map.has(builtin_func_name)) {
+		return Pair<int, int>(-1, -1);
+	}
+	switch (bytecode_rev) {
+		case 0xf3f05dc: // 4.0 dev
+		case 0x506df14:
+		case 0xa7aad78: // 3.5
+		case 0x5565f55: // 3.2
+		case 0x6694c11: // 3.2 dev
+		case 0xa60f242:
+		case 0xc00427a:
+		case 0x620ec47:
+		case 0x7f7d97f:
+		case 0x514a3fb: // 3.1.1
+			if (builtin_func_name == "var2bytes" || builtin_func_name == "bytes2var") {
+				return Pair<int, int>(1, 2);
+			}
+			break;
+		default:
+			break;
+	}
+	return builtin_func_arg_map[builtin_func_name];
+}
+
 Error GDScriptDecomp::decompile_byte_code_encrypted(const String &p_path, Vector<uint8_t> p_key) {
 	Vector<uint8_t> bytecode;
 	Error err = get_buffer_encrypted(p_path, p_key, bytecode);

--- a/bytecode/bytecode_base.cpp
+++ b/bytecode/bytecode_base.cpp
@@ -30,7 +30,22 @@ void GDScriptDecomp::_ensure_space(String &p_code) {
 
 Error GDScriptDecomp::decompile_byte_code_encrypted(const String &p_path, Vector<uint8_t> p_key) {
 	Vector<uint8_t> bytecode;
+	Error err = get_buffer_encrypted(p_path, p_key, bytecode);
+	ERR_FAIL_COND_V(err != OK, err);
+	return decompile_buffer(bytecode);
+}
 
+Error GDScriptDecomp::decompile_byte_code(const String &p_path) {
+	Vector<uint8_t> bytecode;
+
+	bytecode = FileAccess::get_file_as_bytes(p_path);
+
+	error_message = RTR("No error");
+
+	return decompile_buffer(bytecode);
+}
+
+Error GDScriptDecomp::get_buffer_encrypted(const String &p_path, Vector<uint8_t> p_key, Vector<uint8_t> &bytecode) {
 	Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V(fa.is_null(), ERR_FILE_CANT_OPEN);
 
@@ -39,12 +54,16 @@ Error GDScriptDecomp::decompile_byte_code_encrypted(const String &p_path, Vector
 	if (engine_ver_major == 3) {
 		Ref<FileAccessEncryptedv3> fae;
 		fae.instantiate();
-		ERR_FAIL_COND_V(fae.is_null(), ERR_FILE_CORRUPT);
+		if (fae.is_null()) {
+			error_message = RTR("FAE doesn't exist?!");
+			ERR_FAIL_COND_V(fae.is_null(), ERR_BUG);
+		}
 
 		Error err = fae->open_and_parse(fa, p_key, FileAccessEncryptedv3::MODE_READ);
 
 		if (err) {
-			ERR_FAIL_COND_V(err, ERR_FILE_CORRUPT);
+			error_message = RTR("Encryption Error");
+			ERR_FAIL_V(ERR_FILE_CORRUPT);
 		}
 
 		bytecode.resize(fae->get_length());
@@ -57,25 +76,15 @@ Error GDScriptDecomp::decompile_byte_code_encrypted(const String &p_path, Vector
 		Error err = fae->open_and_parse(fa, p_key, FileAccessEncrypted::MODE_READ);
 
 		if (err) {
-			ERR_FAIL_COND_V(err, ERR_FILE_CORRUPT);
+			error_message = RTR("Encryption Error");
+			ERR_FAIL_V(ERR_FILE_CORRUPT);
 		}
 
 		bytecode.resize(fae->get_length());
 		fae->get_buffer(bytecode.ptrw(), bytecode.size());
 	}
 	error_message = RTR("No error");
-
-	return decompile_buffer(bytecode);
-}
-
-Error GDScriptDecomp::decompile_byte_code(const String &p_path) {
-	Vector<uint8_t> bytecode;
-
-	bytecode = FileAccess::get_file_as_bytes(p_path);
-
-	error_message = RTR("No error");
-
-	return decompile_buffer(bytecode);
+	return OK;
 }
 
 String GDScriptDecomp::get_script_text() {
@@ -94,4 +103,86 @@ String GDScriptDecomp::get_constant_string(Vector<Variant> &constants, uint32_t 
 		constString = constString.replace("\n", "\\n");
 	}
 	return constString;
+}
+
+Error GDScriptDecomp::get_ids_consts_tokens(const Vector<uint8_t> &p_buffer, int bytecode_version, Vector<StringName> &identifiers, Vector<Variant> &constants, Vector<uint32_t> &tokens) {
+	//Load bytecode
+	VMap<uint32_t, uint32_t> lines;
+
+	const uint8_t *buf = p_buffer.ptr();
+	int total_len = p_buffer.size();
+	ERR_FAIL_COND_V(p_buffer.size() < 24 || p_buffer[0] != 'G' || p_buffer[1] != 'D' || p_buffer[2] != 'S' || p_buffer[3] != 'C', ERR_INVALID_DATA);
+
+	int version = decode_uint32(&buf[4]);
+	if (version != bytecode_version) {
+		ERR_FAIL_COND_V(version > bytecode_version, ERR_INVALID_DATA);
+	}
+	int identifier_count = decode_uint32(&buf[8]);
+	int constant_count = decode_uint32(&buf[12]);
+	int line_count = decode_uint32(&buf[16]);
+	int token_count = decode_uint32(&buf[20]);
+
+	const uint8_t *b = &buf[24];
+	total_len -= 24;
+
+	identifiers.resize(identifier_count);
+	for (int i = 0; i < identifier_count; i++) {
+		int len = decode_uint32(b);
+		ERR_FAIL_COND_V(len > total_len, ERR_INVALID_DATA);
+		b += 4;
+		Vector<uint8_t> cs;
+		cs.resize(len);
+		for (int j = 0; j < len; j++) {
+			cs.write[j] = b[j] ^ 0xb6;
+		}
+
+		cs.write[cs.size() - 1] = 0;
+		String s;
+		s.parse_utf8((const char *)cs.ptr());
+		b += len;
+		total_len -= len + 4;
+		identifiers.write[i] = s;
+	}
+
+	constants.resize(constant_count);
+	for (int i = 0; i < constant_count; i++) {
+		Variant v;
+		int len;
+		Error err = VariantDecoderCompat::decode_variant_compat(variant_ver_major, v, b, total_len, &len);
+		if (err) {
+			error_message = RTR("Invalid constant");
+			return err;
+		}
+		b += len;
+		total_len -= len;
+		constants.write[i] = v;
+	}
+
+	ERR_FAIL_COND_V(line_count * 8 > total_len, ERR_INVALID_DATA);
+
+	for (int i = 0; i < line_count; i++) {
+		uint32_t token = decode_uint32(b);
+		b += 4;
+		uint32_t linecol = decode_uint32(b);
+		b += 4;
+
+		lines.insert(token, linecol);
+		total_len -= 8;
+	}
+	tokens.resize(token_count);
+	for (int i = 0; i < token_count; i++) {
+		ERR_FAIL_COND_V(total_len < 1, ERR_INVALID_DATA);
+
+		if ((*b) & 0x80) { //BYTECODE_MASK, little endian always
+			ERR_FAIL_COND_V(total_len < 4, ERR_INVALID_DATA);
+
+			tokens.write[i] = decode_uint32(b) & ~0x80;
+			b += 4;
+		} else {
+			tokens.write[i] = *b;
+			b += 1;
+			total_len--;
+		}
+	}
+	return OK;
 }

--- a/bytecode/bytecode_base.h
+++ b/bytecode/bytecode_base.h
@@ -22,15 +22,24 @@ protected:
 	String error_message;
 	int engine_ver_major;
 	int variant_ver_major; // Some early dev versions of 3.0 used v2 variants, and early dev versions of 4.0 used v3 variants
-
 public:
+	enum BYTECODE_TEST_RESULT {
+		BYTECODE_TEST_PASS,
+		BYTECODE_TEST_FAIL,
+		BYTECODE_TEST_CORRUPT,
+		BYTECODE_TEST_UNKNOWN,
+	};
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) = 0;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> p_buffer) = 0;
+
 	Error decompile_byte_code_encrypted(const String &p_path, Vector<uint8_t> p_key);
 	Error decompile_byte_code(const String &p_path);
 
+	Error get_buffer_encrypted(const String &p_path, Vector<uint8_t> p_key, Vector<uint8_t> &r_buffer);
 	String get_script_text();
 	String get_error_message();
 	String get_constant_string(Vector<Variant> &constants, uint32_t constId);
+	Error get_ids_consts_tokens(const Vector<uint8_t> &p_buffer, int bytecode_version, Vector<StringName> &r_identifiers, Vector<Variant> &r_constants, Vector<uint32_t> &r_tokens);
 };
 
 #endif

--- a/bytecode/bytecode_base.h
+++ b/bytecode/bytecode_base.h
@@ -23,6 +23,9 @@ protected:
 	uint64_t bytecode_rev;
 	int engine_ver_major;
 	int variant_ver_major; // Some early dev versions of 3.0 used v2 variants, and early dev versions of 4.0 used v3 variants
+
+	Pair<int, int> get_arg_count_for_builtin(String builtin_func_name);
+
 public:
 	enum BYTECODE_TEST_RESULT {
 		BYTECODE_TEST_PASS,
@@ -30,6 +33,7 @@ public:
 		BYTECODE_TEST_CORRUPT,
 		BYTECODE_TEST_UNKNOWN,
 	};
+
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) = 0;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> p_buffer) = 0;
 

--- a/bytecode/bytecode_base.h
+++ b/bytecode/bytecode_base.h
@@ -20,6 +20,7 @@ protected:
 
 	String script_text;
 	String error_message;
+	uint64_t bytecode_rev;
 	int engine_ver_major;
 	int variant_ver_major; // Some early dev versions of 3.0 used v2 variants, and early dev versions of 4.0 used v3 variants
 public:

--- a/bytecode/bytecode_base.h
+++ b/bytecode/bytecode_base.h
@@ -40,7 +40,7 @@ public:
 	Error decompile_byte_code_encrypted(const String &p_path, Vector<uint8_t> p_key);
 	Error decompile_byte_code(const String &p_path);
 
-	Error get_buffer_encrypted(const String &p_path, Vector<uint8_t> p_key, Vector<uint8_t> &r_buffer);
+	static Error get_buffer_encrypted(const String &p_path, int engine_ver_major, Vector<uint8_t> p_key, Vector<uint8_t> &r_buffer);
 	String get_script_text();
 	String get_error_message();
 	String get_constant_string(Vector<Variant> &constants, uint32_t constId);

--- a/bytecode/bytecode_be46be7.cpp
+++ b/bytecode/bytecode_be46be7.cpp
@@ -72,6 +72,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -271,6 +273,7 @@ Error GDScriptDecomp_be46be7::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_be46be7.h
+++ b/bytecode/bytecode_be46be7.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_be46be7() {
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2

--- a/bytecode/bytecode_be46be7.h
+++ b/bytecode/bytecode_be46be7.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_be46be7() {
+		bytecode_rev = 0xbe46be7;
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2
 	}

--- a/bytecode/bytecode_c00427a.cpp
+++ b/bytecode/bytecode_c00427a.cpp
@@ -99,6 +99,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -319,6 +321,7 @@ Error GDScriptDecomp_c00427a::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_c00427a.h
+++ b/bytecode/bytecode_c00427a.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_c00427a() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_c00427a.h
+++ b/bytecode/bytecode_c00427a.h
@@ -27,6 +27,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_c00427a() {
+		bytecode_rev = 0xc00427a;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_c24c739.cpp
+++ b/bytecode/bytecode_c24c739.cpp
@@ -82,6 +82,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -293,6 +295,7 @@ Error GDScriptDecomp_c24c739::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_c24c739.h
+++ b/bytecode/bytecode_c24c739.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_c24c739() {
+		bytecode_rev = 0xc24c739;
 		engine_ver_major = 3;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_c24c739.h
+++ b/bytecode/bytecode_c24c739.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_c24c739() {
 		engine_ver_major = 3;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_c6120e7.cpp
+++ b/bytecode/bytecode_c6120e7.cpp
@@ -83,6 +83,8 @@ static const char *func_names[] = {
 	"len",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -297,6 +299,7 @@ Error GDScriptDecomp_c6120e7::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_c6120e7.h
+++ b/bytecode/bytecode_c6120e7.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_c6120e7() {
+		bytecode_rev = 0xc6120e7;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_c6120e7.h
+++ b/bytecode/bytecode_c6120e7.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_c6120e7() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_d28da86.cpp
+++ b/bytecode/bytecode_d28da86.cpp
@@ -85,6 +85,8 @@ static const char *func_names[] = {
 	"len",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -299,6 +301,7 @@ Error GDScriptDecomp_d28da86::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_d28da86.h
+++ b/bytecode/bytecode_d28da86.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_d28da86() {
+		bytecode_rev = 0xd28da86;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_d28da86.h
+++ b/bytecode/bytecode_d28da86.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_d28da86() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_d6b31da.cpp
+++ b/bytecode/bytecode_d6b31da.cpp
@@ -92,6 +92,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -315,6 +317,7 @@ Error GDScriptDecomp_d6b31da::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_d6b31da.h
+++ b/bytecode/bytecode_d6b31da.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_d6b31da() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_d6b31da.h
+++ b/bytecode/bytecode_d6b31da.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_d6b31da() {
+		bytecode_rev = 0xd6b31da;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_e82dc40.cpp
+++ b/bytecode/bytecode_e82dc40.cpp
@@ -68,6 +68,8 @@ static const char *func_names[] = {
 	"print_stack",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -266,6 +268,7 @@ Error GDScriptDecomp_e82dc40::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_e82dc40.h
+++ b/bytecode/bytecode_e82dc40.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_e82dc40() {
+		bytecode_rev = 0xe82dc40;
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2
 	}

--- a/bytecode/bytecode_e82dc40.h
+++ b/bytecode/bytecode_e82dc40.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_e82dc40() {
 		engine_ver_major = 1;
 		variant_ver_major = 2; // we just use variant parser/writer for v2

--- a/bytecode/bytecode_ed80f45.cpp
+++ b/bytecode/bytecode_ed80f45.cpp
@@ -78,6 +78,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -282,6 +284,7 @@ Error GDScriptDecomp_ed80f45::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_ed80f45.h
+++ b/bytecode/bytecode_ed80f45.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override;
 	GDScriptDecomp_ed80f45() {
+		bytecode_rev = 0xed80f45;
 		engine_ver_major = 2;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_ed80f45.h
+++ b/bytecode/bytecode_ed80f45.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override;
 	GDScriptDecomp_ed80f45() {
 		engine_ver_major = 2;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_f3f05dc.cpp
+++ b/bytecode/bytecode_f3f05dc.cpp
@@ -101,6 +101,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -319,6 +321,7 @@ Error GDScriptDecomp_f3f05dc::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_f3f05dc.h
+++ b/bytecode/bytecode_f3f05dc.h
@@ -25,6 +25,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_f3f05dc() {
 		engine_ver_major = 4;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_f3f05dc.h
+++ b/bytecode/bytecode_f3f05dc.h
@@ -27,6 +27,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_f3f05dc() {
+		bytecode_rev = 0xf3f05dc;
 		engine_ver_major = 4;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_f8a7c46.cpp
+++ b/bytecode/bytecode_f8a7c46.cpp
@@ -82,6 +82,8 @@ static const char *func_names[] = {
 	"instance_from_id",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -292,6 +294,7 @@ Error GDScriptDecomp_f8a7c46::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_f8a7c46.h
+++ b/bytecode/bytecode_f8a7c46.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_f8a7c46() {
+		bytecode_rev = 0xf8a7c46;
 		engine_ver_major = 3;
 		variant_ver_major = 2;
 	}

--- a/bytecode/bytecode_f8a7c46.h
+++ b/bytecode/bytecode_f8a7c46.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_f8a7c46() {
 		engine_ver_major = 3;
 		variant_ver_major = 2;

--- a/bytecode/bytecode_ff1e7cf.cpp
+++ b/bytecode/bytecode_ff1e7cf.cpp
@@ -90,6 +90,8 @@ static const char *func_names[] = {
 	"is_instance_valid",
 };
 
+static constexpr uint64_t FUNC_MAX = sizeof(func_names) / sizeof(func_names[0]);
+
 enum Token {
 
 	TK_EMPTY,
@@ -305,6 +307,7 @@ Error GDScriptDecomp_ff1e7cf::decompile_buffer(Vector<uint8_t> p_buffer) {
 				line += VariantDecoderCompat::get_variant_type_name(tokens[i] >> TOKEN_BITS, variant_ver_major);
 			} break;
 			case TK_BUILT_IN_FUNC: {
+				ERR_FAIL_COND_V(tokens[i] >> TOKEN_BITS >= FUNC_MAX, ERR_INVALID_DATA);
 				line += func_names[tokens[i] >> TOKEN_BITS];
 			} break;
 			case TK_OP_IN: {

--- a/bytecode/bytecode_ff1e7cf.h
+++ b/bytecode/bytecode_ff1e7cf.h
@@ -26,6 +26,7 @@ protected:
 
 public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
+	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_ff1e7cf() {
 		engine_ver_major = 3;
 		variant_ver_major = 3;

--- a/bytecode/bytecode_ff1e7cf.h
+++ b/bytecode/bytecode_ff1e7cf.h
@@ -28,6 +28,7 @@ public:
 	virtual Error decompile_buffer(Vector<uint8_t> p_buffer) override;
 	virtual BYTECODE_TEST_RESULT test_bytecode(Vector<uint8_t> buffer) override { return BYTECODE_TEST_RESULT::BYTECODE_TEST_UNKNOWN; }; // not implemented
 	GDScriptDecomp_ff1e7cf() {
+		bytecode_rev = 0xff1e7cf;
 		engine_ver_major = 3;
 		variant_ver_major = 3;
 	}

--- a/bytecode/bytecode_tester.cpp
+++ b/bytecode/bytecode_tester.cpp
@@ -1,0 +1,144 @@
+#include "bytecode_tester.h"
+#include "bytecode_versions.h"
+#include "core/io/file_access.h"
+// We are only using this to test 2.1.x and 3.1.x currently.
+
+uint64_t test_files_2_1(const Vector<String> &p_paths) {
+	uint64_t rev = 0;
+	bool ed80f45_failed = false;
+	bool ed80f45_passed = false;
+	bool _85585c7_failed = false;
+	bool _85585c7_passed = false;
+	bool _7124599_failed = false;
+	bool _7124599_passed = false;
+
+	GDScriptDecomp_ed80f45 *decomp_ed80f45 = memnew(GDScriptDecomp_ed80f45);
+	GDScriptDecomp_85585c7 *decomp_85585c7 = memnew(GDScriptDecomp_85585c7);
+	GDScriptDecomp_7124599 *decomp_7124599 = memnew(GDScriptDecomp_7124599);
+	for (String path : p_paths) {
+		Vector<uint8_t> data = FileAccess::get_file_as_bytes(path);
+		if (data.size() == 0) {
+			continue;
+		}
+		if (!ed80f45_failed && !ed80f45_passed) {
+			auto test_result = decomp_ed80f45->test_bytecode(data);
+			if (test_result == GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL) {
+				ed80f45_failed = true;
+			} else if (test_result == GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_PASS) {
+				// we don't need to test further, this revision is the highest possible for bytecode version 10
+				ed80f45_passed = true;
+				rev = 0xed80f45;
+				break;
+			}
+		}
+		if (!_85585c7_failed && !_85585c7_passed) {
+			auto test_result = decomp_85585c7->test_bytecode(data);
+			if (test_result == GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL) {
+				_85585c7_failed = true;
+			} else if (test_result == GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_PASS) {
+				_85585c7_passed = true;
+				if (ed80f45_failed) {
+					// no need to go further
+					rev = 0x85585c7;
+					break;
+				}
+			}
+		}
+		if (!_7124599_failed && !_7124599_passed) {
+			auto test_result = decomp_7124599->test_bytecode(data);
+			if (test_result == GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL) {
+				_7124599_failed = true;
+			} else if (test_result == GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_PASS) {
+				// doesn't currently have a pass condition, but we check it anyway if we come up with something later
+				_7124599_passed = true;
+			}
+		}
+		if (ed80f45_failed && _85585c7_failed && _7124599_failed) {
+			// Welp
+			break;
+		}
+	}
+	if (rev == 0) {
+		// ed80f45 didn't pass, but this passed, so it's probably this version.
+		if (_85585c7_passed) {
+			rev = 0x85585c7;
+		} else if (ed80f45_failed) {
+			// 7124599 doesn't currently have a pass condition; if the others have failed and this has not, then it's probably this version.
+			if (!_7124599_failed) {
+				if (_85585c7_failed) {
+					rev = 0x7124599;
+				} else {
+					rev = 0x85585c7;
+				}
+			}
+		} else if ((!ed80f45_failed && !_85585c7_failed && !_7124599_failed)) {
+			// It likely won't matter what we decompile as, just return the highest revision.
+			rev = 0xed80f45;
+		}
+	}
+	memdelete(decomp_ed80f45);
+	memdelete(decomp_85585c7);
+	memdelete(decomp_7124599);
+	return rev;
+}
+
+// don't use this, just parse the binary for the version string
+uint64_t test_files_3_1(const Vector<String> &p_paths) {
+	// only need to test 514a3fb and 1a36141
+	uint64_t rev = 0;
+	bool _514a3fb_failed = false;
+	bool _1a36141_failed = false;
+
+	GDScriptDecomp_514a3fb *decomp_514a3fb = memnew(GDScriptDecomp_514a3fb);
+	GDScriptDecomp_1a36141 *decomp_1a36141 = memnew(GDScriptDecomp_1a36141);
+
+	// Neither of these tests have pass cases, only fail cases.
+	for (String path : p_paths) {
+		Vector<uint8_t> data = FileAccess::get_file_as_bytes(path);
+		if (data.size() == 0) {
+			continue;
+		}
+		if (!_514a3fb_failed) {
+			auto test_result = decomp_514a3fb->test_bytecode(data);
+			if (test_result == GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL) {
+				_514a3fb_failed = true;
+			}
+		}
+		if (!_1a36141_failed) {
+			auto test_result = decomp_1a36141->test_bytecode(data);
+			if (test_result == GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL) {
+				_1a36141_failed = true;
+			}
+		}
+		if (_514a3fb_failed && _1a36141_failed) {
+			// Welp
+			break;
+		}
+	}
+
+	if (rev == 0) {
+		if (!_514a3fb_failed && !_1a36141_failed) {
+			// won't matter, just use highest revision
+			rev = 0x514a3fb;
+		}
+		if (_514a3fb_failed && !_1a36141_failed) {
+			rev = 0x1a36141;
+		}
+	}
+
+	memdelete(decomp_514a3fb);
+	memdelete(decomp_1a36141);
+	return rev;
+}
+
+uint64_t BytecodeTester::test_files(const Vector<String> &p_paths, int ver_major, int ver_minor) {
+	uint64_t rev = 0;
+	if (ver_major == 2 && ver_minor == 1) {
+		return test_files_2_1(p_paths);
+	} else if (ver_major == 3 && ver_minor == 1) {
+		return test_files_3_1(p_paths);
+	} else {
+		return 0;
+	}
+	return rev;
+}

--- a/bytecode/bytecode_tester.cpp
+++ b/bytecode/bytecode_tester.cpp
@@ -226,21 +226,27 @@ uint64_t test_files_2_1(const Vector<String> &p_paths) {
 		}
 	}
 	if (rev == 0) {
-		// ed80f45 didn't pass or fail, but this passed, so it's probably this version.
-		if (_85585c7_passed) {
-			rev = 0x85585c7;
-		} else if (ed80f45_failed) {
-			// 7124599 doesn't currently have a pass condition; if the others have failed and this has not, then it's probably this version.
-			if (!_7124599_failed) {
-				if (_85585c7_failed) {
-					rev = 0x7124599;
-				} else {
-					rev = 0x85585c7;
-				}
+		if (!ed80f45_failed) {
+			if (_85585c7_passed) {
+				rev = 0x85585c7;
+				// major token changes in ed80f45, the others should have failed
+			} else if (_7124599_failed && _85585c7_failed) {
+				rev = 0xed80f45;
 			}
-		} else if ((!ed80f45_failed && !_85585c7_failed && !_7124599_failed)) {
-			// It likely won't matter what we decompile as, just return the highest revision.
-			rev = 0xed80f45;
+		} else if (ed80f45_failed) {
+			// it's quite possible for both 85585c7 and 7124599 to not fail, as 85585c7 is testing ColorN, which came towards the end of the builtin_func list
+			// and our pass cases are pretty limited there.
+			// if the game doesn't use 	"ColorN", "print_stack", or "instance_from_id", neither will fail.
+			// in that case, it doesn't matter which one we pick, so we'll just use 85585c7.
+			if (!_85585c7_failed) {
+				rev = 0x85585c7;
+				// otherwise, it's probably 7124599
+			} else if (!_7124599_failed) {
+				rev = 0x7124599;
+			}
+		}
+		if (rev == 0) {
+			ERR_PRINT("Failed to detect GDScript revision for engine version 2.1.x, please report this issue on GitHub");
 		}
 	}
 	memdelete(decomp_ed80f45);
@@ -346,10 +352,11 @@ uint64_t test_files_3_1(const Vector<String> &p_paths, const Vector<uint8_t> &p_
 	}
 
 	if (rev == 0) {
-		if (_1a36141_passed && _1ca61a3_failed) {
-			// 0x514a3fb didn't pass or fail, but 0x1a36141 passed, so it's likely 0x1a36141
+		if (!_514a3fb_failed && _1a36141_passed) {
 			rev = 0x1a36141;
-		} else if (!_514a3fb_failed && !_1a36141_failed && _1ca61a3_failed) {
+		} else if ((!_514a3fb_failed || !_1a36141_failed) && _1ca61a3_passed) {
+			rev = 0x1ca61a3;
+		} else if (!_514a3fb_failed && !_1a36141_failed && _1ca61a3_failed) { // there were major token changes in 3.1-beta, 1ca61a3 should have failed if the others didn't
 			// it likely will not matter which revision we use here, as they seem to have not used many built-in functions
 			// just use 3.1.1 (514a3fb), less than a month passed between 3.1.0 and 3.1.1
 			rev = 0x514a3fb;
@@ -359,7 +366,7 @@ uint64_t test_files_3_1(const Vector<String> &p_paths, const Vector<uint8_t> &p_
 			rev = 0x1ca61a3;
 		} else {
 			// If we made it here, our current way of testing is insufficient, the user should report this.
-			ERR_FAIL_V_MSG(0, "Failed to detect GDScript revision for engine version 2.1.x, please report this issue on GitHub.");
+			ERR_FAIL_V_MSG(0, "Failed to detect GDScript revision for engine version 3.1.x, please report this issue on GitHub.");
 		}
 	}
 

--- a/bytecode/bytecode_tester.cpp
+++ b/bytecode/bytecode_tester.cpp
@@ -3,6 +3,147 @@
 #include "core/io/file_access.h"
 // We are only using this to test 2.1.x and 3.1.x currently.
 
+/***********2.1 testing ********
+ discontintuities in the functions for bytecode 10 starts here (-1 means varargs):
+
+
+| 23441ec          | Args | 7124599          | Args | 85585c7          | Args | ed80f45          | Args |
+| ---------------- | ---- | ---------------- | ---- | ---------------- | ---- | ---------------- | ---- |
+| typeof           | 1    | typeof           | 1    | typeof           | 1    | typeof           | 1    |
+| str              | -1   | type_exists      | 1    | type_exists      | 1    | type_exists      | 1    |
+| print            | -1   | str              | -1   | str              | -1   | str              | -1   |
+| printt           | -1   | print            | -1   | print            | -1   | print            | -1   |
+| prints           | -1   | printt           | -1   | printt           | -1   | printt           | -1   |
+| printerr         | -1   | prints           | -1   | prints           | -1   | prints           | -1   |
+| printraw         | -1   | printerr         | -1   | printerr         | -1   | printerr         | -1   |
+| var2str          | 1    | printraw         | -1   | printraw         | -1   | printraw         | -1   |
+| str2var          | 1    | var2str          | 1    | var2str          | 1    | var2str          | 1    |
+| var2bytes        | 1    | str2var          | 1    | str2var          | 1    | str2var          | 1    |
+| bytes2var        | 1    | var2bytes        | 1    | var2bytes        | 1    | var2bytes        | 1    |
+| range            | -1   | bytes2var        | 1    | bytes2var        | 1    | bytes2var        | 1    |
+| load             | 1    | range            | -1   | range            | -1   | range            | -1   |
+| inst2dict        | 1    | load             | 1    | load             | 1    | load             | 1    |
+| dict2inst        | 1    | inst2dict        | 1    | inst2dict        | 1    | inst2dict        | 1    |
+| hash             | 1    | dict2inst        | 1    | dict2inst        | 1    | dict2inst        | 1    |
+| Color8           | 3    | hash             | 1    | hash             | 1    | hash             | 1    |
+| print_stack      | 0    | Color8           | 3    | Color8           | 3    | Color8           | 3    |
+| instance_from_id | 1    | print_stack      | 0    | ColorN           | 1-2  | ColorN           | 1-2  |
+|                  |      | instance_from_id | 1    | print_stack      | 0    | print_stack      | 0    |
+|                  |      |                  |      | instance_from_id | 1    | instance_from_id | 1    |
+
+
+Discontinuities in the token types for bytecode 10 start here:
+( "space" means that there can be newlines between this token and the next )
+| 85585c7  tkn           | next                         | space | ed80f45                | next                                   | space |
+| ---------------------- | --------------------------   | ----- | ---------------------- | -------------------------------------- | ----- |
+| TK_PR_VAR              | TK_IDENTIFIER                | FALSE | TK_PR_VAR              | TK_IDENTIFIER                          |       |
+| TK_PR_PRELOAD          | TK_PARENTHESIS_OPEN          | FALSE | TK_PR_ENUM             | TK_IDENTIFIER OR TK_CURLY_BRACKET_OPEN |       |
+| TK_PR_ASSERT           | TK_PARENTHESIS_OPEN          | TRUE  | TK_PR_PRELOAD          | TK_PARENTHESIS_OPEN                    | FALSE |
+| TK_PR_YIELD            | TK_PARENTHESIS_OPEN          | FALSE | TK_PR_ASSERT           | TK_PARENTHESIS_OPEN                    | TRUE  |
+| TK_PR_SIGNAL           | TK_PARENTHESIS_OPEN          | FALSE | TK_PR_YIELD            | TK_PARENTHESIS_OPEN                    | FALSE |
+| TK_PR_BREAKPOINT       | N/A (not in release exports) | FALSE | TK_PR_SIGNAL           | TK_PARENTHESIS_OPEN                    | FALSE |
+| TK_BRACKET_OPEN        | N/A                          | FALSE | TK_PR_BREAKPOINT       | N/A (not in release exports)           | FALSE |
+| TK_BRACKET_CLOSE       | N/A                          | FALSE | TK_BRACKET_OPEN        | N/A                                    | FALSE |
+| TK_CURLY_BRACKET_OPEN  | N/A                          | FALSE | TK_BRACKET_CLOSE       | N/A                                    | FALSE |
+| TK_CURLY_BRACKET_CLOSE | N/A                          | FALSE | TK_CURLY_BRACKET_OPEN  | N/A                                    | FALSE |
+| TK_PARENTHESIS_OPEN    | N/A                          | FALSE | TK_CURLY_BRACKET_CLOSE | N/A                                    | FALSE |
+| TK_PARENTHESIS_CLOSE   | N/A                          | FALSE | TK_PARENTHESIS_OPEN    | N/A                                    | FALSE |
+| TK_COMMA               | N/A                          | FALSE | TK_PARENTHESIS_CLOSE   | N/A                                    | FALSE |
+| TK_SEMICOLON           | N/A                          | FALSE | TK_COMMA               | N/A                                    | FALSE |
+| TK_PERIOD              | see below                    | FALSE | TK_SEMICOLON           | N/A                                    | FALSE |
+| TK_QUESTION_MARK       | no semantic meaning in 2.x   | FALSE | TK_PERIOD              | see below                              | FALSE |
+| TK_COLON               | N/A                          | FALSE | TK_QUESTION_MARK       | no semantic meaning in 2.x             | FALSE |
+| TK_NEWLINE             | N/A                          | FALSE | TK_COLON               | N/A                                    | FALSE |
+| TK_CONST_PI            | N/A                          | FALSE | TK_NEWLINE             | N/A                                    | FALSE |
+| TK_ERROR               | INVALID                      | FALSE | TK_CONST_PI            | N/A                                    | FALSE |
+| TK_EOF                 | INVALID                      | FALSE | TK_ERROR               | INVALID                                | FALSE |
+| TK_CURSOR              | INVALID                      | FALSE | TK_EOF                 | INVALID                                | FALSE |
+| TK_MAX                 | INVALID                      | FALSE | TK_CURSOR              | INVALID                                | FALSE |
+|                        |                              |       | TK_MAX                 | INVALID                                | FALSE |
+
+TODO: Have yet to add this to the version 2.1 testing
+TK_PERIOD cases (all of bytecode 10):
+
+if preceding is TK_PARENTHESIS_CLOSE, then TK_PARENTHESIS_OPEN, TK_IDENTIFIER, or TK_BUILT_IN_FUNC must follow
+if preceding is TK_BUILT_IN_TYPE, then TK_IDENTIFIER must follow
+otherwise, TK_IDENTIFIER or TK_BUILT_IN_FUNC must follow
+
+* special case for TK_PR_EXTENDS statements:
+  They made a mistake while writing the parser, and you can technically have multiple periods between identifiers if you're parsing an extends statement.
+  So we must copy the _parse_extends logic from Godot 2.x to validate those statements.
+	The TK_PR_EXTENDS parser does not allow for question marks in TK_PERIOD, so if we find a TK_PERIOD, then we know it's ed80f45.
+
+*/
+
+/***********3.1 testing********
+
+(For sanities sake, we're only going to be testing the beta and release versions of 3.1)
+
+built-in func divergence for bytecode version 13 (3.1.x only)
+
+| 1ca61a3 (3.1 beta) | args  | 1a36141 (3.1.0)   | args  | 514a3fb (3.1.1)   | args  |
+| ------------------ | ----- | ----------------- | ----- | ----------------- | ----- |
+| range_lerp         | 5     | range_lerp        | 5     | range_lerp        | 5     |
+| dectime            | 3     | dectime           | 3     | smoothstep        | 3     |
+| randomize          | 0     | randomize         | 0     | dectime           | 3     |
+| randi              | 0     | randi             | 0     | randomize         | 0     |
+| randf              | 0     | randf             | 0     | randi             | 0     |
+| rand_range         | 2     | rand_range        | 2     | randf             | 0     |
+| seed               | 1     | seed              | 1     | rand_range        | 2     |
+| rand_seed          | 1     | rand_seed         | 1     | seed              | 1     |
+| deg2rad            | 1     | deg2rad           | 1     | rand_seed         | 1     |
+| rad2deg            | 1     | rad2deg           | 1     | deg2rad           | 1     |
+| linear2db          | 1     | linear2db         | 1     | rad2deg           | 1     |
+| db2linear          | 1     | db2linear         | 1     | linear2db         | 1     |
+| polar2cartesian    | 2     | polar2cartesian   | 2     | db2linear         | 1     |
+| cartesian2polar    | 2     | cartesian2polar   | 2     | polar2cartesian   | 2     |
+| wrapi              | 3     | wrapi             | 3     | cartesian2polar   | 2     |
+| wrapf              | 3     | wrapf             | 3     | wrapi             | 3     |
+| max                | 2     | max               | 2     | wrapf             | 3     |
+| min                | 2     | min               | 2     | max               | 2     |
+| clamp              | 3     | clamp             | 3     | min               | 2     |
+| nearest_po2        | 1     | nearest_po2       | 1     | clamp             | 3     |
+| weakref            | 1     | weakref           | 1     | nearest_po2       | 1     |
+| funcref            | 2     | funcref           | 2     | weakref           | 1     |
+| convert            | 2     | convert           | 2     | funcref           | 2     |
+| typeof             | 1     | typeof            | 1     | convert           | 2     |
+| type_exists        | 1     | type_exists       | 1     | typeof            | 1     |
+| char               | 1     | char              | 1     | type_exists       | 1     |
+| str                | -1    | str               | -1    | char              | 1     |
+| print              | -1    | print             | -1    | str               | -1    |
+| printt             | -1    | printt            | -1    | print             | -1    |
+| prints             | -1    | prints            | -1    | printt            | -1    |
+| printerr           | -1    | printerr          | -1    | prints            | -1    |
+| printraw           | -1    | printraw          | -1    | printerr          | -1    |
+| print_debug        | -1    | print_debug       | -1    | printraw          | -1    |
+| push_error         | 1     | push_error        | 1     | print_debug       | -1    |
+| push_warning       | 1     | push_warning      | 1     | push_error        | 1     |
+| var2str            | 1     | var2str           | 1     | push_warning      | 1     |
+| str2var            | 1     | str2var           | 1     | var2str           | 1     |
+| var2bytes          | 1 - 2 | var2bytes         | 1 - 2 | str2var           | 1     |
+| bytes2var          | 1 - 2 | bytes2var         | 1 - 2 | var2bytes         | 1 - 2 |
+| range              | 1 - 3 | range             | 1 - 3 | bytes2var         | 1 - 2 |
+| load               | 1     | load              | 1     | range             | 1 - 3 |
+| inst2dict          | 1     | inst2dict         | 1     | load              | 1     |
+| dict2inst          | 1     | dict2inst         | 1     | inst2dict         | 1     |
+| validate_json      | 1     | validate_json     | 1     | dict2inst         | 1     |
+| parse_json         | 1     | parse_json        | 1     | validate_json     | 1     |
+| to_json            | 1     | to_json           | 1     | parse_json        | 1     |
+| hash               | 1     | hash              | 1     | to_json           | 1     |
+| Color8             | 3     | Color8            | 3     | hash              | 1     |
+| ColorN             | 1 - 2 | ColorN            | 1 - 2 | Color8            | 3     |
+| print_stack        | 0     | print_stack       | 0     | ColorN            | 1 - 2 |
+| get_stack          | 0     | get_stack         | 0     | print_stack       | 0     |
+| instance_from_id   | 1     | instance_from_id  | 1     | get_stack         | 0     |
+| len                | 1     | len               | 1     | instance_from_id  | 1     |
+| is_instance_valid  | 1     | is_instance_valid | 1     | len               | 1     |
+|                    |       |                   |       | is_instance_valid | 1     |
+
+
+	discontinuities between tokens in bytecode 13 (3.1 only) start here:
+// TODO: add this
+*/
+
 uint64_t test_files_2_1(const Vector<String> &p_paths) {
 	uint64_t rev = 0;
 	bool ed80f45_failed = false;
@@ -11,7 +152,6 @@ uint64_t test_files_2_1(const Vector<String> &p_paths) {
 	bool _85585c7_passed = false;
 	bool _7124599_failed = false;
 	bool _7124599_passed = false;
-
 	GDScriptDecomp_ed80f45 *decomp_ed80f45 = memnew(GDScriptDecomp_ed80f45);
 	GDScriptDecomp_85585c7 *decomp_85585c7 = memnew(GDScriptDecomp_85585c7);
 	GDScriptDecomp_7124599 *decomp_7124599 = memnew(GDScriptDecomp_7124599);
@@ -22,36 +162,63 @@ uint64_t test_files_2_1(const Vector<String> &p_paths) {
 		}
 		if (!ed80f45_failed && !ed80f45_passed) {
 			auto test_result = decomp_ed80f45->test_bytecode(data);
-			if (test_result == GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL) {
-				ed80f45_failed = true;
-			} else if (test_result == GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_PASS) {
-				// we don't need to test further, this revision is the highest possible for bytecode version 10
-				ed80f45_passed = true;
-				rev = 0xed80f45;
-				break;
+			switch (test_result) {
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL:
+					ed80f45_failed = true;
+					break;
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_PASS:
+					// we don't need to test further, this revision is the highest possible for bytecode version 10
+					ed80f45_passed = true;
+					rev = 0xed80f45;
+					break;
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_CORRUPT:
+					WARN_PRINT("BYTECODE_TEST_CORRUPT test result for ed80f45, script " + path);
+					ed80f45_failed = true;
+					break;
+				default:
+					break;
 			}
 		}
 		if (!_85585c7_failed && !_85585c7_passed) {
 			auto test_result = decomp_85585c7->test_bytecode(data);
-			if (test_result == GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL) {
-				_85585c7_failed = true;
-			} else if (test_result == GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_PASS) {
-				_85585c7_passed = true;
-				if (ed80f45_failed) {
-					// no need to go further
-					rev = 0x85585c7;
+			switch (test_result) {
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL:
+					_85585c7_failed = true;
 					break;
-				}
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_PASS:
+					_85585c7_passed = true;
+					if (ed80f45_failed) {
+						// no need to go further
+						rev = 0x85585c7;
+					}
+					break;
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_CORRUPT:
+					WARN_PRINT("BYTECODE_TEST_CORRUPT test result for 85585c7, script " + path);
+					_85585c7_failed = true;
+					break;
+				default:
+					break;
 			}
 		}
 		if (!_7124599_failed && !_7124599_passed) {
 			auto test_result = decomp_7124599->test_bytecode(data);
-			if (test_result == GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL) {
-				_7124599_failed = true;
-			} else if (test_result == GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_PASS) {
-				// doesn't currently have a pass condition, but we check it anyway if we come up with something later
-				_7124599_passed = true;
+			switch (test_result) {
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL:
+					_7124599_failed = true;
+					break;
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_PASS:
+					_7124599_passed = true; // doesn't currently have a pass case
+					break;
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_CORRUPT:
+					WARN_PRINT("BYTECODE_TEST_CORRUPT test result for 7124599, script " + path);
+					_7124599_failed = true;
+					break;
+				default:
+					break;
 			}
+		}
+		if (rev != 0) {
+			break;
 		}
 		if (ed80f45_failed && _85585c7_failed && _7124599_failed) {
 			// Welp
@@ -82,17 +249,18 @@ uint64_t test_files_2_1(const Vector<String> &p_paths) {
 	return rev;
 }
 
-// don't use this, just parse the binary for the version string
 uint64_t test_files_3_1(const Vector<String> &p_paths) {
-	// only need to test 514a3fb and 1a36141
 	uint64_t rev = 0;
 	bool _514a3fb_failed = false;
 	bool _1a36141_failed = false;
+	bool _1a36141_passed = false;
+	bool _1ca61a3_failed = false;
+	bool _1ca61a3_passed = false;
 
 	GDScriptDecomp_514a3fb *decomp_514a3fb = memnew(GDScriptDecomp_514a3fb);
 	GDScriptDecomp_1a36141 *decomp_1a36141 = memnew(GDScriptDecomp_1a36141);
+	GDScriptDecomp_1ca61a3 *decomp_1ca61a3 = memnew(GDScriptDecomp_1ca61a3);
 
-	// Neither of these tests have pass cases, only fail cases.
 	for (String path : p_paths) {
 		Vector<uint8_t> data = FileAccess::get_file_as_bytes(path);
 		if (data.size() == 0) {
@@ -100,17 +268,72 @@ uint64_t test_files_3_1(const Vector<String> &p_paths) {
 		}
 		if (!_514a3fb_failed) {
 			auto test_result = decomp_514a3fb->test_bytecode(data);
-			if (test_result == GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL) {
-				_514a3fb_failed = true;
+			// the same as the above, but as a switch statement like in test_files_2_1
+			switch (test_result) {
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL:
+					_514a3fb_failed = true;
+					break;
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_PASS:
+					// we don't need to test further, this revision is the highest possible for bytecode version 13 (3.1)
+					rev = 0x514a3fb;
+					break;
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_CORRUPT:
+					WARN_PRINT("BYTECODE_TEST_CORRUPT test result for 514a3fb, script " + path);
+					_514a3fb_failed = true;
+					break;
+				default:
+					break;
 			}
 		}
-		if (!_1a36141_failed) {
+		if (!_1a36141_failed && !_1a36141_passed) {
 			auto test_result = decomp_1a36141->test_bytecode(data);
-			if (test_result == GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL) {
-				_1a36141_failed = true;
+			switch (test_result) {
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL:
+					_1a36141_failed = true;
+					break;
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_PASS:
+					_1a36141_passed = true;
+					if (_514a3fb_failed) {
+						// no need to go further
+						rev = 0x1a36141;
+						break;
+					}
+					break;
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_CORRUPT:
+					WARN_PRINT("BYTECODE_TEST_CORRUPT test result for 1a36141, script " + path);
+					_1a36141_failed = true;
+					break;
+				default:
+					break;
 			}
 		}
-		if (_514a3fb_failed && _1a36141_failed) {
+		if (!_1ca61a3_failed && !_1ca61a3_passed) {
+			auto test_result = decomp_1ca61a3->test_bytecode(data);
+			switch (test_result) {
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_FAIL:
+					_1ca61a3_failed = true;
+					break;
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_PASS:
+					_1ca61a3_passed = true;
+					if (_514a3fb_failed && _1a36141_failed) {
+						// no need to go further
+						rev = 0x1ca61a3;
+						break;
+					}
+					break;
+				case GDScriptDecomp::BYTECODE_TEST_RESULT::BYTECODE_TEST_CORRUPT:
+					WARN_PRINT("BYTECODE_TEST_CORRUPT test result for 1ca61a3, script " + path);
+					_1ca61a3_failed = true;
+					break;
+				default:
+					break;
+			}
+		}
+		if (rev != 0) {
+			// we found a match, no need to keep going
+			break;
+		}
+		if (_514a3fb_failed && _1a36141_failed && _1ca61a3_failed) {
 			// Welp
 			break;
 		}
@@ -118,16 +341,19 @@ uint64_t test_files_3_1(const Vector<String> &p_paths) {
 
 	if (rev == 0) {
 		if (!_514a3fb_failed && !_1a36141_failed) {
-			// won't matter, just use highest revision
+			// won't matter, just use 3.1.1 (514a3fb), less than a month passed between 3.1.0 and 3.1.1
 			rev = 0x514a3fb;
-		}
-		if (_514a3fb_failed && !_1a36141_failed) {
+		} else if (_514a3fb_failed && !_1a36141_failed) {
 			rev = 0x1a36141;
+		} else if (_514a3fb_failed && _1a36141_failed && !_1ca61a3_failed) {
+			// unlikely to be beta, which is why we check this last
+			rev = 0x1ca61a3;
 		}
 	}
 
 	memdelete(decomp_514a3fb);
 	memdelete(decomp_1a36141);
+	memdelete(decomp_1ca61a3);
 	return rev;
 }
 

--- a/bytecode/bytecode_tester.h
+++ b/bytecode/bytecode_tester.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "bytecode/bytecode_base.h"
+#include "core/string/ustring.h"
+#include "core/templates/vector.h"
+
+class BytecodeTester {
+public:
+	// We are only using this to test 2.1.x and 3.1.x currently.
+	static uint64_t test_files(const Vector<String> &p_paths, int ver_major, int ver_minor);
+};

--- a/bytecode/bytecode_tester.h
+++ b/bytecode/bytecode_tester.h
@@ -6,6 +6,9 @@
 
 class BytecodeTester {
 public:
-	// We are only using this to test 2.1.x and 3.1.x currently.
+	// NOTE: This function is only implemented for testing 2.1 or 3.1 scripts. This returns 0 for everything else.
 	static uint64_t test_files(const Vector<String> &p_paths, int ver_major, int ver_minor);
+
+	// NOTE: This function is only implemented for testing 3.1 scripts (2.1 had no encryption scheme). This returns 0 for everything else.
+	static uint64_t test_files_encrypted(const Vector<String> &p_paths, const Vector<uint8_t> &p_key, int ver_major, int ver_minor);
 };

--- a/bytecode/bytecode_versions.cpp
+++ b/bytecode/bytecode_versions.cpp
@@ -57,6 +57,7 @@ void register_decomp_versions() {
 	ClassDB::register_class<GDScriptDecomp_a60f242>();
 	ClassDB::register_class<GDScriptDecomp_6694c11>();
 	ClassDB::register_class<GDScriptDecomp_5565f55>();
+	ClassDB::register_class<GDScriptDecomp_a7aad78>();
 }
 
 GDScriptDecomp *create_decomp_for_commit(uint64_t p_commit_hash) {
@@ -161,6 +162,8 @@ GDScriptDecomp *create_decomp_for_commit(uint64_t p_commit_hash) {
 			return memnew(GDScriptDecomp_6694c11);
 		case 0x5565f55:
 			return memnew(GDScriptDecomp_5565f55);
+		case 0xa7aad78:
+			return memnew(GDScriptDecomp_a7aad78);
 		case 0x506df14:
 			return memnew(GDScriptDecomp_506df14);
 		case 0xf3f05dc:

--- a/bytecode/bytecode_versions.h
+++ b/bytecode/bytecode_versions.h
@@ -84,7 +84,7 @@ static GDScriptDecompVersion decomp_versions[] = {
 	{ 0xc00427a, "     3.2 dev (c00427a / 2019-06-01 / Bytecode version: 13) - added `move_toward` function" },
 	{ 0x620ec47, "     3.2 dev (620ec47 / 2019-05-01 / Bytecode version: 13) - added `step_decimals` function" },
 	{ 0x7f7d97f, "     3.2 dev (7f7d97f / 2019-04-29 / Bytecode version: 13) - added `is_equal_approx` and `is_zero_approx` functions" },
-	{ 0x514a3fb, "3.1.1 release (514a3fb / 2019-03-19 / Bytecode version: 13) - added `smoothstep` function" },
+	{ 0x514a3fb, "3.1.1 release (514a3fb / 2019-03-19 / Bytecode version: 13) - added `smoothstep` function, add 2nd optional arg to `var2bytes` and `bytes2var`" },
 	{ 0x1a36141, "3.1.0 release (1a36141 / 2019-02-20 / Bytecode version: 13) - removed `DO`, `CASE`, `SWITCH` tokens" },
 	{ 0x1ca61a3, "     3.1 beta 1 - beta 5 (1ca61a3 / 2018-10-31 / Bytecode version: 13) - added `push_error`, `push_warning` function" },
 	{ 0xd6b31da, "     3.1 dev (d6b31da / 2018-09-15 / Bytecode version: 13) - added `PUPPET` token, token `SLAVESYNC` renamed to `PUPPETSYNC`" },

--- a/bytecode/bytecode_versions.h
+++ b/bytecode/bytecode_versions.h
@@ -45,6 +45,7 @@
 #include "bytecode/bytecode_a3f1ee5.h"
 #include "bytecode/bytecode_a56d6ff.h"
 #include "bytecode/bytecode_a60f242.h"
+#include "bytecode/bytecode_a7aad78.h"
 #include "bytecode/bytecode_be46be7.h"
 #include "bytecode/bytecode_c00427a.h"
 #include "bytecode/bytecode_c24c739.h"
@@ -76,6 +77,7 @@ static GDScriptDecompVersion decomp_versions[] = {
 	//  { 0x69c95f4, "     4.0 dev (69c95f4 / 2020-02-20 / Bytecode version: 13) - added Callable and Signal to Variant" },
 	{ 0xf3f05dc, "     4.0 dev (f3f05dc / 2020-02-13 / Bytecode version: 13) - removed `SYNC` and `SLAVE` tokens" },
 	{ 0x506df14, "     4.0 dev (506df14 / 2020-02-12 / Bytecode version: 13) - removed `decimals` function" },
+	{ 0xa7aad78, "3.5.0 release (a7aad78 / 2020-10-07 / Bytecode version: 13) - added `deep_equal` function (never added to 4.x)" },
 	{ 0x5565f55, "3.2.0 release (5565f55 / 2019-08-26 / Bytecode version: 13) - added `ord` function" },
 	{ 0x6694c11, "     3.2 dev (6694c11 / 2019-07-20 / Bytecode version: 13) - added `lerp_angle` function" },
 	{ 0xa60f242, "     3.2 dev (a60f242 / 2019-07-19 / Bytecode version: 13) - added `posmod` function" },

--- a/doc_classes/GDScriptDecomp_a7aad78.xml
+++ b/doc_classes/GDScriptDecomp_a7aad78.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDScriptDecomp_a7aad78" inherits="GDScriptDecomp" version="4.0">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/utility/gdre_packed_source.cpp
+++ b/utility/gdre_packed_source.cpp
@@ -214,7 +214,7 @@ bool GDREPackedSource::try_open_pack(const String &p_path, bool p_replace_files,
 	uint32_t version = f->get_32();
 	uint32_t ver_major = f->get_32();
 	uint32_t ver_minor = f->get_32();
-	uint32_t ver_rev = f->get_32(); // patch number, not used for validation.
+	uint32_t ver_rev = f->get_32(); // patch number, did not start getting set to anything other than 0 until 3.2
 
 	if (version > PACK_FORMAT_VERSION) {
 		ERR_FAIL_V_MSG(false, "Pack version unsupported: " + itos(version) + ".");

--- a/utility/gdre_packed_source.cpp
+++ b/utility/gdre_packed_source.cpp
@@ -257,13 +257,21 @@ bool GDREPackedSource::try_open_pack(const String &p_path, bool p_replace_files,
 		}
 		f = fae;
 	}
+	String ver_string;
+
+	// they only started writing the actual patch number in 3.2
+	if (ver_major < 3 || (ver_major == 3 && ver_minor < 2)) {
+		ver_string = itos(ver_major) + "." + itos(ver_minor) + ".x";
+	} else {
+		ver_string = itos(ver_major) + "." + itos(ver_minor) + "." + itos(ver_rev);
+	}
 
 	// Everything worked, now set the data
 	Ref<GDRESettings::PackInfo> pckinfo;
 	pckinfo.instantiate();
 	pckinfo->init(
 			pck_path, ver_major, ver_minor, ver_rev, version, pack_flags, file_base, file_count,
-			itos(ver_major) + "." + itos(ver_minor) + "." + itos(ver_rev), is_exe ? GDRESettings::PackInfo::EXE : GDRESettings::PackInfo::PCK);
+			ver_string, is_exe ? GDRESettings::PackInfo::EXE : GDRESettings::PackInfo::PCK);
 	GDRESettings::get_singleton()->add_pack_info(pckinfo);
 
 	for (uint32_t i = 0; i < file_count; i++) {

--- a/utility/gdre_settings.cpp
+++ b/utility/gdre_settings.cpp
@@ -439,7 +439,7 @@ Error GDRESettings::get_version_from_bin_resources() {
 	}
 	current_pack->ver_major = ver_major;
 	current_pack->ver_minor = ver_minor;
-	current_pack->version_string = itos(ver_major) + "." + itos(ver_minor) + "." + itos(0);
+	current_pack->version_string = itos(ver_major) + "." + itos(ver_minor) + ".x";
 	return OK;
 }
 

--- a/utility/import_exporter.cpp
+++ b/utility/import_exporter.cpp
@@ -817,7 +817,7 @@ String ImportExporter::_get_path(const String &output_dir, const String &p_path)
 }
 
 void ImportExporter::report_unsupported_resource(const String &type, const String &format_name, const String &import_path, bool suppress_warn, bool suppress_print) {
-	String type_format_str = type + "%" + format_name;
+	String type_format_str = type + "%" + format_name.to_lower();
 	if (unsupported_types.find(type_format_str) == -1) {
 		WARN_PRINT("Conversion for Resource of type " + type + " and format " + format_name + " not implemented");
 		unsupported_types.push_back(type_format_str);

--- a/utility/import_exporter.cpp
+++ b/utility/import_exporter.cpp
@@ -372,7 +372,7 @@ Error ImportExporter::decompile_scripts(const String &p_out_dir) {
 	}
 	// need to put the patch version in the string for 2.1.0-2.1.6 and 3.1.0-3.1.1
 	switch (revision) {
-		case 0xe82dc40:
+		case 0xed80f45:
 			patch_version = "3-6";
 			break;
 		case 0x85585c7:


### PR DESCRIPTION
Godot versions 2.1 and 3.1 broke binary script compatibility in patch releases (ugh). 
To make matters worse, they didn't start writing the patch number to the PCK until 3.2. 
EVEN WORSE, Godot didn't have a version string in the executable with the patch number until version 2.1.3; previous versions just wrote "2.x.stable.\<BUILD\>", and there were breakages between 2.1.1 and 2.1.2.

That left the following options for detecting the bytecode revision we needed to decompile these scripts:
* We could at least implement binary file parsing for 3.1.x to get the version string from the executable, but we're not always going to be guaranteed to have access to the executable (this is something I want to do eventually anyway for custom build detection, but it's going to take a while)
* We could implement dynamic detection via the `detect_bytecode_ver.gd` script, but that would only work if the game being tested is for the same platform that we're decompiling on. Additionally, there are many situations where we do not want to run the executable for security reasons (like, REing a potentially malicious game).

So, the only real option for these versions was to implement static testing of the bytecode.

This was accomplished by testing the following:

## Token changes
We can detect token shifts by checking certain tokens that would be affected by a shift caused by an added token in a subsequent revision of the byte code. We know that for at least some tokens, there are absolute requirements as to which token comes afterwards. 
This is mostly implemented in the current testing by checking if TK_PARENTHESIS_OPEN follows TK_BUILT_IN_FUNC, but we test the ENUM token for revision `0xed80f45`.

## Built-in function changes
We know the expected argument count for all revisions. While we don't have a proper token parser to do intelligent parsing of all the arguments, we can at least count the number of arguments by simply counting commas that are not within other enclosures. Bytecode revisions prior to GDScript 2.0 did not allow commas in anything other than enclosures in function arguments; this changed in GDScript 2.0 (lambdas) but that doesn't have a compiled version yet.

If we successfully test a built-in function arg count for a function after the shift occurs, and the other candidate built-in func also has different argument counts, we can say with reasonable certainty that it is the correct revision.

## Implementation:
This adds a `test_bytecode()` function to `GDScriptDecomp`, but it is only implemented for

* 0x514a3fb (13, 3.1.1)
* 0x1a36141 (13, 3.1.0)
* 0x1ca61a3 (13, 3.1 beta 1-5)
* 0xed80f45 (10, 2.1.3 - 2.1.6)
* 0x85585c7 (10, 2.1.2)
* 0x7124599 (10, 2.1.0 - 2.1.1)

It is not currently implemented on any other revision. It is unlikely that we will run into any of the `dev` bytecode revisions in the wild, and we have methods of successfully determining the major and minor version of the engine through the PCK header, the APK AndroidManifest.xml, and, as a last resort, checking the headers of all the binary resources in the project.

Because of the above, the pass cases for the implemented tests only take into account the release/beta bytecode revisions within the same major and minor versions. This means that we might have false positives if it's from a dev version.

This could be extended in the future to cover the dev versions, but I'd want to refactor the `GDScriptDecomp` classes significantly before that so that these tests can be generalized.

This also adds bytecode revision `a7aad78` to gdsdecomp for Godot 3.5; there was a hanging PR to add the built-in function `deep_equal` that was merged in very late in the development cycle. Fortunately, it was added at the END of the built-in functions, so we at least weren't mangling any scripts from 3.5 games.