### PR TITLE
Godot 2.x fixes

### DIFF
--- a/compat/image_parser_v2.cpp
+++ b/compat/image_parser_v2.cpp
@@ -193,7 +193,12 @@ Error ImageParserV2::decode_image_v2(Ref<FileAccess> f, Variant &r_v, bool conve
 		data.resize(f->get_32());
 		uint8_t *w = data.ptrw();
 		f->get_buffer(w, data.size());
-
+		// Godot 2.0 sometimes exported empty images as "IMAGE_ENCODING_LOSSY" rather than "IMAGE_ENCODING_EMPTY", so we need to check for that.
+		if (data.size() == 0) {
+			img.instantiate();
+			r_v = img;
+			return OK;
+		}
 		if (encoding == V2Image::IMAGE_ENCODING_LOSSY) {
 			img = WebPCompat::webp_unpack_v2v3(data);
 		} else if (encoding == V2Image::IMAGE_ENCODING_LOSSLESS && Image::png_unpacker) {

--- a/compat/resource_loader_compat.cpp
+++ b/compat/resource_loader_compat.cpp
@@ -952,7 +952,12 @@ Error ResourceLoaderCompat::load() {
 			rp.type = value.get_type();
 			if (rp.type == Variant::OBJECT) {
 				Object *obj = value;
-				rp.class_name = obj->get_class_name();
+				if (obj) {
+					rp.class_name = obj->get_class_name();
+				} else {
+					// We screwed up a load of an embedded object, just fail
+					ERR_FAIL_V_MSG(error, "Failed to load resource " + path + ": Object property " + name + " was null, please report this!!");
+				}
 			}
 			lrp.push_back(rp);
 			// If not a fake_load, set the properties of the instanced resource

--- a/compat/texture_loader_compat.cpp
+++ b/compat/texture_loader_compat.cpp
@@ -842,7 +842,11 @@ Ref<Image> TextureLoaderCompat::load_image_from_tex(const String p_path, Error *
 	if (*r_err == ERR_UNAVAILABLE) {
 		return Ref<Image>();
 	}
-	ERR_FAIL_COND_V_MSG(image.is_null() || image->is_empty(), Ref<Image>(), "Failed to load image from " + p_path);
+
+	ERR_FAIL_COND_V_MSG(err || image.is_null(), Ref<Image>(), "Failed to load image from " + p_path);
+	if (image->is_empty()) {
+		WARN_PRINT("Image data is empty: " + p_path);
+	}
 	return image;
 }
 

--- a/utility/import_exporter.cpp
+++ b/utility/import_exporter.cpp
@@ -119,7 +119,7 @@ Error ImportExporter::_export_imports(const String &p_out_dir, const Vector<Stri
 			}
 			should_rewrite_metadata = true;
 		}
-		String src_ext = iinfo->get_source_file().get_extension();
+		String src_ext = iinfo->get_source_file().get_extension().to_lower();
 		// ***** Export resource *****
 		if (opt_export_textures && importer == "texture") {
 			// Right now we only convert 2d image textures
@@ -164,6 +164,13 @@ Error ImportExporter::_export_imports(const String &p_out_dir, const Vector<Stri
 				//|| (opt_bin2text && iinfo->get_source_file().get_extension() == "tres" && iinfo->get_source_file().get_extension() == "res") ||
 				// (opt_bin2text && iinfo->get_importer() == "scene" && iinfo->get_source_file().get_extension() == "tscn")
 		) {
+			// We don't currently support converting old 2.x xml resources
+			if (src_ext == "xml") {
+				WARN_PRINT_ONCE("Conversion of Godot 2.x xml resource files currently unimplemented");
+				report_unsupported_resource(type, src_ext, path);
+				not_converted.push_back(iinfo);
+				continue;
+			}
 			err = convert_res_bin_2_txt(output_dir, iinfo->get_path(), iinfo->get_export_dest());
 			// v2-v3 export left the autoconverted resource in the main path, remove it
 			if (get_ver_major() <= 3 && !err) {
@@ -401,7 +408,7 @@ Error ImportExporter::decompile_scripts(const String &p_out_dir) {
 		Ref<DirAccess> da = DirAccess::open(p_out_dir);
 		print_verbose("decompiling " + f);
 		bool encrypted = false;
-		if (f.get_extension() == "gde") {
+		if (f.get_extension().to_lower() == "gde") {
 			encrypted = true;
 			err = decomp->decompile_byte_code_encrypted(f, get_settings()->get_encryption_key());
 		} else {

--- a/utility/import_exporter.cpp
+++ b/utility/import_exporter.cpp
@@ -820,7 +820,8 @@ Error ImportExporter::_convert_tex(const String &output_dir, const String &p_pat
 		print_line("Did not convert deprecated Texture resource " + p_path);
 		return err;
 	}
-	ERR_FAIL_COND_V_MSG(err != OK, err, "Failed to load texture " + p_path);
+	ERR_FAIL_COND_V_MSG(err != OK || img.is_null(), err, "Failed to load texture " + p_path);
+	ERR_FAIL_COND_V_MSG(img->is_empty(), ERR_FILE_EOF, "Image data is empty for texture " + p_path + ", not saving");
 	err = ensure_dir(dst_dir);
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Failed to create dirs for " + dest_path);
 	if (img->is_compressed()) {


### PR DESCRIPTION
Fixes #126

- Fix v2 import metadata loading
- Fix handling of empty images during texture export
- Do not attempt to convert 2.x XML resources