### PR TITLE
GDC compilation

### DIFF
--- a/editor/gdre_editor.cpp
+++ b/editor/gdre_editor.cpp
@@ -21,8 +21,10 @@
 #include "utility/pck_dumper.h"
 
 #include "modules/gdscript/gdscript.h"
+#include "gdscript_tokenizer_old.h"
 #include "modules/gdscript/gdscript_utility_functions.h"
 
+#include "core/io/file_access.h"
 #include "core/io/file_access_encrypted.h"
 #include "core/io/resource_format_binary.h"
 #include "modules/svg/image_loader_svg.h"
@@ -361,8 +363,7 @@ void GodotREEditor::init_gui(Control *p_control, HBoxContainer *p_menu, bool p_l
 		menu_button->set_icon(icons["REScript"]);
 		menu_popup = menu_button->get_popup();
 		menu_popup->add_icon_item(icons["REScript"], RTR("Decompile .GDC/.GDE script files..."), MENU_DECOMP_GDS);
-		menu_popup->add_icon_item(icons["REScript"], RTR("Compile .GD script files..."), MENU_COMP_GDS);
-		menu_popup->set_item_disabled(menu_popup->get_item_index(MENU_COMP_GDS), true); //TEMP RE-ENABLE WHEN IMPLEMENTED
+		menu_popup->add_icon_item(icons["REScript"], RTR("Compile .GD script files..."), MENU_COMP_GDS); //NOTE: Temp re-enable when implemented
 		menu_button->set_anchor(Side::SIDE_TOP, 0);
 		menu_popup->connect("id_pressed", callable_mp(this, &GodotREEditor::menu_option_pressed));
 		p_menu->add_child(menu_button);
@@ -668,9 +669,8 @@ void GodotREEditor::_compile_files() {
 }
 
 void GodotREEditor::_compile_process() {
-	/*
 	Vector<String> files = script_dialog_c->get_file_list();
-	Vector<uint8_t> key = key_dialog->get_key(); = script_dialog_c->get_key();
+	Vector<uint8_t> key = key_dialog->get_key(); // = script_dialog_c->get_key();
 	String dir = script_dialog_c->get_target_dir();
 	String ext = (key.size() == 32) ? ".gde" : ".gdc";
 
@@ -679,7 +679,6 @@ void GodotREEditor::_compile_process() {
 	EditorProgressGDDC *pr = memnew(EditorProgressGDDC(ne_parent, "re_compile", RTR("Compiling files..."), files.size(), true));
 
 	for (int i = 0; i < files.size(); i++) {
-
 		print_warning(RTR("compiling") + " " + files[i].get_file(), RTR("Compile"));
 		String target_name = dir.path_join(files[i].get_file().get_basename() + ext);
 
@@ -695,7 +694,7 @@ void GodotREEditor::_compile_process() {
 			file = GDScriptTokenizerBuffer::parse_code_string(txt);
 
 			Ref<FileAccess> fa = FileAccess::open(target_name, FileAccess::WRITE);
-			if (fa) {
+			if (fa.is_valid()) {
 				if (key.size() == 32) {
 					Ref<FileAccessEncrypted> fae;
 					fae.instantiate();
@@ -706,11 +705,13 @@ void GodotREEditor::_compile_process() {
 					} else {
 						failed_files += files[i] + " (FileAccessEncrypted error)\n";
 					}
-					memdelete(fae);
+					//memdelete(fae);
+					fae.unref();
 				} else {
 					fa->store_buffer(file.ptr(), file.size());
 					fa->close();
-					memdelete(fa);
+					//memdelete(fa);
+					fa.unref();
 				}
 			} else {
 				failed_files += files[i] + " (FileAccess error)\n";
@@ -727,7 +728,7 @@ void GodotREEditor::_compile_process() {
 	} else {
 		show_warning(RTR("No errors detected."), RTR("Compile"), RTR("The operation completed successfully!"));
 	}
-*/
+	/**/
 }
 
 /*************************************************************************/

--- a/editor/gdscript_tokenizer_old.cpp
+++ b/editor/gdscript_tokenizer_old.cpp
@@ -1,0 +1,1897 @@
+/**************************************************************************/
+/*  gdscript_tokenizer.cpp                                                */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/**************************************************************************/
+
+#include "gdscript_tokenizer_old.h"
+#include "map.h"
+#include "core/io/marshalls.h"
+
+#define FALLTHROUGH [[fallthrough]]
+#define UPPERCASE(m_c) (((m_c) >= 'a' && (m_c) <= 'z') ? ((m_c) - ('a' - 'A')) : (m_c))
+#define LOWERCASE(m_c) (((m_c) >= 'A' && (m_c) <= 'Z') ? ((m_c) + ('a' - 'A')) : (m_c))
+#define IS_DIGIT(m_d) ((m_d) >= '0' && (m_d) <= '9')
+#define IS_HEX_DIGIT(m_d) (((m_d) >= '0' && (m_d) <= '9') || ((m_d) >= 'a' && (m_d) <= 'f') || ((m_d) >= 'A' && (m_d) <= 'F'))
+
+const char *GDScriptTokenizerOld::get_func_name(Function p_func) const {
+	ERR_FAIL_INDEX_V(p_func, FUNC_MAX, "");
+
+	static const char *_names[FUNC_MAX] = {
+		"sin",
+		"cos",
+		"tan",
+		"sinh",
+		"cosh",
+		"tanh",
+		"asin",
+		"acos",
+		"atan",
+		"atan2",
+		"sqrt",
+		"fmod",
+		"fposmod",
+		"posmod",
+		"floor",
+		"ceil",
+		"round",
+		"abs",
+		"sign",
+		"pow",
+		"log",
+		"exp",
+		"is_nan",
+		"is_inf",
+		"is_equal_approx",
+		"is_zero_approx",
+		"ease",
+		"decimals",
+		"step_decimals",
+		"stepify",
+		"lerp",
+		"lerp_angle",
+		"inverse_lerp",
+		"range_lerp",
+		"smoothstep",
+		"move_toward",
+		"dectime",
+		"randomize",
+		"randi",
+		"randf",
+		"rand_range",
+		"seed",
+		"rand_seed",
+		"deg2rad",
+		"rad2deg",
+		"linear2db",
+		"db2linear",
+		"polar2cartesian",
+		"cartesian2polar",
+		"wrapi",
+		"wrapf",
+		"max",
+		"min",
+		"clamp",
+		"nearest_po2",
+		"weakref",
+		"funcref",
+		"convert",
+		"typeof",
+		"type_exists",
+		"char",
+		"ord",
+		"str",
+		"print",
+		"printt",
+		"prints",
+		"printerr",
+		"printraw",
+		"print_debug",
+		"push_error",
+		"push_warning",
+		"var2str",
+		"str2var",
+		"var2bytes",
+		"bytes2var",
+		"range",
+		"load",
+		"inst2dict",
+		"dict2inst",
+		"validate_json",
+		"parse_json",
+		"to_json",
+		"hash",
+		"Color8",
+		"ColorN",
+		"print_stack",
+		"get_stack",
+		"instance_from_id",
+		"len",
+		"is_instance_valid",
+		"deep_equal",
+	};
+
+	return _names[p_func];
+}
+
+const char *GDScriptTokenizerOld::token_names[TK_MAX] = {
+	"Empty",
+	"Identifier",
+	"Constant",
+	"Self",
+	"Built-In Type",
+	"Built-In Func",
+	"In",
+	"'=='",
+	"'!='",
+	"'<'",
+	"'<='",
+	"'>'",
+	"'>='",
+	"'and'",
+	"'or'",
+	"'not'",
+	"'+'",
+	"'-'",
+	"'*'",
+	"'/'",
+	"'%'",
+	"'<<'",
+	"'>>'",
+	"'='",
+	"'+='",
+	"'-='",
+	"'*='",
+	"'/='",
+	"'%='",
+	"'<<='",
+	"'>>='",
+	"'&='",
+	"'|='",
+	"'^='",
+	"'&'",
+	"'|'",
+	"'^'",
+	"'~'",
+	//"Plus Plus",
+	//"Minus Minus",
+	"if",
+	"elif",
+	"else",
+	"for",
+	"while",
+	"break",
+	"continue",
+	"pass",
+	"return",
+	"match",
+	"func",
+	"class",
+	"class_name",
+	"extends",
+	"is",
+	"onready",
+	"tool",
+	"static",
+	"export",
+	"setget",
+	"const",
+	"var",
+	"as",
+	"void",
+	"enum",
+	"preload",
+	"assert",
+	"yield",
+	"signal",
+	"breakpoint",
+	"rpc",
+	"sync",
+	"master",
+	"puppet",
+	"slave",
+	"remotesync",
+	"mastersync",
+	"puppetsync",
+	"'['",
+	"']'",
+	"'{'",
+	"'}'",
+	"'('",
+	"')'",
+	"','",
+	"';'",
+	"'.'",
+	"'?'",
+	"':'",
+	"'$'",
+	"'->'",
+	"'\\n'",
+	"PI",
+	"TAU",
+	"_",
+	"INF",
+	"NAN",
+	"Error",
+	"EOF",
+	"Cursor"
+};
+
+struct _bit {
+	Variant::Type type;
+	const char *text;
+};
+//built in types
+
+static const _bit _type_list[] = {
+	//types
+	{ Variant::BOOL, "bool" },
+	{ Variant::INT, "int" },
+	{ Variant::FLOAT, "float" },
+	{ Variant::STRING, "String" },
+	{ Variant::VECTOR2, "Vector2" },
+	{ Variant::RECT2, "Rect2" },
+	{ Variant::TRANSFORM2D, "Transform2D" },
+	{ Variant::VECTOR3, "Vector3" },
+	{ Variant::AABB, "AABB" },
+	{ Variant::PLANE, "Plane" },
+	{ Variant::QUATERNION, "Quat" },
+	{ Variant::BASIS, "Basis" },
+	{ Variant::TRANSFORM3D, "Transform" },
+	{ Variant::COLOR, "Color" },
+	{ Variant::RID, "RID" },
+	{ Variant::OBJECT, "Object" },
+	{ Variant::NODE_PATH, "NodePath" },
+	{ Variant::DICTIONARY, "Dictionary" },
+	{ Variant::ARRAY, "Array" },
+	{ Variant::PACKED_BYTE_ARRAY, "PoolByteArray" },
+	{ Variant::PACKED_INT64_ARRAY, "PoolIntArray" },
+	{ Variant::PACKED_FLOAT64_ARRAY, "PoolRealArray" },
+	{ Variant::PACKED_STRING_ARRAY, "PoolStringArray" },
+	{ Variant::PACKED_VECTOR2_ARRAY, "PoolVector2Array" },
+	{ Variant::PACKED_VECTOR3_ARRAY, "PoolVector3Array" },
+	{ Variant::PACKED_COLOR_ARRAY, "PoolColorArray" },
+	{ Variant::VARIANT_MAX, nullptr },
+};
+
+struct _kws {
+	GDScriptTokenizerOld::Token token;
+	const char *text;
+};
+
+static const _kws _keyword_list[] = {
+	//ops
+	{ GDScriptTokenizerOld::TK_OP_IN, "in" },
+	{ GDScriptTokenizerOld::TK_OP_NOT, "not" },
+	{ GDScriptTokenizerOld::TK_OP_OR, "or" },
+	{ GDScriptTokenizerOld::TK_OP_AND, "and" },
+	//func
+	{ GDScriptTokenizerOld::TK_PR_FUNCTION, "func" },
+	{ GDScriptTokenizerOld::TK_PR_CLASS, "class" },
+	{ GDScriptTokenizerOld::TK_PR_CLASS_NAME, "class_name" },
+	{ GDScriptTokenizerOld::TK_PR_EXTENDS, "extends" },
+	{ GDScriptTokenizerOld::TK_PR_IS, "is" },
+	{ GDScriptTokenizerOld::TK_PR_ONREADY, "onready" },
+	{ GDScriptTokenizerOld::TK_PR_TOOL, "tool" },
+	{ GDScriptTokenizerOld::TK_PR_STATIC, "static" },
+	{ GDScriptTokenizerOld::TK_PR_EXPORT, "export" },
+	{ GDScriptTokenizerOld::TK_PR_SETGET, "setget" },
+	{ GDScriptTokenizerOld::TK_PR_VAR, "var" },
+	{ GDScriptTokenizerOld::TK_PR_AS, "as" },
+	{ GDScriptTokenizerOld::TK_PR_VOID, "void" },
+	{ GDScriptTokenizerOld::TK_PR_PRELOAD, "preload" },
+	{ GDScriptTokenizerOld::TK_PR_ASSERT, "assert" },
+	{ GDScriptTokenizerOld::TK_PR_YIELD, "yield" },
+	{ GDScriptTokenizerOld::TK_PR_SIGNAL, "signal" },
+	{ GDScriptTokenizerOld::TK_PR_BREAKPOINT, "breakpoint" },
+	{ GDScriptTokenizerOld::TK_PR_REMOTE, "remote" },
+	{ GDScriptTokenizerOld::TK_PR_MASTER, "master" },
+	{ GDScriptTokenizerOld::TK_PR_SLAVE, "slave" },
+	{ GDScriptTokenizerOld::TK_PR_PUPPET, "puppet" },
+	{ GDScriptTokenizerOld::TK_PR_SYNC, "sync" },
+	{ GDScriptTokenizerOld::TK_PR_REMOTESYNC, "remotesync" },
+	{ GDScriptTokenizerOld::TK_PR_MASTERSYNC, "mastersync" },
+	{ GDScriptTokenizerOld::TK_PR_PUPPETSYNC, "puppetsync" },
+	{ GDScriptTokenizerOld::TK_PR_CONST, "const" },
+	{ GDScriptTokenizerOld::TK_PR_ENUM, "enum" },
+	//controlflow
+	{ GDScriptTokenizerOld::TK_CF_IF, "if" },
+	{ GDScriptTokenizerOld::TK_CF_ELIF, "elif" },
+	{ GDScriptTokenizerOld::TK_CF_ELSE, "else" },
+	{ GDScriptTokenizerOld::TK_CF_FOR, "for" },
+	{ GDScriptTokenizerOld::TK_CF_WHILE, "while" },
+	{ GDScriptTokenizerOld::TK_CF_BREAK, "break" },
+	{ GDScriptTokenizerOld::TK_CF_CONTINUE, "continue" },
+	{ GDScriptTokenizerOld::TK_CF_RETURN, "return" },
+	{ GDScriptTokenizerOld::TK_CF_MATCH, "match" },
+	{ GDScriptTokenizerOld::TK_CF_PASS, "pass" },
+	{ GDScriptTokenizerOld::TK_SELF, "self" },
+	{ GDScriptTokenizerOld::TK_CONST_PI, "PI" },
+	{ GDScriptTokenizerOld::TK_CONST_TAU, "TAU" },
+	{ GDScriptTokenizerOld::TK_WILDCARD, "_" },
+	{ GDScriptTokenizerOld::TK_CONST_INF, "INF" },
+	{ GDScriptTokenizerOld::TK_CONST_NAN, "NAN" },
+	{ GDScriptTokenizerOld::TK_ERROR, nullptr }
+};
+
+const char *GDScriptTokenizerOld::get_token_name(Token p_token) {
+	ERR_FAIL_INDEX_V(p_token, TK_MAX, "<error>");
+	return token_names[p_token];
+}
+
+bool GDScriptTokenizerOld::is_token_literal(int p_offset, bool variable_safe) const {
+	switch (get_token(p_offset)) {
+		// Can always be literal:
+		case TK_IDENTIFIER:
+
+		case TK_PR_ONREADY:
+		case TK_PR_TOOL:
+		case TK_PR_STATIC:
+		case TK_PR_EXPORT:
+		case TK_PR_SETGET:
+		case TK_PR_SIGNAL:
+		case TK_PR_REMOTE:
+		case TK_PR_MASTER:
+		case TK_PR_PUPPET:
+		case TK_PR_SYNC:
+		case TK_PR_REMOTESYNC:
+		case TK_PR_MASTERSYNC:
+		case TK_PR_PUPPETSYNC:
+			return true;
+
+		// Literal for non-variables only:
+		case TK_BUILT_IN_TYPE:
+		case TK_BUILT_IN_FUNC:
+
+		case TK_OP_IN:
+			//case TK_OP_NOT:
+			//case TK_OP_OR:
+			//case TK_OP_AND:
+
+		case TK_PR_CLASS:
+		case TK_PR_CONST:
+		case TK_PR_ENUM:
+		case TK_PR_PRELOAD:
+		case TK_PR_FUNCTION:
+		case TK_PR_EXTENDS:
+		case TK_PR_ASSERT:
+		case TK_PR_YIELD:
+		case TK_PR_VAR:
+
+		case TK_CF_IF:
+		case TK_CF_ELIF:
+		case TK_CF_ELSE:
+		case TK_CF_FOR:
+		case TK_CF_WHILE:
+		case TK_CF_BREAK:
+		case TK_CF_CONTINUE:
+		case TK_CF_RETURN:
+		case TK_CF_MATCH:
+		case TK_CF_PASS:
+		case TK_SELF:
+		case TK_CONST_PI:
+		case TK_CONST_TAU:
+		case TK_WILDCARD:
+		case TK_CONST_INF:
+		case TK_CONST_NAN:
+		case TK_ERROR:
+			return !variable_safe;
+
+		case TK_CONSTANT: {
+			switch (get_token_constant(p_offset).get_type()) {
+				case Variant::NIL:
+				case Variant::BOOL:
+					return true;
+				default:
+					return false;
+			}
+		}
+		default:
+			return false;
+	}
+}
+
+StringName GDScriptTokenizerOld::get_token_literal(int p_offset) const {
+	Token token = get_token(p_offset);
+	switch (token) {
+		case TK_IDENTIFIER:
+			return get_token_identifier(p_offset);
+		case TK_BUILT_IN_TYPE: {
+			Variant::Type type = get_token_type(p_offset);
+			int idx = 0;
+
+			while (_type_list[idx].text) {
+				if (type == _type_list[idx].type) {
+					return _type_list[idx].text;
+				}
+				idx++;
+			}
+		} break; // Shouldn't get here, stuff happens
+		case TK_BUILT_IN_FUNC:
+			return get_func_name(get_token_built_in_func(p_offset));
+		case TK_CONSTANT: {
+			const Variant value = get_token_constant(p_offset);
+
+			switch (value.get_type()) {
+				case Variant::NIL:
+					return "null";
+				case Variant::BOOL:
+					return value ? "true" : "false";
+				default: {
+				}
+			}
+		}
+		case TK_OP_AND:
+		case TK_OP_OR:
+			break; // Don't get into default, since they can be non-literal
+		default: {
+			int idx = 0;
+
+			while (_keyword_list[idx].text) {
+				if (token == _keyword_list[idx].token) {
+					return _keyword_list[idx].text;
+				}
+				idx++;
+			}
+		}
+	}
+	ERR_FAIL_V_MSG("", "Failed to get token literal.");
+}
+
+static bool _is_text_char(CharType c) {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_';
+}
+
+static bool _is_number(CharType c) {
+	return (c >= '0' && c <= '9');
+}
+
+static bool _is_hex(CharType c) {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
+static bool _is_bin(CharType c) {
+	return (c == '0' || c == '1');
+}
+
+void GDScriptTokenizerText::_make_token(Token p_type) {
+	TokenData &tk = tk_rb[tk_rb_pos];
+
+	tk.type = p_type;
+	tk.line = line;
+	tk.col = column;
+
+	tk_rb_pos = (tk_rb_pos + 1) % RB_SIZE;
+}
+void GDScriptTokenizerText::_make_identifier(const StringName &p_identifier) {
+	TokenData &tk = tk_rb[tk_rb_pos];
+
+	tk.type = TK_IDENTIFIER;
+	tk.identifier = p_identifier;
+	tk.line = line;
+	tk.col = column;
+
+	tk_rb_pos = (tk_rb_pos + 1) % RB_SIZE;
+}
+
+void GDScriptTokenizerText::_make_built_in_func(Function p_func) {
+	TokenData &tk = tk_rb[tk_rb_pos];
+
+	tk.type = TK_BUILT_IN_FUNC;
+	tk.func = p_func;
+	tk.line = line;
+	tk.col = column;
+
+	tk_rb_pos = (tk_rb_pos + 1) % RB_SIZE;
+}
+void GDScriptTokenizerText::_make_constant(const Variant &p_constant) {
+	TokenData &tk = tk_rb[tk_rb_pos];
+
+	tk.type = TK_CONSTANT;
+	tk.constant = p_constant;
+	tk.line = line;
+	tk.col = column;
+
+	tk_rb_pos = (tk_rb_pos + 1) % RB_SIZE;
+}
+
+void GDScriptTokenizerText::_make_type(const Variant::Type &p_type) {
+	TokenData &tk = tk_rb[tk_rb_pos];
+
+	tk.type = TK_BUILT_IN_TYPE;
+	tk.vtype = p_type;
+	tk.line = line;
+	tk.col = column;
+
+	tk_rb_pos = (tk_rb_pos + 1) % RB_SIZE;
+}
+
+int64_t hex_to_int64(String str, bool p_with_prefix = true) {
+	int len = str.length();
+	//ERR_FAIL_COND_V_MSG(p_with_prefix ? len < 3 : len == 0, 0, String("Invalid hexadecimal notation length in string ") + (p_with_prefix ? "with" : "without") + " prefix \"" + *this + "\".");
+
+	const char32_t *s = str.ptr();
+
+	int64_t sign = s[0] == '-' ? -1 : 1;
+
+	if (sign < 0) {
+		s++;
+	}
+
+	if (p_with_prefix) {
+		//ERR_FAIL_COND_V_MSG(s[0] != '0' || LOWERCASE(s[1]) != 'x', 0, "Invalid hexadecimal notation prefix in string \"" + *this + "\".");
+		s += 2;
+	}
+
+	int64_t hex = 0;
+
+	while (*s) {
+		CharType c = LOWERCASE(*s);
+		int64_t n;
+		if (c >= '0' && c <= '9') {
+			n = c - '0';
+		} else if (c >= 'a' && c <= 'f') {
+			n = (c - 'a') + 10;
+		} else {
+			//ERR_FAIL_V_MSG(0, "Invalid hexadecimal notation character \"" + chr(*s) + "\" in string \"" + *this + "\".");
+		}
+		bool overflow = ((hex > INT64_MAX / 16) && (sign == 1 || (sign == -1 && hex != (INT64_MAX >> 4) + 1))) || (sign == -1 && hex == (INT64_MAX >> 4) + 1 && c > '0');
+		//ERR_FAIL_COND_V_MSG(overflow, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + *this + " as a 64-bit signed integer, since the value is " + (sign == 1 ? "too large." : "too small."));
+		hex *= 16;
+		hex += n;
+		s++;
+	}
+
+	return hex * sign;
+}
+
+int64_t bin_to_int64(String str, bool p_with_prefix = true) {
+	int len = str.length();
+	//ERR_FAIL_COND_V_MSG(p_with_prefix ? len < 3 : len == 0, 0, String("Invalid binary notation length in string ") + (p_with_prefix ? "with" : "without") + " prefix \"" + *this + "\".");
+
+	const char32_t *s = str.ptr();
+
+	int64_t sign = s[0] == '-' ? -1 : 1;
+
+	if (sign < 0) {
+		s++;
+	}
+
+	if (p_with_prefix) {
+		//ERR_FAIL_COND_V_MSG(s[0] != '0' || LOWERCASE(s[1]) != 'b', 0, "Invalid binary notation prefix in string \"" + *this + "\".");
+		s += 2;
+	}
+
+	int64_t binary = 0;
+
+	while (*s) {
+		CharType c = LOWERCASE(*s);
+		int64_t n;
+		if (c == '0' || c == '1') {
+			n = c - '0';
+		} else {
+			//ERR_FAIL_V_MSG(0, "Invalid binary notation character \"" + chr(*s) + "\" in string \"" + *this + "\".");
+		}
+		// Check for overflow/underflow, with special case to ensure INT64_MIN does not result in error
+		bool overflow = ((binary > INT64_MAX / 2) && (sign == 1 || (sign == -1 && binary != (INT64_MAX >> 1) + 1))) || (sign == -1 && binary == (INT64_MAX >> 1) + 1 && c > '0');
+		//ERR_FAIL_COND_V_MSG(overflow, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + *this + " as a 64-bit signed integer, since the value is " + (sign == 1 ? "too large." : "too small."));
+		binary *= 2;
+		binary += n;
+		s++;
+	}
+
+	return binary * sign;
+}
+
+int64_t to_int64(String str) {
+	if (str.length() == 0) {
+		return 0;
+	}
+
+	int to = (str.find(".") >= 0) ? str.find(".") : str.length();
+
+	int64_t integer = 0;
+	int64_t sign = 1;
+
+	for (int i = 0; i < to; i++) {
+		char32_t c = str[i];
+		if (c >= '0' && c <= '9') {
+			bool overflow = (integer > INT64_MAX / 10) || (integer == INT64_MAX / 10 && ((sign == 1 && c > '7') || (sign == -1 && c > '8')));
+			//ERR_FAIL_COND_V_MSG(overflow, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + *this + " as a 64-bit signed integer, since the value is " + (sign == 1 ? "too large." : "too small."));
+			integer *= 10;
+			integer += c - '0';
+
+		} else if (integer == 0 && c == '-') {
+			sign = -sign;
+		}
+	}
+
+	return integer * sign;
+}
+
+template <class C>
+static double built_in_strtod(
+		/* A decimal ASCII floating-point number,
+		 * optionally preceded by white space. Must
+		 * have form "-I.FE-X", where I is the integer
+		 * part of the mantissa, F is the fractional
+		 * part of the mantissa, and X is the
+		 * exponent. Either of the signs may be "+",
+		 * "-", or omitted. Either I or F may be
+		 * omitted, or both. The decimal point isn't
+		 * necessary unless F is present. The "E" may
+		 * actually be an "e". E and X may both be
+		 * omitted (but not just one). */
+		const C *string,
+		/* If non-nullptr, store terminating Cacter's
+		 * address here. */
+		C **endPtr = nullptr) {
+	/* Largest possible base 10 exponent. Any
+	 * exponent larger than this will already
+	 * produce underflow or overflow, so there's
+	 * no need to worry about additional digits. */
+	static const int maxExponent = 511;
+	/* Table giving binary powers of 10. Entry
+	 * is 10^2^i. Used to convert decimal
+	 * exponents into floating-point numbers. */
+	static const double powersOf10[] = {
+		10.,
+		100.,
+		1.0e4,
+		1.0e8,
+		1.0e16,
+		1.0e32,
+		1.0e64,
+		1.0e128,
+		1.0e256
+	};
+
+	bool sign, expSign = false;
+	double fraction, dblExp;
+	const double *d;
+	const C *p;
+	int c;
+	/* Exponent read from "EX" field. */
+	int exp = 0;
+	/* Exponent that derives from the fractional
+	 * part. Under normal circumstances, it is
+	 * the negative of the number of digits in F.
+	 * However, if I is very long, the last digits
+	 * of I get dropped (otherwise a long I with a
+	 * large negative exponent could cause an
+	 * unnecessary overflow on I alone). In this
+	 * case, fracExp is incremented one for each
+	 * dropped digit. */
+	int fracExp = 0;
+	/* Number of digits in mantissa. */
+	int mantSize;
+	/* Number of mantissa digits BEFORE decimal point. */
+	int decPt;
+	/* Temporarily holds location of exponent in string. */
+	const C *pExp;
+
+	/*
+	 * Strip off leading blanks and check for a sign.
+	 */
+
+	p = string;
+	while (*p == ' ' || *p == '\t' || *p == '\n') {
+		p += 1;
+	}
+	if (*p == '-') {
+		sign = true;
+		p += 1;
+	} else {
+		if (*p == '+') {
+			p += 1;
+		}
+		sign = false;
+	}
+
+	/*
+	 * Count the number of digits in the mantissa (including the decimal
+	 * point), and also locate the decimal point.
+	 */
+
+	decPt = -1;
+	for (mantSize = 0;; mantSize += 1) {
+		c = *p;
+		if (!IS_DIGIT(c)) {
+			if ((c != '.') || (decPt >= 0)) {
+				break;
+			}
+			decPt = mantSize;
+		}
+		p += 1;
+	}
+
+	/*
+	 * Now suck up the digits in the mantissa. Use two integers to collect 9
+	 * digits each (this is faster than using floating-point). If the mantissa
+	 * has more than 18 digits, ignore the extras, since they can't affect the
+	 * value anyway.
+	 */
+
+	pExp = p;
+	p -= mantSize;
+	if (decPt < 0) {
+		decPt = mantSize;
+	} else {
+		mantSize -= 1; /* One of the digits was the point. */
+	}
+	if (mantSize > 18) {
+		fracExp = decPt - 18;
+		mantSize = 18;
+	} else {
+		fracExp = decPt - mantSize;
+	}
+	if (mantSize == 0) {
+		fraction = 0.0;
+		p = string;
+		goto done;
+	} else {
+		int frac1, frac2;
+
+		frac1 = 0;
+		for (; mantSize > 9; mantSize -= 1) {
+			c = *p;
+			p += 1;
+			if (c == '.') {
+				c = *p;
+				p += 1;
+			}
+			frac1 = 10 * frac1 + (c - '0');
+		}
+		frac2 = 0;
+		for (; mantSize > 0; mantSize -= 1) {
+			c = *p;
+			p += 1;
+			if (c == '.') {
+				c = *p;
+				p += 1;
+			}
+			frac2 = 10 * frac2 + (c - '0');
+		}
+		fraction = (1.0e9 * frac1) + frac2;
+	}
+
+	/*
+	 * Skim off the exponent.
+	 */
+
+	p = pExp;
+	if ((*p == 'E') || (*p == 'e')) {
+		p += 1;
+		if (*p == '-') {
+			expSign = true;
+			p += 1;
+		} else {
+			if (*p == '+') {
+				p += 1;
+			}
+			expSign = false;
+		}
+		if (!IS_DIGIT(CharType(*p))) {
+			p = pExp;
+			goto done;
+		}
+		while (IS_DIGIT(CharType(*p))) {
+			exp = exp * 10 + (*p - '0');
+			p += 1;
+		}
+	}
+	if (expSign) {
+		exp = fracExp - exp;
+	} else {
+		exp = fracExp + exp;
+	}
+
+	/*
+	 * Generate a floating-point number that represents the exponent. Do this
+	 * by processing the exponent one bit at a time to combine many powers of
+	 * 2 of 10. Then combine the exponent with the fraction.
+	 */
+
+	if (exp < 0) {
+		expSign = true;
+		exp = -exp;
+	} else {
+		expSign = false;
+	}
+
+	if (exp > maxExponent) {
+		exp = maxExponent;
+		WARN_PRINT("Exponent too high");
+	}
+	dblExp = 1.0;
+	for (d = powersOf10; exp != 0; exp >>= 1, ++d) {
+		if (exp & 01) {
+			dblExp *= *d;
+		}
+	}
+	if (expSign) {
+		fraction /= dblExp;
+	} else {
+		fraction *= dblExp;
+	}
+
+done:
+	if (endPtr != nullptr) {
+		*endPtr = (C *)p;
+	}
+
+	if (sign) {
+		return -fraction;
+	}
+	return fraction;
+}
+
+double to_double(const String str) {
+	return built_in_strtod<char32_t>(str.ptr());
+}
+
+void GDScriptTokenizerText::_make_error(const String &p_error) {
+	error_flag = true;
+	last_error = p_error;
+
+	TokenData &tk = tk_rb[tk_rb_pos];
+	tk.type = TK_ERROR;
+	tk.constant = p_error;
+	tk.line = line;
+	tk.col = column;
+	tk_rb_pos = (tk_rb_pos + 1) % RB_SIZE;
+}
+
+void GDScriptTokenizerText::_make_newline(int p_indentation, int p_tabs) {
+	TokenData &tk = tk_rb[tk_rb_pos];
+	tk.type = TK_NEWLINE;
+	tk.constant = Vector2(p_indentation, p_tabs);
+	tk.line = line;
+	tk.col = column;
+	tk_rb_pos = (tk_rb_pos + 1) % RB_SIZE;
+}
+
+void GDScriptTokenizerText::_advance() {
+	if (error_flag) {
+		//parser broke
+		_make_error(last_error);
+		return;
+	}
+
+	if (code_pos >= len) {
+		_make_token(TK_EOF);
+		return;
+	}
+#define GETCHAR(m_ofs) ((m_ofs + code_pos) >= len ? 0 : _code[m_ofs + code_pos])
+#define INCPOS(m_amount)      \
+	{                         \
+		code_pos += m_amount; \
+		column += m_amount;   \
+	}
+	while (true) {
+		bool is_node_path = false;
+		StringMode string_mode = STRING_DOUBLE_QUOTE;
+
+		switch (GETCHAR(0)) {
+			case 0:
+				_make_token(TK_EOF);
+				break;
+			case '\\':
+				INCPOS(1);
+				if (GETCHAR(0) == '\r') {
+					INCPOS(1);
+				}
+
+				if (GETCHAR(0) != '\n') {
+					_make_error("Expected newline after '\\'.");
+					return;
+				}
+
+				INCPOS(1);
+				line++;
+
+				while (GETCHAR(0) == ' ' || GETCHAR(0) == '\t') {
+					INCPOS(1);
+				}
+
+				continue;
+			case '\t':
+			case '\r':
+			case ' ':
+				INCPOS(1);
+				continue;
+			case '#': { // line comment skip
+#ifdef DEBUG_ENABLED
+				String comment;
+#endif // DEBUG_ENABLED
+				while (GETCHAR(0) != '\n') {
+#ifdef DEBUG_ENABLED
+					comment += GETCHAR(0);
+#endif // DEBUG_ENABLED
+					code_pos++;
+					if (GETCHAR(0) == 0) { //end of file
+						//_make_error("Unterminated Comment");
+						_make_token(TK_EOF);
+						return;
+					}
+				}
+#ifdef DEBUG_ENABLED
+				String comment_content = comment.trim_prefix("#").trim_prefix(" ");
+				if (comment_content.begins_with("warning-ignore:")) {
+					String code = comment_content.get_slice(":", 1);
+					warning_skips.push_back(Pair<int, String>(line, code.strip_edges().to_lower()));
+				} else if (comment_content.begins_with("warning-ignore-all:")) {
+					String code = comment_content.get_slice(":", 1);
+					warning_global_skips.insert(code.strip_edges().to_lower());
+				} else if (comment_content.strip_edges() == "warnings-disable") {
+					ignore_warnings = true;
+				}
+#endif // DEBUG_ENABLED
+				FALLTHROUGH;
+			}
+			case '\n': {
+				line++;
+				INCPOS(1);
+				bool used_spaces = false;
+				int tabs = 0;
+				column = 1;
+				int i = 0;
+				while (true) {
+					if (GETCHAR(i) == ' ') {
+						i++;
+						used_spaces = true;
+					} else if (GETCHAR(i) == '\t') {
+						if (used_spaces) {
+							_make_error("Spaces used before tabs on a line");
+							return;
+						}
+						i++;
+						tabs++;
+					} else {
+						break; // not indentation anymore
+					}
+				}
+
+				_make_newline(i, tabs);
+				return;
+			}
+			case '/': {
+				switch (GETCHAR(1)) {
+					case '=': { // diveq
+
+						_make_token(TK_OP_ASSIGN_DIV);
+						INCPOS(1);
+
+					} break;
+					default:
+						_make_token(TK_OP_DIV);
+				}
+			} break;
+			case '=': {
+				if (GETCHAR(1) == '=') {
+					_make_token(TK_OP_EQUAL);
+					INCPOS(1);
+
+				} else {
+					_make_token(TK_OP_ASSIGN);
+				}
+
+			} break;
+			case '<': {
+				if (GETCHAR(1) == '=') {
+					_make_token(TK_OP_LESS_EQUAL);
+					INCPOS(1);
+				} else if (GETCHAR(1) == '<') {
+					if (GETCHAR(2) == '=') {
+						_make_token(TK_OP_ASSIGN_SHIFT_LEFT);
+						INCPOS(1);
+					} else {
+						_make_token(TK_OP_SHIFT_LEFT);
+					}
+					INCPOS(1);
+				} else {
+					_make_token(TK_OP_LESS);
+				}
+
+			} break;
+			case '>': {
+				if (GETCHAR(1) == '=') {
+					_make_token(TK_OP_GREATER_EQUAL);
+					INCPOS(1);
+				} else if (GETCHAR(1) == '>') {
+					if (GETCHAR(2) == '=') {
+						_make_token(TK_OP_ASSIGN_SHIFT_RIGHT);
+						INCPOS(1);
+
+					} else {
+						_make_token(TK_OP_SHIFT_RIGHT);
+					}
+					INCPOS(1);
+				} else {
+					_make_token(TK_OP_GREATER);
+				}
+
+			} break;
+			case '!': {
+				if (GETCHAR(1) == '=') {
+					_make_token(TK_OP_NOT_EQUAL);
+					INCPOS(1);
+				} else {
+					_make_token(TK_OP_NOT);
+				}
+
+			} break;
+			//case '"' //string - no strings in shader
+			//case '\'' //string - no strings in shader
+			case '{':
+				_make_token(TK_CURLY_BRACKET_OPEN);
+				break;
+			case '}':
+				_make_token(TK_CURLY_BRACKET_CLOSE);
+				break;
+			case '[':
+				_make_token(TK_BRACKET_OPEN);
+				break;
+			case ']':
+				_make_token(TK_BRACKET_CLOSE);
+				break;
+			case '(':
+				_make_token(TK_PARENTHESIS_OPEN);
+				break;
+			case ')':
+				_make_token(TK_PARENTHESIS_CLOSE);
+				break;
+			case ',':
+				_make_token(TK_COMMA);
+				break;
+			case ';':
+				_make_token(TK_SEMICOLON);
+				break;
+			case '?':
+				_make_token(TK_QUESTION_MARK);
+				break;
+			case ':':
+				_make_token(TK_COLON); //for methods maybe but now useless.
+				break;
+			case '$':
+				_make_token(TK_DOLLAR); //for the get_node() shortener
+				break;
+			case '^': {
+				if (GETCHAR(1) == '=') {
+					_make_token(TK_OP_ASSIGN_BIT_XOR);
+					INCPOS(1);
+				} else {
+					_make_token(TK_OP_BIT_XOR);
+				}
+
+			} break;
+			case '~':
+				_make_token(TK_OP_BIT_INVERT);
+				break;
+			case '&': {
+				if (GETCHAR(1) == '&') {
+					_make_token(TK_OP_AND);
+					INCPOS(1);
+				} else if (GETCHAR(1) == '=') {
+					_make_token(TK_OP_ASSIGN_BIT_AND);
+					INCPOS(1);
+				} else {
+					_make_token(TK_OP_BIT_AND);
+				}
+			} break;
+			case '|': {
+				if (GETCHAR(1) == '|') {
+					_make_token(TK_OP_OR);
+					INCPOS(1);
+				} else if (GETCHAR(1) == '=') {
+					_make_token(TK_OP_ASSIGN_BIT_OR);
+					INCPOS(1);
+				} else {
+					_make_token(TK_OP_BIT_OR);
+				}
+			} break;
+			case '*': {
+				if (GETCHAR(1) == '=') {
+					_make_token(TK_OP_ASSIGN_MUL);
+					INCPOS(1);
+				} else {
+					_make_token(TK_OP_MUL);
+				}
+			} break;
+			case '+': {
+				if (GETCHAR(1) == '=') {
+					_make_token(TK_OP_ASSIGN_ADD);
+					INCPOS(1);
+					/*
+				}  else if (GETCHAR(1)=='+') {
+					_make_token(TK_OP_PLUS_PLUS);
+					INCPOS(1);
+				*/
+				} else {
+					_make_token(TK_OP_ADD);
+				}
+
+			} break;
+			case '-': {
+				if (GETCHAR(1) == '=') {
+					_make_token(TK_OP_ASSIGN_SUB);
+					INCPOS(1);
+				} else if (GETCHAR(1) == '>') {
+					_make_token(TK_FORWARD_ARROW);
+					INCPOS(1);
+				} else {
+					_make_token(TK_OP_SUB);
+				}
+			} break;
+			case '%': {
+				if (GETCHAR(1) == '=') {
+					_make_token(TK_OP_ASSIGN_MOD);
+					INCPOS(1);
+				} else {
+					_make_token(TK_OP_MOD);
+				}
+			} break;
+			case '@':
+				if (CharType(GETCHAR(1)) != '"' && CharType(GETCHAR(1)) != '\'') {
+					_make_error("Unexpected '@'");
+					return;
+				}
+				INCPOS(1);
+				is_node_path = true;
+				FALLTHROUGH;
+			case '\'':
+			case '"': {
+				if (GETCHAR(0) == '\'') {
+					string_mode = STRING_SINGLE_QUOTE;
+				}
+
+				int i = 1;
+				if (string_mode == STRING_DOUBLE_QUOTE && GETCHAR(i) == '"' && GETCHAR(i + 1) == '"') {
+					i += 2;
+					string_mode = STRING_MULTILINE;
+				}
+
+				String str;
+				while (true) {
+					if (CharType(GETCHAR(i)) == 0) {
+						_make_error("Unterminated String");
+						return;
+					} else if (string_mode == STRING_DOUBLE_QUOTE && CharType(GETCHAR(i)) == '"') {
+						break;
+					} else if (string_mode == STRING_SINGLE_QUOTE && CharType(GETCHAR(i)) == '\'') {
+						break;
+					} else if (string_mode == STRING_MULTILINE && CharType(GETCHAR(i)) == '\"' && CharType(GETCHAR(i + 1)) == '\"' && CharType(GETCHAR(i + 2)) == '\"') {
+						i += 2;
+						break;
+					} else if (string_mode != STRING_MULTILINE && CharType(GETCHAR(i)) == '\n') {
+						_make_error("Unexpected EOL at String.");
+						return;
+					} else if (CharType(GETCHAR(i)) == 0xFFFF) {
+						//string ends here, next will be TK
+						i--;
+						break;
+					} else if (CharType(GETCHAR(i)) == '\\') {
+						//escaped characters...
+						i++;
+						CharType next = GETCHAR(i);
+						if (next == 0) {
+							_make_error("Unterminated String");
+							return;
+						}
+						CharType res = 0;
+
+						switch (next) {
+							case 'a':
+								res = 7;
+								break;
+							case 'b':
+								res = 8;
+								break;
+							case 't':
+								res = 9;
+								break;
+							case 'n':
+								res = 10;
+								break;
+							case 'v':
+								res = 11;
+								break;
+							case 'f':
+								res = 12;
+								break;
+							case 'r':
+								res = 13;
+								break;
+							case '\'':
+								res = '\'';
+								break;
+							case '\"':
+								res = '\"';
+								break;
+							case '\\':
+								res = '\\';
+								break;
+							case '/':
+								res = '/';
+								break; //wtf
+
+							case 'u': {
+								//hexnumbarh - oct is deprecated
+								i += 1;
+								for (int j = 0; j < 4; j++) {
+									CharType c = GETCHAR(i + j);
+									if (c == 0) {
+										_make_error("Unterminated String");
+										return;
+									}
+
+									CharType v = 0;
+									if (c >= '0' && c <= '9') {
+										v = c - '0';
+									} else if (c >= 'a' && c <= 'f') {
+										v = c - 'a';
+										v += 10;
+									} else if (c >= 'A' && c <= 'F') {
+										v = c - 'A';
+										v += 10;
+									} else {
+										_make_error("Malformed hex constant in string");
+										return;
+									}
+
+									res <<= 4;
+									res |= v;
+								}
+								i += 3;
+
+							} break;
+							default: {
+								_make_error("Invalid escape sequence");
+								return;
+							} break;
+						}
+
+						str += res;
+
+					} else {
+						if (CharType(GETCHAR(i)) == '\n') {
+							line++;
+							column = 1;
+						}
+
+						str += CharType(GETCHAR(i));
+					}
+					i++;
+				}
+				INCPOS(i);
+
+				if (is_node_path) {
+					_make_constant(NodePath(str));
+				} else {
+					_make_constant(str);
+				}
+
+			} break;
+			case 0xFFFF: {
+				_make_token(TK_CURSOR);
+			} break;
+			default: {
+				if (_is_number(GETCHAR(0)) || (GETCHAR(0) == '.' && _is_number(GETCHAR(1)))) {
+					// parse number
+					bool period_found = false;
+					bool exponent_found = false;
+					bool hexa_found = false;
+					bool bin_found = false;
+					bool sign_found = false;
+
+					String str;
+					int i = 0;
+
+					while (true) {
+						if (GETCHAR(i) == '.') {
+							if (period_found || exponent_found) {
+								_make_error("Invalid numeric constant at '.'");
+								return;
+							} else if (bin_found) {
+								_make_error("Invalid binary constant at '.'");
+								return;
+							} else if (hexa_found) {
+								_make_error("Invalid hexadecimal constant at '.'");
+								return;
+							}
+							period_found = true;
+						} else if (GETCHAR(i) == 'x') {
+							if (hexa_found || bin_found || str.length() != 1 || !((i == 1 && str[0] == '0') || (i == 2 && str[1] == '0' && str[0] == '-'))) {
+								_make_error("Invalid numeric constant at 'x'");
+								return;
+							}
+							hexa_found = true;
+						} else if (hexa_found && _is_hex(GETCHAR(i))) {
+						} else if (!hexa_found && GETCHAR(i) == 'b') {
+							if (bin_found || str.length() != 1 || !((i == 1 && str[0] == '0') || (i == 2 && str[1] == '0' && str[0] == '-'))) {
+								_make_error("Invalid numeric constant at 'b'");
+								return;
+							}
+							bin_found = true;
+						} else if (!hexa_found && GETCHAR(i) == 'e') {
+							if (exponent_found || bin_found) {
+								_make_error("Invalid numeric constant at 'e'");
+								return;
+							}
+							exponent_found = true;
+						} else if (_is_number(GETCHAR(i))) {
+							//all ok
+
+						} else if (bin_found && _is_bin(GETCHAR(i))) {
+						} else if ((GETCHAR(i) == '-' || GETCHAR(i) == '+') && exponent_found) {
+							if (sign_found) {
+								_make_error("Invalid numeric constant at '-'");
+								return;
+							}
+							sign_found = true;
+						} else if (GETCHAR(i) == '_') {
+							i++;
+							continue; // Included for readability, shouldn't be a part of the string
+						} else {
+							break;
+						}
+
+						str += CharType(GETCHAR(i));
+						i++;
+					}
+
+					if (!(_is_number(str[str.length() - 1]) || (hexa_found && _is_hex(str[str.length() - 1])))) {
+						_make_error("Invalid numeric constant: " + str);
+						return;
+					}
+
+					INCPOS(i);
+					if (hexa_found) {
+						int64_t val = hex_to_int64(str);
+						_make_constant(val);
+					} else if (bin_found) {
+						int64_t val = bin_to_int64(str);
+						_make_constant(val);
+					} else if (period_found || exponent_found) {
+						double val = to_double(str);
+						_make_constant(val);
+					} else {
+						int64_t val = to_int64(str);
+						_make_constant(val);
+					}
+
+					return;
+				}
+
+				if (GETCHAR(0) == '.') {
+					//parse period
+					_make_token(TK_PERIOD);
+					break;
+				}
+
+				if (_is_text_char(GETCHAR(0))) {
+					// parse identifier
+					String str;
+					str += CharType(GETCHAR(0));
+
+					int i = 1;
+					while (_is_text_char(GETCHAR(i))) {
+						str += CharType(GETCHAR(i));
+						i++;
+					}
+
+					bool identifier = false;
+
+					if (str == "null") {
+						_make_constant(Variant());
+
+					} else if (str == "true") {
+						_make_constant(true);
+
+					} else if (str == "false") {
+						_make_constant(false);
+					} else {
+						bool found = false;
+
+						{
+							int idx = 0;
+
+							while (_type_list[idx].text) {
+								if (str == _type_list[idx].text) {
+									_make_type(_type_list[idx].type);
+									found = true;
+									break;
+								}
+								idx++;
+							}
+						}
+
+						if (!found) {
+							//built in func?
+
+							for (int j = 0; j < FUNC_MAX; j++) {
+								if (str == get_func_name(Function(j))) {
+									_make_built_in_func(Function(j));
+									found = true;
+									break;
+								}
+							}
+						}
+
+						if (!found) {
+							//keyword
+
+							int idx = 0;
+							found = false;
+
+							while (_keyword_list[idx].text) {
+								if (str == _keyword_list[idx].text) {
+									_make_token(_keyword_list[idx].token);
+									found = true;
+									break;
+								}
+								idx++;
+							}
+						}
+
+						if (!found) {
+							identifier = true;
+						}
+					}
+
+					if (identifier) {
+						_make_identifier(str);
+					}
+					INCPOS(str.length());
+					return;
+				}
+
+				_make_error("Unknown character");
+				return;
+
+			} break;
+		}
+
+		INCPOS(1);
+		break;
+	}
+}
+
+void GDScriptTokenizerText::set_code(const String &p_code) {
+	code = p_code;
+	len = p_code.length();
+	if (len) {
+		_code = (const CharType *)&code[0];
+	} else {
+		_code = nullptr;
+	}
+	code_pos = 0;
+	line = 1; //it is stand-ar-ized that lines begin in 1 in code..
+	column = 1; //the same holds for columns
+	tk_rb_pos = 0;
+	error_flag = false;
+#ifdef DEBUG_ENABLED
+	ignore_warnings = false;
+#endif // DEBUG_ENABLED
+	last_error = "";
+	for (int i = 0; i < MAX_LOOKAHEAD + 1; i++) {
+		_advance();
+	}
+}
+
+GDScriptTokenizerText::Token GDScriptTokenizerText::get_token(int p_offset) const {
+	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, TK_ERROR);
+	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, TK_ERROR);
+
+	int ofs = (RB_SIZE + tk_rb_pos + p_offset - MAX_LOOKAHEAD - 1) % RB_SIZE;
+	return tk_rb[ofs].type;
+}
+
+int GDScriptTokenizerText::get_token_line(int p_offset) const {
+	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, -1);
+	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, -1);
+
+	int ofs = (RB_SIZE + tk_rb_pos + p_offset - MAX_LOOKAHEAD - 1) % RB_SIZE;
+	return tk_rb[ofs].line;
+}
+
+int GDScriptTokenizerText::get_token_column(int p_offset) const {
+	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, -1);
+	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, -1);
+
+	int ofs = (RB_SIZE + tk_rb_pos + p_offset - MAX_LOOKAHEAD - 1) % RB_SIZE;
+	return tk_rb[ofs].col;
+}
+
+const Variant &GDScriptTokenizerText::get_token_constant(int p_offset) const {
+	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, tk_rb[0].constant);
+	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, tk_rb[0].constant);
+
+	int ofs = (RB_SIZE + tk_rb_pos + p_offset - MAX_LOOKAHEAD - 1) % RB_SIZE;
+	ERR_FAIL_COND_V(tk_rb[ofs].type != TK_CONSTANT, tk_rb[0].constant);
+	return tk_rb[ofs].constant;
+}
+
+StringName GDScriptTokenizerText::get_token_identifier(int p_offset) const {
+	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, StringName());
+	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, StringName());
+
+	int ofs = (RB_SIZE + tk_rb_pos + p_offset - MAX_LOOKAHEAD - 1) % RB_SIZE;
+	ERR_FAIL_COND_V(tk_rb[ofs].type != TK_IDENTIFIER, StringName());
+	return tk_rb[ofs].identifier;
+}
+
+Function GDScriptTokenizerText::get_token_built_in_func(int p_offset) const {
+	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, FUNC_MAX);
+	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, FUNC_MAX);
+
+	int ofs = (RB_SIZE + tk_rb_pos + p_offset - MAX_LOOKAHEAD - 1) % RB_SIZE;
+	ERR_FAIL_COND_V(tk_rb[ofs].type != TK_BUILT_IN_FUNC, FUNC_MAX);
+	return tk_rb[ofs].func;
+}
+
+Variant::Type GDScriptTokenizerText::get_token_type(int p_offset) const {
+	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, Variant::NIL);
+	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, Variant::NIL);
+
+	int ofs = (RB_SIZE + tk_rb_pos + p_offset - MAX_LOOKAHEAD - 1) % RB_SIZE;
+	ERR_FAIL_COND_V(tk_rb[ofs].type != TK_BUILT_IN_TYPE, Variant::NIL);
+	return tk_rb[ofs].vtype;
+}
+
+int GDScriptTokenizerText::get_token_line_indent(int p_offset) const {
+	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, 0);
+	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, 0);
+
+	int ofs = (RB_SIZE + tk_rb_pos + p_offset - MAX_LOOKAHEAD - 1) % RB_SIZE;
+	ERR_FAIL_COND_V(tk_rb[ofs].type != TK_NEWLINE, 0);
+	return tk_rb[ofs].constant.operator Vector2().x;
+}
+
+int GDScriptTokenizerText::get_token_line_tab_indent(int p_offset) const {
+	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, 0);
+	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, 0);
+
+	int ofs = (RB_SIZE + tk_rb_pos + p_offset - MAX_LOOKAHEAD - 1) % RB_SIZE;
+	ERR_FAIL_COND_V(tk_rb[ofs].type != TK_NEWLINE, 0);
+	return tk_rb[ofs].constant.operator Vector2().y;
+}
+
+String GDScriptTokenizerText::get_token_error(int p_offset) const {
+	ERR_FAIL_COND_V(p_offset <= -MAX_LOOKAHEAD, String());
+	ERR_FAIL_COND_V(p_offset >= MAX_LOOKAHEAD, String());
+
+	int ofs = (RB_SIZE + tk_rb_pos + p_offset - MAX_LOOKAHEAD - 1) % RB_SIZE;
+	ERR_FAIL_COND_V(tk_rb[ofs].type != TK_ERROR, String());
+	return tk_rb[ofs].constant;
+}
+
+void GDScriptTokenizerText::advance(int p_amount) {
+	ERR_FAIL_COND(p_amount <= 0);
+	for (int i = 0; i < p_amount; i++) {
+		_advance();
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#define BYTECODE_VERSION 13
+
+Error GDScriptTokenizerBuffer::set_code_buffer(const Vector<uint8_t> &p_buffer) {
+	const uint8_t *buf = p_buffer.ptr();
+	int total_len = p_buffer.size();
+	ERR_FAIL_COND_V(p_buffer.size() < 24 || p_buffer[0] != 'G' || p_buffer[1] != 'D' || p_buffer[2] != 'S' || p_buffer[3] != 'C', ERR_INVALID_DATA);
+
+	int version = decode_uint32(&buf[4]);
+	ERR_FAIL_COND_V_MSG(version > BYTECODE_VERSION, ERR_INVALID_DATA, "Bytecode is too recent! Please use a newer engine version.");
+
+	int identifier_count = decode_uint32(&buf[8]);
+	int constant_count = decode_uint32(&buf[12]);
+	int line_count = decode_uint32(&buf[16]);
+	int token_count = decode_uint32(&buf[20]);
+
+	const uint8_t *b = &buf[24];
+	total_len -= 24;
+
+	identifiers.resize(identifier_count);
+	for (int i = 0; i < identifier_count; i++) {
+		int len = decode_uint32(b);
+		ERR_FAIL_COND_V(len > total_len, ERR_INVALID_DATA);
+		b += 4;
+		Vector<uint8_t> cs;
+		cs.resize(len);
+		for (int j = 0; j < len; j++) {
+			cs.write[j] = b[j] ^ 0xb6;
+		}
+
+		cs.write[cs.size() - 1] = 0;
+		String s;
+		s.parse_utf8((const char *)cs.ptr());
+		b += len;
+		total_len -= len + 4;
+		identifiers.write[i] = s;
+	}
+
+	constants.resize(constant_count);
+	for (int i = 0; i < constant_count; i++) {
+		Variant v;
+		int len;
+		// An object cannot be constant, never decode objects
+		Error err = decode_variant(v, b, total_len, &len, false);
+		if (err) {
+			return err;
+		}
+		b += len;
+		total_len -= len;
+		constants.write[i] = v;
+	}
+
+	ERR_FAIL_COND_V(line_count * 8 > total_len, ERR_INVALID_DATA);
+
+	for (int i = 0; i < line_count; i++) {
+		uint32_t token = decode_uint32(b);
+		b += 4;
+		uint32_t linecol = decode_uint32(b);
+		b += 4;
+
+		lines.insert(token, linecol);
+		total_len -= 8;
+	}
+
+	tokens.resize(token_count);
+
+	for (int i = 0; i < token_count; i++) {
+		ERR_FAIL_COND_V(total_len < 1, ERR_INVALID_DATA);
+
+		if ((*b) & TOKEN_BYTE_MASK) { //little endian always
+			ERR_FAIL_COND_V(total_len < 4, ERR_INVALID_DATA);
+
+			tokens.write[i] = decode_uint32(b) & ~TOKEN_BYTE_MASK;
+			b += 4;
+		} else {
+			tokens.write[i] = *b;
+			b += 1;
+			total_len--;
+		}
+	}
+
+	token = 0;
+
+	return OK;
+}
+
+Vector<uint8_t> GDScriptTokenizerBuffer::parse_code_string(const String &p_code) {
+	Vector<uint8_t> buf;
+
+	Map<StringName, int> identifier_map;
+	HashMap<Variant, int, VariantHasher, VariantComparator> constant_map;
+	Map<uint32_t, int> line_map;
+	Vector<uint32_t> token_array;
+
+	GDScriptTokenizerText tt;
+	tt.set_code(p_code);
+	int line = -1;
+
+	while (true) {
+		if (tt.get_token_line() != line) {
+			line = tt.get_token_line();
+			line_map[line] = token_array.size();
+		}
+
+		uint32_t token = tt.get_token();
+		switch (tt.get_token()) {
+			case TK_IDENTIFIER: {
+				StringName id = tt.get_token_identifier();
+				if (!identifier_map.has(id)) {
+					int idx = identifier_map.size();
+					identifier_map[id] = idx;
+				}
+				token |= identifier_map[id] << TOKEN_BITS;
+			} break;
+			case TK_CONSTANT: {
+				const Variant &c = tt.get_token_constant();
+				if (!constant_map.has(c)) {
+					int idx = constant_map.size();
+					constant_map[c] = idx;
+				}
+				token |= constant_map[c] << TOKEN_BITS;
+			} break;
+			case TK_BUILT_IN_TYPE: {
+				token |= tt.get_token_type() << TOKEN_BITS;
+			} break;
+			case TK_BUILT_IN_FUNC: {
+				token |= tt.get_token_built_in_func() << TOKEN_BITS;
+
+			} break;
+			case TK_NEWLINE: {
+				token |= tt.get_token_line_indent() << TOKEN_BITS;
+			} break;
+			case TK_ERROR: {
+				ERR_FAIL_V(Vector<uint8_t>());
+			} break;
+			default: {
+			}
+		};
+
+		token_array.push_back(token);
+
+		if (tt.get_token() == TK_EOF) {
+			break;
+		}
+		tt.advance();
+	}
+
+	//reverse maps
+
+	Map<int, StringName> rev_identifier_map;
+	for (Map<StringName, int>::Element *E = identifier_map.front(); E; E = E->next()) {
+		rev_identifier_map[E->get()] = E->key();
+	}
+
+	Map<int, Variant> rev_constant_map;
+	const Variant *K = nullptr;
+
+	for (KeyValue<Variant, int> &F : constant_map) {
+		rev_constant_map[constant_map[F.key]] = F.key;
+	}
+
+	Map<int, uint32_t> rev_line_map;
+	for (Map<uint32_t, int>::Element *E = line_map.front(); E; E = E->next()) {
+		rev_line_map[E->get()] = E->key();
+	}
+
+	//save header
+	buf.resize(24);
+	buf.write[0] = 'G';
+	buf.write[1] = 'D';
+	buf.write[2] = 'S';
+	buf.write[3] = 'C';
+	encode_uint32(BYTECODE_VERSION, &buf.write[4]);
+	encode_uint32(identifier_map.size(), &buf.write[8]);
+	encode_uint32(constant_map.size(), &buf.write[12]);
+	encode_uint32(line_map.size(), &buf.write[16]);
+	encode_uint32(token_array.size(), &buf.write[20]);
+
+	//save identifiers
+
+	for (Map<int, StringName>::Element *E = rev_identifier_map.front(); E; E = E->next()) {
+		CharString cs = String(E->get()).utf8();
+		int len = cs.length() + 1;
+		int extra = 4 - (len % 4);
+		if (extra == 4) {
+			extra = 0;
+		}
+
+		uint8_t ibuf[4];
+		encode_uint32(len + extra, ibuf);
+		for (int i = 0; i < 4; i++) {
+			buf.push_back(ibuf[i]);
+		}
+		for (int i = 0; i < len; i++) {
+			buf.push_back(cs[i] ^ 0xb6);
+		}
+		for (int i = 0; i < extra; i++) {
+			buf.push_back(0 ^ 0xb6);
+		}
+	}
+
+	for (Map<int, Variant>::Element *E = rev_constant_map.front(); E; E = E->next()) {
+		int len;
+		// Objects cannot be constant, never encode objects
+		Error err = encode_variant(E->get(), nullptr, len, false);
+		ERR_FAIL_COND_V_MSG(err != OK, Vector<uint8_t>(), "Error when trying to encode Variant.");
+		int pos = buf.size();
+		buf.resize(pos + len);
+		encode_variant(E->get(), &buf.write[pos], len, false);
+	}
+
+	for (Map<int, uint32_t>::Element *E = rev_line_map.front(); E; E = E->next()) {
+		uint8_t ibuf[8];
+		encode_uint32(E->key(), &ibuf[0]);
+		encode_uint32(E->get(), &ibuf[4]);
+		for (int i = 0; i < 8; i++) {
+			buf.push_back(ibuf[i]);
+		}
+	}
+
+	for (int i = 0; i < token_array.size(); i++) {
+		uint32_t token = token_array[i];
+
+		if (token & ~TOKEN_MASK) {
+			uint8_t buf4[4];
+			encode_uint32(token_array[i] | TOKEN_BYTE_MASK, &buf4[0]);
+			for (int j = 0; j < 4; j++) {
+				buf.push_back(buf4[j]);
+			}
+		} else {
+			buf.push_back(token);
+		}
+	}
+
+	return buf;
+}
+
+GDScriptTokenizerBuffer::Token GDScriptTokenizerBuffer::get_token(int p_offset) const {
+	int offset = token + p_offset;
+
+	if (offset < 0 || offset >= tokens.size()) {
+		return TK_EOF;
+	}
+
+	return GDScriptTokenizerBuffer::Token(tokens[offset] & TOKEN_MASK);
+}
+
+StringName GDScriptTokenizerBuffer::get_token_identifier(int p_offset) const {
+	int offset = token + p_offset;
+
+	ERR_FAIL_INDEX_V(offset, tokens.size(), StringName());
+	uint32_t identifier = tokens[offset] >> TOKEN_BITS;
+	ERR_FAIL_UNSIGNED_INDEX_V(identifier, (uint32_t)identifiers.size(), StringName());
+
+	return identifiers[identifier];
+}
+
+Function GDScriptTokenizerBuffer::get_token_built_in_func(int p_offset) const {
+	int offset = token + p_offset;
+	ERR_FAIL_INDEX_V(offset, tokens.size(), Function::FUNC_MAX);
+	return Function(tokens[offset] >> TOKEN_BITS);
+}
+
+Variant::Type GDScriptTokenizerBuffer::get_token_type(int p_offset) const {
+	int offset = token + p_offset;
+	ERR_FAIL_INDEX_V(offset, tokens.size(), Variant::NIL);
+
+	return Variant::Type(tokens[offset] >> TOKEN_BITS);
+}
+
+int GDScriptTokenizerBuffer::get_token_line(int p_offset) const {
+	int offset = token + p_offset;
+	int pos = lines.find_nearest(offset);
+
+	if (pos < 0) {
+		return -1;
+	}
+	if (pos >= lines.size()) {
+		pos = lines.size() - 1;
+	}
+
+	uint32_t l = lines.getv(pos);
+	return l & TOKEN_LINE_MASK;
+}
+int GDScriptTokenizerBuffer::get_token_column(int p_offset) const {
+	int offset = token + p_offset;
+	int pos = lines.find_nearest(offset);
+	if (pos < 0) {
+		return -1;
+	}
+	if (pos >= lines.size()) {
+		pos = lines.size() - 1;
+	}
+
+	uint32_t l = lines.getv(pos);
+	return l >> TOKEN_LINE_BITS;
+}
+int GDScriptTokenizerBuffer::get_token_line_indent(int p_offset) const {
+	int offset = token + p_offset;
+	ERR_FAIL_INDEX_V(offset, tokens.size(), 0);
+	return tokens[offset] >> TOKEN_BITS;
+}
+const Variant &GDScriptTokenizerBuffer::get_token_constant(int p_offset) const {
+	int offset = token + p_offset;
+	ERR_FAIL_INDEX_V(offset, tokens.size(), nil);
+	uint32_t constant = tokens[offset] >> TOKEN_BITS;
+	ERR_FAIL_UNSIGNED_INDEX_V(constant, (uint32_t)constants.size(), nil);
+	return constants[constant];
+}
+String GDScriptTokenizerBuffer::get_token_error(int p_offset) const {
+	ERR_FAIL_V(String());
+}
+
+void GDScriptTokenizerBuffer::advance(int p_amount) {
+	ERR_FAIL_INDEX(p_amount + token, tokens.size());
+	token += p_amount;
+}
+GDScriptTokenizerBuffer::GDScriptTokenizerBuffer() {
+	token = 0;
+}

--- a/editor/gdscript_tokenizer_old.h
+++ b/editor/gdscript_tokenizer_old.h
@@ -1,0 +1,375 @@
+/**************************************************************************/
+/*  gdscript_tokenizer.h                                                  */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/**************************************************************************/
+
+#ifndef GDSCRIPT_TOKENIZER_H
+#define GDSCRIPT_TOKENIZER_H
+
+#include "core/string/string_name.h"
+#include "core/string/ustring.h"
+#include "core/templates/pair.h"
+#include "core/templates/vmap.h"
+#include "core/variant/variant.h"
+
+typedef char32_t CharType;
+
+enum Function {
+	MATH_SIN,
+	MATH_COS,
+	MATH_TAN,
+	MATH_SINH,
+	MATH_COSH,
+	MATH_TANH,
+	MATH_ASIN,
+	MATH_ACOS,
+	MATH_ATAN,
+	MATH_ATAN2,
+	MATH_SQRT,
+	MATH_FMOD,
+	MATH_FPOSMOD,
+	MATH_POSMOD,
+	MATH_FLOOR,
+	MATH_CEIL,
+	MATH_ROUND,
+	MATH_ABS,
+	MATH_SIGN,
+	MATH_POW,
+	MATH_LOG,
+	MATH_EXP,
+	MATH_ISNAN,
+	MATH_ISINF,
+	MATH_ISEQUALAPPROX,
+	MATH_ISZEROAPPROX,
+	MATH_EASE,
+	MATH_DECIMALS,
+	MATH_STEP_DECIMALS,
+	MATH_STEPIFY,
+	MATH_LERP,
+	MATH_LERP_ANGLE,
+	MATH_INVERSE_LERP,
+	MATH_RANGE_LERP,
+	MATH_SMOOTHSTEP,
+	MATH_MOVE_TOWARD,
+	MATH_DECTIME,
+	MATH_RANDOMIZE,
+	MATH_RAND,
+	MATH_RANDF,
+	MATH_RANDOM,
+	MATH_SEED,
+	MATH_RANDSEED,
+	MATH_DEG2RAD,
+	MATH_RAD2DEG,
+	MATH_LINEAR2DB,
+	MATH_DB2LINEAR,
+	MATH_POLAR2CARTESIAN,
+	MATH_CARTESIAN2POLAR,
+	MATH_WRAP,
+	MATH_WRAPF,
+	LOGIC_MAX,
+	LOGIC_MIN,
+	LOGIC_CLAMP,
+	LOGIC_NEAREST_PO2,
+	OBJ_WEAKREF,
+	FUNC_FUNCREF,
+	TYPE_CONVERT,
+	TYPE_OF,
+	TYPE_EXISTS,
+	TEXT_CHAR,
+	TEXT_ORD,
+	TEXT_STR,
+	TEXT_PRINT,
+	TEXT_PRINT_TABBED,
+	TEXT_PRINT_SPACED,
+	TEXT_PRINTERR,
+	TEXT_PRINTRAW,
+	TEXT_PRINT_DEBUG,
+	PUSH_ERROR,
+	PUSH_WARNING,
+	VAR_TO_STR,
+	STR_TO_VAR,
+	VAR_TO_BYTES,
+	BYTES_TO_VAR,
+	GEN_RANGE,
+	RESOURCE_LOAD,
+	INST2DICT,
+	DICT2INST,
+	VALIDATE_JSON,
+	PARSE_JSON,
+	TO_JSON,
+	HASH,
+	COLOR8,
+	COLORN,
+	PRINT_STACK,
+	GET_STACK,
+	INSTANCE_FROM_ID,
+	LEN,
+	IS_INSTANCE_VALID,
+	DEEP_EQUAL,
+	FUNC_MAX
+};
+
+class GDScriptTokenizerOld {
+public:
+	enum Token {
+
+		TK_EMPTY,
+		TK_IDENTIFIER,
+		TK_CONSTANT,
+		TK_SELF,
+		TK_BUILT_IN_TYPE,
+		TK_BUILT_IN_FUNC,
+		TK_OP_IN,
+		TK_OP_EQUAL,
+		TK_OP_NOT_EQUAL,
+		TK_OP_LESS,
+		TK_OP_LESS_EQUAL,
+		TK_OP_GREATER,
+		TK_OP_GREATER_EQUAL,
+		TK_OP_AND,
+		TK_OP_OR,
+		TK_OP_NOT,
+		TK_OP_ADD,
+		TK_OP_SUB,
+		TK_OP_MUL,
+		TK_OP_DIV,
+		TK_OP_MOD,
+		TK_OP_SHIFT_LEFT,
+		TK_OP_SHIFT_RIGHT,
+		TK_OP_ASSIGN,
+		TK_OP_ASSIGN_ADD,
+		TK_OP_ASSIGN_SUB,
+		TK_OP_ASSIGN_MUL,
+		TK_OP_ASSIGN_DIV,
+		TK_OP_ASSIGN_MOD,
+		TK_OP_ASSIGN_SHIFT_LEFT,
+		TK_OP_ASSIGN_SHIFT_RIGHT,
+		TK_OP_ASSIGN_BIT_AND,
+		TK_OP_ASSIGN_BIT_OR,
+		TK_OP_ASSIGN_BIT_XOR,
+		TK_OP_BIT_AND,
+		TK_OP_BIT_OR,
+		TK_OP_BIT_XOR,
+		TK_OP_BIT_INVERT,
+		//TK_OP_PLUS_PLUS,
+		//TK_OP_MINUS_MINUS,
+		TK_CF_IF,
+		TK_CF_ELIF,
+		TK_CF_ELSE,
+		TK_CF_FOR,
+		TK_CF_WHILE,
+		TK_CF_BREAK,
+		TK_CF_CONTINUE,
+		TK_CF_PASS,
+		TK_CF_RETURN,
+		TK_CF_MATCH,
+		TK_PR_FUNCTION,
+		TK_PR_CLASS,
+		TK_PR_CLASS_NAME,
+		TK_PR_EXTENDS,
+		TK_PR_IS,
+		TK_PR_ONREADY,
+		TK_PR_TOOL,
+		TK_PR_STATIC,
+		TK_PR_EXPORT,
+		TK_PR_SETGET,
+		TK_PR_CONST,
+		TK_PR_VAR,
+		TK_PR_AS,
+		TK_PR_VOID,
+		TK_PR_ENUM,
+		TK_PR_PRELOAD,
+		TK_PR_ASSERT,
+		TK_PR_YIELD,
+		TK_PR_SIGNAL,
+		TK_PR_BREAKPOINT,
+		TK_PR_REMOTE,
+		TK_PR_SYNC,
+		TK_PR_MASTER,
+		TK_PR_SLAVE, // Deprecated by TK_PR_PUPPET, to remove in 4.0
+		TK_PR_PUPPET,
+		TK_PR_REMOTESYNC,
+		TK_PR_MASTERSYNC,
+		TK_PR_PUPPETSYNC,
+		TK_BRACKET_OPEN,
+		TK_BRACKET_CLOSE,
+		TK_CURLY_BRACKET_OPEN,
+		TK_CURLY_BRACKET_CLOSE,
+		TK_PARENTHESIS_OPEN,
+		TK_PARENTHESIS_CLOSE,
+		TK_COMMA,
+		TK_SEMICOLON,
+		TK_PERIOD,
+		TK_QUESTION_MARK,
+		TK_COLON,
+		TK_DOLLAR,
+		TK_FORWARD_ARROW,
+		TK_NEWLINE,
+		TK_CONST_PI,
+		TK_CONST_TAU,
+		TK_WILDCARD,
+		TK_CONST_INF,
+		TK_CONST_NAN,
+		TK_ERROR,
+		TK_EOF,
+		TK_CURSOR, //used for code completion
+		TK_MAX
+	};
+
+protected:
+	enum StringMode {
+		STRING_SINGLE_QUOTE,
+		STRING_DOUBLE_QUOTE,
+		STRING_MULTILINE
+	};
+
+	static const char *token_names[TK_MAX];
+
+public:
+	static const char *get_token_name(Token p_token);
+
+	bool is_token_literal(int p_offset = 0, bool variable_safe = false) const;
+	StringName get_token_literal(int p_offset = 0) const;
+	const char *get_func_name(Function p_func) const;
+
+	virtual const Variant &get_token_constant(int p_offset = 0) const = 0;
+	virtual Token get_token(int p_offset = 0) const = 0;
+	virtual StringName get_token_identifier(int p_offset = 0) const = 0;
+	virtual Function get_token_built_in_func(int p_offset = 0) const = 0;
+	virtual Variant::Type get_token_type(int p_offset = 0) const = 0;
+	virtual int get_token_line(int p_offset = 0) const = 0;
+	virtual int get_token_column(int p_offset = 0) const = 0;
+	virtual int get_token_line_indent(int p_offset = 0) const = 0;
+	virtual int get_token_line_tab_indent(int p_offset = 0) const = 0;
+	virtual String get_token_error(int p_offset = 0) const = 0;
+	virtual void advance(int p_amount = 1) = 0;
+#ifdef DEBUG_ENABLED
+	virtual const Vector<Pair<int, String>> &get_warning_skips() const = 0;
+	virtual const Set<String> &get_warning_global_skips() const = 0;
+	virtual bool is_ignoring_warnings() const = 0;
+#endif // DEBUG_ENABLED
+
+	virtual ~GDScriptTokenizerOld(){};
+};
+
+class GDScriptTokenizerText : public GDScriptTokenizerOld {
+	enum {
+		MAX_LOOKAHEAD = 4,
+		RB_SIZE = MAX_LOOKAHEAD * 2 + 1
+
+	};
+
+	struct TokenData {
+		Token type;
+		StringName identifier; //for identifier types
+		Variant constant; //for constant types
+		union {
+			Variant::Type vtype; //for type types
+			Function func; //function for built in functions
+			int warning_code; //for warning skip
+		};
+		int line, col;
+		TokenData() {
+			type = TK_EMPTY;
+			line = col = 0;
+			vtype = Variant::NIL;
+		}
+	};
+
+	void _make_token(Token p_type);
+	void _make_newline(int p_indentation = 0, int p_tabs = 0);
+	void _make_identifier(const StringName &p_identifier);
+	void _make_built_in_func(Function p_func);
+	void _make_constant(const Variant &p_constant);
+	void _make_type(const Variant::Type &p_type);
+	void _make_error(const String &p_error);
+
+	String code;
+	int len;
+	int code_pos;
+	const CharType *_code;
+	int line;
+	int column;
+	TokenData tk_rb[RB_SIZE * 2 + 1];
+	int tk_rb_pos;
+	String last_error;
+	bool error_flag;
+
+#ifdef DEBUG_ENABLED
+	Vector<Pair<int, String>> warning_skips;
+	Set<String> warning_global_skips;
+	bool ignore_warnings;
+#endif // DEBUG_ENABLED
+
+	void _advance();
+
+public:
+	void set_code(const String &p_code);
+	virtual Token get_token(int p_offset = 0) const;
+	virtual StringName get_token_identifier(int p_offset = 0) const;
+	virtual Function get_token_built_in_func(int p_offset = 0) const;
+	virtual Variant::Type get_token_type(int p_offset = 0) const;
+	virtual int get_token_line(int p_offset = 0) const;
+	virtual int get_token_column(int p_offset = 0) const;
+	virtual int get_token_line_indent(int p_offset = 0) const;
+	virtual int get_token_line_tab_indent(int p_offset = 0) const;
+	virtual const Variant &get_token_constant(int p_offset = 0) const;
+	virtual String get_token_error(int p_offset = 0) const;
+	virtual void advance(int p_amount = 1);
+#ifdef DEBUG_ENABLED
+	virtual const Vector<Pair<int, String>> &get_warning_skips() const { return warning_skips; }
+	virtual const Set<String> &get_warning_global_skips() const { return warning_global_skips; }
+	virtual bool is_ignoring_warnings() const { return ignore_warnings; }
+#endif // DEBUG_ENABLED
+};
+
+// END_MAIN_TOKENIZER
+
+class GDScriptTokenizerBuffer : public GDScriptTokenizerOld {
+	enum {
+
+		TOKEN_BYTE_MASK = 0x80,
+		TOKEN_BITS = 8,
+		TOKEN_MASK = (1 << TOKEN_BITS) - 1,
+		TOKEN_LINE_BITS = 24,
+		TOKEN_LINE_MASK = (1 << TOKEN_LINE_BITS) - 1,
+	};
+
+	Vector<StringName> identifiers;
+	Vector<Variant> constants;
+	VMap<uint32_t, uint32_t> lines;
+	Vector<uint32_t> tokens;
+	Variant nil;
+	int token;
+
+public:
+	Error set_code_buffer(const Vector<uint8_t> &p_buffer);
+	static Vector<uint8_t> parse_code_string(const String &p_code);
+	virtual Token get_token(int p_offset = 0) const;
+	virtual StringName get_token_identifier(int p_offset = 0) const;
+	virtual Function get_token_built_in_func(int p_offset = 0) const;
+	virtual Variant::Type get_token_type(int p_offset = 0) const;
+	virtual int get_token_line(int p_offset = 0) const;
+	virtual int get_token_column(int p_offset = 0) const;
+	virtual int get_token_line_indent(int p_offset = 0) const;
+	virtual int get_token_line_tab_indent(int p_offset = 0) const { return 0; }
+	virtual const Variant &get_token_constant(int p_offset = 0) const;
+	virtual String get_token_error(int p_offset = 0) const;
+	virtual void advance(int p_amount = 1);
+#ifdef DEBUG_ENABLED
+	virtual const Vector<Pair<int, String>> &get_warning_skips() const {
+		static Vector<Pair<int, String>> v;
+		return v;
+	}
+	virtual const Set<String> &get_warning_global_skips() const {
+		static Set<String> s;
+		return s;
+	}
+	virtual bool is_ignoring_warnings() const { return true; }
+#endif // DEBUG_ENABLED
+	GDScriptTokenizerBuffer();
+};
+
+#endif // GDSCRIPT_TOKENIZER_H

--- a/editor/map.h
+++ b/editor/map.h
@@ -1,0 +1,655 @@
+/**************************************************************************/
+/*  map.h                                                                 */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/**************************************************************************/
+
+#ifndef MAP_H
+#define MAP_H
+
+#include "core/error/error_macros.h"
+#include "core/os/memory.h"
+
+// based on the very nice implementation of rb-trees by:
+// https://web.archive.org/web/20120507164830/http://web.mit.edu/~emin/www/source_code/red_black_tree/index.html
+
+template <class K, class V, class C = Comparator<K>, class A = DefaultAllocator>
+class Map {
+	enum Color {
+		RED,
+		BLACK
+	};
+	struct _Data;
+
+public:
+	class Element {
+	private:
+		friend class Map<K, V, C, A>;
+		int color;
+		Element *right;
+		Element *left;
+		Element *parent;
+		Element *_next;
+		Element *_prev;
+		K _key;
+		V _value;
+		//_Data *data;
+
+	public:
+		const Element *next() const {
+			return _next;
+		}
+		Element *next() {
+			return _next;
+		}
+		const Element *prev() const {
+			return _prev;
+		}
+		Element *prev() {
+			return _prev;
+		}
+		const K &key() const {
+			return _key;
+		};
+		V &value() {
+			return _value;
+		};
+		const V &value() const {
+			return _value;
+		};
+		V &get() {
+			return _value;
+		};
+		const V &get() const {
+			return _value;
+		};
+		Element() {
+			color = RED;
+			right = nullptr;
+			left = nullptr;
+			parent = nullptr;
+			_next = nullptr;
+			_prev = nullptr;
+		};
+	};
+
+private:
+	struct _Data {
+		Element *_root;
+		Element *_nil;
+		int size_cache;
+
+		_FORCE_INLINE_ _Data() {
+#ifdef GLOBALNIL_DISABLED
+			_nil = memnew_allocator(Element, A);
+			_nil->parent = _nil->left = _nil->right = _nil;
+			_nil->color = BLACK;
+#else
+			_nil = (Element *)&_GlobalNilClass::_nil;
+#endif
+			_root = nullptr;
+			size_cache = 0;
+		}
+
+		void _create_root() {
+			_root = memnew_allocator(Element, A);
+			_root->parent = _root->left = _root->right = _nil;
+			_root->color = BLACK;
+		}
+
+		void _free_root() {
+			if (_root) {
+				memdelete_allocator<Element, A>(_root);
+				_root = nullptr;
+			}
+		}
+
+		~_Data() {
+			_free_root();
+
+#ifdef GLOBALNIL_DISABLED
+			memdelete_allocator<Element, A>(_nil);
+#endif
+		}
+	};
+
+	_Data _data;
+
+	inline void _set_color(Element *p_node, int p_color) {
+		ERR_FAIL_COND(p_node == _data._nil && p_color == RED);
+		p_node->color = p_color;
+	}
+
+	inline void _rotate_left(Element *p_node) {
+		Element *r = p_node->right;
+		p_node->right = r->left;
+		if (r->left != _data._nil) {
+			r->left->parent = p_node;
+		}
+		r->parent = p_node->parent;
+		if (p_node == p_node->parent->left) {
+			p_node->parent->left = r;
+		} else {
+			p_node->parent->right = r;
+		}
+
+		r->left = p_node;
+		p_node->parent = r;
+	}
+
+	inline void _rotate_right(Element *p_node) {
+		Element *l = p_node->left;
+		p_node->left = l->right;
+		if (l->right != _data._nil) {
+			l->right->parent = p_node;
+		}
+		l->parent = p_node->parent;
+		if (p_node == p_node->parent->right) {
+			p_node->parent->right = l;
+		} else {
+			p_node->parent->left = l;
+		}
+
+		l->right = p_node;
+		p_node->parent = l;
+	}
+
+	inline Element *_successor(Element *p_node) const {
+		Element *node = p_node;
+
+		if (node->right != _data._nil) {
+			node = node->right;
+			while (node->left != _data._nil) { /* returns the minimum of the right subtree of node */
+				node = node->left;
+			}
+			return node;
+		} else {
+			while (node == node->parent->right) {
+				node = node->parent;
+			}
+
+			if (node->parent == _data._root) {
+				return nullptr; // No successor, as p_node = last node
+			}
+			return node->parent;
+		}
+	}
+
+	inline Element *_predecessor(Element *p_node) const {
+		Element *node = p_node;
+
+		if (node->left != _data._nil) {
+			node = node->left;
+			while (node->right != _data._nil) { /* returns the minimum of the left subtree of node */
+				node = node->right;
+			}
+			return node;
+		} else {
+			while (node == node->parent->left) {
+				node = node->parent;
+			}
+
+			if (node == _data._root) {
+				return nullptr; // No predecessor, as p_node = first node
+			}
+			return node->parent;
+		}
+	}
+
+	Element *_find(const K &p_key) const {
+		Element *node = _data._root->left;
+		C less;
+
+		while (node != _data._nil) {
+			if (less(p_key, node->_key)) {
+				node = node->left;
+			} else if (less(node->_key, p_key)) {
+				node = node->right;
+			} else {
+				return node; // found
+			}
+		}
+
+		return nullptr;
+	}
+
+	Element *_find_closest(const K &p_key) const {
+		Element *node = _data._root->left;
+		Element *prev = nullptr;
+		C less;
+
+		while (node != _data._nil) {
+			prev = node;
+
+			if (less(p_key, node->_key)) {
+				node = node->left;
+			} else if (less(node->_key, p_key)) {
+				node = node->right;
+			} else {
+				return node; // found
+			}
+		}
+
+		if (prev == nullptr) {
+			return nullptr; // tree empty
+		}
+
+		if (less(p_key, prev->_key)) {
+			prev = prev->_prev;
+		}
+
+		return prev;
+	}
+
+	void _insert_rb_fix(Element *p_new_node) {
+		Element *node = p_new_node;
+		Element *nparent = node->parent;
+		Element *ngrand_parent;
+
+		while (nparent->color == RED) {
+			ngrand_parent = nparent->parent;
+
+			if (nparent == ngrand_parent->left) {
+				if (ngrand_parent->right->color == RED) {
+					_set_color(nparent, BLACK);
+					_set_color(ngrand_parent->right, BLACK);
+					_set_color(ngrand_parent, RED);
+					node = ngrand_parent;
+					nparent = node->parent;
+				} else {
+					if (node == nparent->right) {
+						_rotate_left(nparent);
+						node = nparent;
+						nparent = node->parent;
+					}
+					_set_color(nparent, BLACK);
+					_set_color(ngrand_parent, RED);
+					_rotate_right(ngrand_parent);
+				}
+			} else {
+				if (ngrand_parent->left->color == RED) {
+					_set_color(nparent, BLACK);
+					_set_color(ngrand_parent->left, BLACK);
+					_set_color(ngrand_parent, RED);
+					node = ngrand_parent;
+					nparent = node->parent;
+				} else {
+					if (node == nparent->left) {
+						_rotate_right(nparent);
+						node = nparent;
+						nparent = node->parent;
+					}
+					_set_color(nparent, BLACK);
+					_set_color(ngrand_parent, RED);
+					_rotate_left(ngrand_parent);
+				}
+			}
+		}
+
+		_set_color(_data._root->left, BLACK);
+	}
+
+	Element *_insert(const K &p_key, const V &p_value) {
+		Element *new_parent = _data._root;
+		Element *node = _data._root->left;
+		C less;
+
+		while (node != _data._nil) {
+			new_parent = node;
+
+			if (less(p_key, node->_key)) {
+				node = node->left;
+			} else if (less(node->_key, p_key)) {
+				node = node->right;
+			} else {
+				node->_value = p_value;
+				return node; // Return existing node with new value
+			}
+		}
+
+		Element *new_node = memnew_allocator(Element, A);
+		new_node->parent = new_parent;
+		new_node->right = _data._nil;
+		new_node->left = _data._nil;
+		new_node->_key = p_key;
+		new_node->_value = p_value;
+		//new_node->data=_data;
+
+		if (new_parent == _data._root || less(p_key, new_parent->_key)) {
+			new_parent->left = new_node;
+		} else {
+			new_parent->right = new_node;
+		}
+
+		new_node->_next = _successor(new_node);
+		new_node->_prev = _predecessor(new_node);
+		if (new_node->_next) {
+			new_node->_next->_prev = new_node;
+		}
+		if (new_node->_prev) {
+			new_node->_prev->_next = new_node;
+		}
+
+		_data.size_cache++;
+		_insert_rb_fix(new_node);
+		return new_node;
+	}
+
+	void _erase_fix_rb(Element *p_node) {
+		Element *root = _data._root->left;
+		Element *node = _data._nil;
+		Element *sibling = p_node;
+		Element *parent = sibling->parent;
+
+		while (node != root) { // If red node found, will exit at a break
+			if (sibling->color == RED) {
+				_set_color(sibling, BLACK);
+				_set_color(parent, RED);
+				if (sibling == parent->right) {
+					sibling = sibling->left;
+					_rotate_left(parent);
+				} else {
+					sibling = sibling->right;
+					_rotate_right(parent);
+				}
+			}
+			if ((sibling->left->color == BLACK) && (sibling->right->color == BLACK)) {
+				_set_color(sibling, RED);
+				if (parent->color == RED) {
+					_set_color(parent, BLACK);
+					break;
+				} else { // loop: haven't found any red nodes yet
+					node = parent;
+					parent = node->parent;
+					sibling = (node == parent->left) ? parent->right : parent->left;
+				}
+			} else {
+				if (sibling == parent->right) {
+					if (sibling->right->color == BLACK) {
+						_set_color(sibling->left, BLACK);
+						_set_color(sibling, RED);
+						_rotate_right(sibling);
+						sibling = sibling->parent;
+					}
+					_set_color(sibling, parent->color);
+					_set_color(parent, BLACK);
+					_set_color(sibling->right, BLACK);
+					_rotate_left(parent);
+					break;
+				} else {
+					if (sibling->left->color == BLACK) {
+						_set_color(sibling->right, BLACK);
+						_set_color(sibling, RED);
+						_rotate_left(sibling);
+						sibling = sibling->parent;
+					}
+
+					_set_color(sibling, parent->color);
+					_set_color(parent, BLACK);
+					_set_color(sibling->left, BLACK);
+					_rotate_right(parent);
+					break;
+				}
+			}
+		}
+
+		ERR_FAIL_COND(_data._nil->color != BLACK);
+	}
+
+	void _erase(Element *p_node) {
+		Element *rp = ((p_node->left == _data._nil) || (p_node->right == _data._nil)) ? p_node : p_node->_next;
+		Element *node = (rp->left == _data._nil) ? rp->right : rp->left;
+
+		Element *sibling;
+		if (rp == rp->parent->left) {
+			rp->parent->left = node;
+			sibling = rp->parent->right;
+		} else {
+			rp->parent->right = node;
+			sibling = rp->parent->left;
+		}
+
+		if (node->color == RED) {
+			node->parent = rp->parent;
+			_set_color(node, BLACK);
+		} else if (rp->color == BLACK && rp->parent != _data._root) {
+			_erase_fix_rb(sibling);
+		}
+
+		if (rp != p_node) {
+			ERR_FAIL_COND(rp == _data._nil);
+
+			rp->left = p_node->left;
+			rp->right = p_node->right;
+			rp->parent = p_node->parent;
+			rp->color = p_node->color;
+			if (p_node->left != _data._nil) {
+				p_node->left->parent = rp;
+			}
+			if (p_node->right != _data._nil) {
+				p_node->right->parent = rp;
+			}
+
+			if (p_node == p_node->parent->left) {
+				p_node->parent->left = rp;
+			} else {
+				p_node->parent->right = rp;
+			}
+		}
+
+		if (p_node->_next) {
+			p_node->_next->_prev = p_node->_prev;
+		}
+		if (p_node->_prev) {
+			p_node->_prev->_next = p_node->_next;
+		}
+
+		memdelete_allocator<Element, A>(p_node);
+		_data.size_cache--;
+		ERR_FAIL_COND(_data._nil->color == RED);
+	}
+
+	void _calculate_depth(Element *p_element, int &max_d, int d) const {
+		if (p_element == _data._nil) {
+			return;
+		}
+
+		_calculate_depth(p_element->left, max_d, d + 1);
+		_calculate_depth(p_element->right, max_d, d + 1);
+
+		if (d > max_d) {
+			max_d = d;
+		}
+	}
+
+	void _cleanup_tree(Element *p_element) {
+		if (p_element == _data._nil) {
+			return;
+		}
+
+		_cleanup_tree(p_element->left);
+		_cleanup_tree(p_element->right);
+		memdelete_allocator<Element, A>(p_element);
+	}
+
+	void _copy_from(const Map &p_map) {
+		clear();
+		// not the fastest way, but safeset to write.
+		for (Element *I = p_map.front(); I; I = I->next()) {
+			insert(I->key(), I->value());
+		}
+	}
+
+public:
+	const Element *find(const K &p_key) const {
+		if (!_data._root) {
+			return nullptr;
+		}
+
+		const Element *res = _find(p_key);
+		return res;
+	}
+
+	Element *find(const K &p_key) {
+		if (!_data._root) {
+			return nullptr;
+		}
+
+		Element *res = _find(p_key);
+		return res;
+	}
+
+	const Element *find_closest(const K &p_key) const {
+		if (!_data._root) {
+			return NULL;
+		}
+
+		const Element *res = _find_closest(p_key);
+		return res;
+	}
+
+	Element *find_closest(const K &p_key) {
+		if (!_data._root) {
+			return nullptr;
+		}
+
+		Element *res = _find_closest(p_key);
+		return res;
+	}
+
+	bool has(const K &p_key) const {
+		return find(p_key) != nullptr;
+	}
+
+	Element *insert(const K &p_key, const V &p_value) {
+		if (!_data._root) {
+			_data._create_root();
+		}
+		return _insert(p_key, p_value);
+	}
+
+	void erase(Element *p_element) {
+		if (!_data._root || !p_element) {
+			return;
+		}
+
+		_erase(p_element);
+		if (_data.size_cache == 0 && _data._root) {
+			_data._free_root();
+		}
+	}
+
+	bool erase(const K &p_key) {
+		if (!_data._root) {
+			return false;
+		}
+
+		Element *e = find(p_key);
+		if (!e) {
+			return false;
+		}
+
+		_erase(e);
+		if (_data.size_cache == 0 && _data._root) {
+			_data._free_root();
+		}
+		return true;
+	}
+
+	const V &operator[](const K &p_key) const {
+		CRASH_COND(!_data._root);
+		const Element *e = find(p_key);
+		CRASH_COND(!e);
+		return e->_value;
+	}
+
+	V &operator[](const K &p_key) {
+		if (!_data._root) {
+			_data._create_root();
+		}
+
+		Element *e = find(p_key);
+		if (!e) {
+			e = insert(p_key, V());
+		}
+
+		return e->_value;
+	}
+
+	Element *front() const {
+		if (!_data._root) {
+			return nullptr;
+		}
+
+		Element *e = _data._root->left;
+		if (e == _data._nil) {
+			return nullptr;
+		}
+
+		while (e->left != _data._nil) {
+			e = e->left;
+		}
+
+		return e;
+	}
+
+	Element *back() const {
+		if (!_data._root) {
+			return nullptr;
+		}
+
+		Element *e = _data._root->left;
+		if (e == _data._nil) {
+			return nullptr;
+		}
+
+		while (e->right != _data._nil) {
+			e = e->right;
+		}
+
+		return e;
+	}
+
+	inline bool empty() const { return _data.size_cache == 0; }
+	inline int size() const { return _data.size_cache; }
+
+	int calculate_depth() const {
+		// used for debug mostly
+		if (!_data._root) {
+			return 0;
+		}
+
+		int max_d = 0;
+		_calculate_depth(_data._root->left, max_d, 0);
+		return max_d;
+	}
+
+	void clear() {
+		if (!_data._root) {
+			return;
+		}
+
+		_cleanup_tree(_data._root->left);
+		_data._root->left = _data._nil;
+		_data.size_cache = 0;
+		_data._free_root();
+	}
+
+	void operator=(const Map &p_map) {
+		_copy_from(p_map);
+	}
+
+	Map(const Map &p_map) {
+		_copy_from(p_map);
+	}
+
+	_FORCE_INLINE_ Map() {
+	}
+
+	~Map() {
+		clear();
+	}
+};
+
+#endif // MAP_H

--- a/patches/ustring.cpp.patched
+++ b/patches/ustring.cpp.patched
@@ -1,0 +1,5154 @@
+/**************************************************************************/
+/*  ustring.cpp                                                           */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/**************************************************************************/
+
+#include "ustring.h"
+
+#include "core/crypto/crypto_core.h"
+#include "core/math/color.h"
+#include "core/math/math_funcs.h"
+#include "core/os/memory.h"
+#include "core/string/print_string.h"
+#include "core/string/string_name.h"
+#include "core/string/translation.h"
+#include "core/string/ucaps.h"
+#include "core/variant/variant.h"
+#include "core/version_generated.gen.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <cstdint>
+
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS // to disable build-time warning which suggested to use strcpy_s instead strcpy
+#endif
+
+#if defined(MINGW_ENABLED) || defined(_MSC_VER)
+#define snprintf _snprintf_s
+#endif
+
+static const int MAX_DECIMALS = 32;
+
+static _FORCE_INLINE_ char32_t lower_case(char32_t c) {
+	return (is_ascii_upper_case(c) ? (c + ('a' - 'A')) : c);
+}
+
+const char CharString::_null = 0;
+const char16_t Char16String::_null = 0;
+const char32_t String::_null = 0;
+
+bool select_word(const String &p_s, int p_col, int &r_beg, int &r_end) {
+	const String &s = p_s;
+	int beg = CLAMP(p_col, 0, s.length());
+	int end = beg;
+
+	if (s[beg] > 32 || beg == s.length()) {
+		bool symbol = beg < s.length() && is_symbol(s[beg]);
+
+		while (beg > 0 && s[beg - 1] > 32 && (symbol == is_symbol(s[beg - 1]))) {
+			beg--;
+		}
+		while (end < s.length() && s[end + 1] > 32 && (symbol == is_symbol(s[end + 1]))) {
+			end++;
+		}
+
+		if (end < s.length()) {
+			end += 1;
+		}
+
+		r_beg = beg;
+		r_end = end;
+
+		return true;
+	} else {
+		return false;
+	}
+}
+
+/*************************************************************************/
+/*  Char16String                                                         */
+/*************************************************************************/
+
+bool Char16String::operator<(const Char16String &p_right) const {
+	if (length() == 0) {
+		return p_right.length() != 0;
+	}
+
+	return is_str_less(get_data(), p_right.get_data());
+}
+
+Char16String &Char16String::operator+=(char16_t p_char) {
+	const int lhs_len = length();
+	resize(lhs_len + 2);
+
+	char16_t *dst = ptrw();
+	dst[lhs_len] = p_char;
+	dst[lhs_len + 1] = 0;
+
+	return *this;
+}
+
+void Char16String::operator=(const char16_t *p_cstr) {
+	copy_from(p_cstr);
+}
+
+const char16_t *Char16String::get_data() const {
+	if (size()) {
+		return &operator[](0);
+	} else {
+		return u"";
+	}
+}
+
+void Char16String::copy_from(const char16_t *p_cstr) {
+	if (!p_cstr) {
+		resize(0);
+		return;
+	}
+
+	const char16_t *s = p_cstr;
+	for (; *s; s++) {
+	}
+	size_t len = s - p_cstr;
+
+	if (len == 0) {
+		resize(0);
+		return;
+	}
+
+	Error err = resize(++len); // include terminating null char
+
+	ERR_FAIL_COND_MSG(err != OK, "Failed to copy char16_t string.");
+
+	memcpy(ptrw(), p_cstr, len * sizeof(char16_t));
+}
+
+/*************************************************************************/
+/*  CharString                                                           */
+/*************************************************************************/
+
+bool CharString::operator<(const CharString &p_right) const {
+	if (length() == 0) {
+		return p_right.length() != 0;
+	}
+
+	return is_str_less(get_data(), p_right.get_data());
+}
+
+bool CharString::operator==(const CharString &p_right) const {
+	if (length() == 0) {
+		// True if both have length 0, false if only p_right has a length
+		return p_right.length() == 0;
+	} else if (p_right.length() == 0) {
+		// False due to unequal length
+		return false;
+	}
+
+	return strcmp(ptr(), p_right.ptr()) == 0;
+}
+
+CharString &CharString::operator+=(char p_char) {
+	const int lhs_len = length();
+	resize(lhs_len + 2);
+
+	char *dst = ptrw();
+	dst[lhs_len] = p_char;
+	dst[lhs_len + 1] = 0;
+
+	return *this;
+}
+
+void CharString::operator=(const char *p_cstr) {
+	copy_from(p_cstr);
+}
+
+const char *CharString::get_data() const {
+	if (size()) {
+		return &operator[](0);
+	} else {
+		return "";
+	}
+}
+
+void CharString::copy_from(const char *p_cstr) {
+	if (!p_cstr) {
+		resize(0);
+		return;
+	}
+
+	size_t len = strlen(p_cstr);
+
+	if (len == 0) {
+		resize(0);
+		return;
+	}
+
+	Error err = resize(++len); // include terminating null char
+
+	ERR_FAIL_COND_MSG(err != OK, "Failed to copy C-string.");
+
+	memcpy(ptrw(), p_cstr, len);
+}
+
+/*************************************************************************/
+/*  String                                                               */
+/*************************************************************************/
+
+Error String::parse_url(String &r_scheme, String &r_host, int &r_port, String &r_path) const {
+	// Splits the URL into scheme, host, port, path. Strip credentials when present.
+	String base = *this;
+	r_scheme = "";
+	r_host = "";
+	r_port = 0;
+	r_path = "";
+	int pos = base.find("://");
+	// Scheme
+	if (pos != -1) {
+		r_scheme = base.substr(0, pos + 3).to_lower();
+		base = base.substr(pos + 3, base.length() - pos - 3);
+	}
+	pos = base.find("/");
+	// Path
+	if (pos != -1) {
+		r_path = base.substr(pos, base.length() - pos);
+		base = base.substr(0, pos);
+	}
+	// Host
+	pos = base.find("@");
+	if (pos != -1) {
+		// Strip credentials
+		base = base.substr(pos + 1, base.length() - pos - 1);
+	}
+	if (base.begins_with("[")) {
+		// Literal IPv6
+		pos = base.rfind("]");
+		if (pos == -1) {
+			return ERR_INVALID_PARAMETER;
+		}
+		r_host = base.substr(1, pos - 1);
+		base = base.substr(pos + 1, base.length() - pos - 1);
+	} else {
+		// Anything else
+		if (base.get_slice_count(":") > 2) {
+			return ERR_INVALID_PARAMETER;
+		}
+		pos = base.rfind(":");
+		if (pos == -1) {
+			r_host = base;
+			base = "";
+		} else {
+			r_host = base.substr(0, pos);
+			base = base.substr(pos, base.length() - pos);
+		}
+	}
+	if (r_host.is_empty()) {
+		return ERR_INVALID_PARAMETER;
+	}
+	r_host = r_host.to_lower();
+	// Port
+	if (base.begins_with(":")) {
+		base = base.substr(1, base.length() - 1);
+		if (!base.is_valid_int()) {
+			return ERR_INVALID_PARAMETER;
+		}
+		r_port = base.to_int();
+		if (r_port < 1 || r_port > 65535) {
+			return ERR_INVALID_PARAMETER;
+		}
+	}
+	return OK;
+}
+
+void String::copy_from(const char *p_cstr) {
+	// copy Latin-1 encoded c-string directly
+	if (!p_cstr) {
+		resize(0);
+		return;
+	}
+
+	const size_t len = strlen(p_cstr);
+
+	if (len == 0) {
+		resize(0);
+		return;
+	}
+
+	resize(len + 1); // include 0
+
+	char32_t *dst = this->ptrw();
+
+	for (size_t i = 0; i <= len; i++) {
+		uint8_t c = p_cstr[i] >= 0 ? p_cstr[i] : uint8_t(256 + p_cstr[i]);
+		if (c == 0 && i < len) {
+			print_unicode_error("NUL character", true);
+			dst[i] = 0x20;
+		} else {
+			dst[i] = c;
+		}
+	}
+}
+
+void String::copy_from(const char *p_cstr, const int p_clip_to) {
+	// copy Latin-1 encoded c-string directly
+	if (!p_cstr) {
+		resize(0);
+		return;
+	}
+
+	int len = 0;
+	const char *ptr = p_cstr;
+	while ((p_clip_to < 0 || len < p_clip_to) && *(ptr++) != 0) {
+		len++;
+	}
+
+	if (len == 0) {
+		resize(0);
+		return;
+	}
+
+	resize(len + 1); // include 0
+
+	char32_t *dst = this->ptrw();
+
+	for (int i = 0; i < len; i++) {
+		uint8_t c = p_cstr[i] >= 0 ? p_cstr[i] : uint8_t(256 + p_cstr[i]);
+		if (c == 0) {
+			print_unicode_error("NUL character", true);
+			dst[i] = 0x20;
+		} else {
+			dst[i] = c;
+		}
+	}
+	dst[len] = 0;
+}
+
+void String::copy_from(const wchar_t *p_cstr) {
+#ifdef WINDOWS_ENABLED
+	// wchar_t is 16-bit, parse as UTF-16
+	parse_utf16((const char16_t *)p_cstr);
+#else
+	// wchar_t is 32-bit, copy directly
+	copy_from((const char32_t *)p_cstr);
+#endif
+}
+
+void String::copy_from(const wchar_t *p_cstr, const int p_clip_to) {
+#ifdef WINDOWS_ENABLED
+	// wchar_t is 16-bit, parse as UTF-16
+	parse_utf16((const char16_t *)p_cstr, p_clip_to);
+#else
+	// wchar_t is 32-bit, copy directly
+	copy_from((const char32_t *)p_cstr, p_clip_to);
+#endif
+}
+
+void String::copy_from(const char32_t &p_char) {
+	if (p_char == 0) {
+		print_unicode_error("NUL character", true);
+		return;
+	}
+	if ((p_char & 0xfffff800) == 0xd800) {
+		print_unicode_error(vformat("Unpaired surrogate (%x)", (uint32_t)p_char));
+	}
+	if (p_char > 0x10ffff) {
+		print_unicode_error(vformat("Invalid unicode codepoint (%x)", (uint32_t)p_char));
+	}
+
+	resize(2);
+
+	char32_t *dst = ptrw();
+	dst[0] = p_char;
+	dst[1] = 0;
+}
+
+void String::copy_from(const char32_t *p_cstr) {
+	if (!p_cstr) {
+		resize(0);
+		return;
+	}
+
+	int len = 0;
+	const char32_t *ptr = p_cstr;
+	while (*(ptr++) != 0) {
+		len++;
+	}
+
+	if (len == 0) {
+		resize(0);
+		return;
+	}
+
+	copy_from_unchecked(p_cstr, len);
+}
+
+void String::copy_from(const char32_t *p_cstr, const int p_clip_to) {
+	if (!p_cstr) {
+		resize(0);
+		return;
+	}
+
+	int len = 0;
+	const char32_t *ptr = p_cstr;
+	while ((p_clip_to < 0 || len < p_clip_to) && *(ptr++) != 0) {
+		len++;
+	}
+
+	if (len == 0) {
+		resize(0);
+		return;
+	}
+
+	copy_from_unchecked(p_cstr, len);
+}
+
+// assumes the following have already been validated:
+// p_char != nullptr
+// p_length > 0
+// p_length <= p_char strlen
+void String::copy_from_unchecked(const char32_t *p_char, const int p_length) {
+	resize(p_length + 1);
+	char32_t *dst = ptrw();
+	dst[p_length] = 0;
+
+	for (int i = 0; i < p_length; i++) {
+		if (p_char[i] == 0) {
+			print_unicode_error("NUL character", true);
+			dst[i] = 0x20;
+			continue;
+		}
+		if ((p_char[i] & 0xfffff800) == 0xd800) {
+			print_unicode_error(vformat("Unpaired surrogate (%x)", (uint32_t)p_char[i]));
+		}
+		if (p_char[i] > 0x10ffff) {
+			print_unicode_error(vformat("Invalid unicode codepoint (%x)", (uint32_t)p_char[i]));
+		}
+		dst[i] = p_char[i];
+	}
+}
+
+void String::operator=(const char *p_str) {
+	copy_from(p_str);
+}
+
+void String::operator=(const char32_t *p_str) {
+	copy_from(p_str);
+}
+
+void String::operator=(const wchar_t *p_str) {
+	copy_from(p_str);
+}
+
+String String::operator+(const String &p_str) const {
+	String res = *this;
+	res += p_str;
+	return res;
+}
+
+String String::operator+(char32_t p_char) const {
+	String res = *this;
+	res += p_char;
+	return res;
+}
+
+String operator+(const char *p_chr, const String &p_str) {
+	String tmp = p_chr;
+	tmp += p_str;
+	return tmp;
+}
+
+String operator+(const wchar_t *p_chr, const String &p_str) {
+#ifdef WINDOWS_ENABLED
+	// wchar_t is 16-bit
+	String tmp = String::utf16((const char16_t *)p_chr);
+#else
+	// wchar_t is 32-bit
+	String tmp = (const char32_t *)p_chr;
+#endif
+	tmp += p_str;
+	return tmp;
+}
+
+String operator+(char32_t p_chr, const String &p_str) {
+	return (String::chr(p_chr) + p_str);
+}
+
+String &String::operator+=(const String &p_str) {
+	const int lhs_len = length();
+	if (lhs_len == 0) {
+		*this = p_str;
+		return *this;
+	}
+
+	const int rhs_len = p_str.length();
+	if (rhs_len == 0) {
+		return *this;
+	}
+
+	resize(lhs_len + rhs_len + 1);
+
+	const char32_t *src = p_str.ptr();
+	char32_t *dst = ptrw() + lhs_len;
+
+	// Don't copy the terminating null with `memcpy` to avoid undefined behavior when string is being added to itself (it would overlap the destination).
+	memcpy(dst, src, rhs_len * sizeof(char32_t));
+	*(dst + rhs_len) = _null;
+
+	return *this;
+}
+
+String &String::operator+=(const char *p_str) {
+	if (!p_str || p_str[0] == 0) {
+		return *this;
+	}
+
+	const int lhs_len = length();
+	const size_t rhs_len = strlen(p_str);
+
+	resize(lhs_len + rhs_len + 1);
+
+	char32_t *dst = ptrw() + lhs_len;
+
+	for (size_t i = 0; i <= rhs_len; i++) {
+		uint8_t c = p_str[i] >= 0 ? p_str[i] : uint8_t(256 + p_str[i]);
+		if (c == 0 && i < rhs_len) {
+			print_unicode_error("NUL character", true);
+			dst[i] = 0x20;
+		} else {
+			dst[i] = c;
+		}
+	}
+
+	return *this;
+}
+
+String &String::operator+=(const wchar_t *p_str) {
+#ifdef WINDOWS_ENABLED
+	// wchar_t is 16-bit
+	*this += String::utf16((const char16_t *)p_str);
+#else
+	// wchar_t is 32-bit
+	*this += String((const char32_t *)p_str);
+#endif
+	return *this;
+}
+
+String &String::operator+=(const char32_t *p_str) {
+	*this += String(p_str);
+	return *this;
+}
+
+String &String::operator+=(char32_t p_char) {
+	if (p_char == 0) {
+		print_unicode_error("NUL character", true);
+		return *this;
+	}
+	if ((p_char & 0xfffff800) == 0xd800) {
+		print_unicode_error(vformat("Unpaired surrogate (%x)", (uint32_t)p_char));
+	}
+	if (p_char > 0x10ffff) {
+		print_unicode_error(vformat("Invalid unicode codepoint (%x)", (uint32_t)p_char));
+	}
+
+	const int lhs_len = length();
+	resize(lhs_len + 2);
+	char32_t *dst = ptrw();
+	dst[lhs_len] = p_char;
+	dst[lhs_len + 1] = 0;
+
+	return *this;
+}
+
+bool String::operator==(const char *p_str) const {
+	// compare Latin-1 encoded c-string
+	int len = 0;
+	const char *aux = p_str;
+
+	while (*(aux++) != 0) {
+		len++;
+	}
+
+	if (length() != len) {
+		return false;
+	}
+	if (is_empty()) {
+		return true;
+	}
+
+	int l = length();
+
+	const char32_t *dst = get_data();
+
+	// Compare char by char
+	for (int i = 0; i < l; i++) {
+		if ((char32_t)p_str[i] != dst[i]) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool String::operator==(const wchar_t *p_str) const {
+#ifdef WINDOWS_ENABLED
+	// wchar_t is 16-bit, parse as UTF-16
+	return *this == String::utf16((const char16_t *)p_str);
+#else
+	// wchar_t is 32-bit, compare char by char
+	return *this == (const char32_t *)p_str;
+#endif
+}
+
+bool String::operator==(const char32_t *p_str) const {
+	int len = 0;
+	const char32_t *aux = p_str;
+
+	while (*(aux++) != 0) {
+		len++;
+	}
+
+	if (length() != len) {
+		return false;
+	}
+	if (is_empty()) {
+		return true;
+	}
+
+	int l = length();
+
+	const char32_t *dst = get_data();
+
+	/* Compare char by char */
+	for (int i = 0; i < l; i++) {
+		if (p_str[i] != dst[i]) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool String::operator==(const String &p_str) const {
+	if (length() != p_str.length()) {
+		return false;
+	}
+	if (is_empty()) {
+		return true;
+	}
+
+	int l = length();
+
+	const char32_t *src = get_data();
+	const char32_t *dst = p_str.get_data();
+
+	/* Compare char by char */
+	for (int i = 0; i < l; i++) {
+		if (src[i] != dst[i]) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool String::operator==(const StrRange &p_str_range) const {
+	int len = p_str_range.len;
+
+	if (length() != len) {
+		return false;
+	}
+	if (is_empty()) {
+		return true;
+	}
+
+	const char32_t *c_str = p_str_range.c_str;
+	const char32_t *dst = &operator[](0);
+
+	/* Compare char by char */
+	for (int i = 0; i < len; i++) {
+		if (c_str[i] != dst[i]) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool operator==(const char *p_chr, const String &p_str) {
+	return p_str == p_chr;
+}
+
+bool operator==(const wchar_t *p_chr, const String &p_str) {
+#ifdef WINDOWS_ENABLED
+	// wchar_t is 16-bit
+	return p_str == String::utf16((const char16_t *)p_chr);
+#else
+	// wchar_t is 32-bi
+	return p_str == String((const char32_t *)p_chr);
+#endif
+}
+
+bool operator!=(const char *p_chr, const String &p_str) {
+	return !(p_str == p_chr);
+}
+
+bool operator!=(const wchar_t *p_chr, const String &p_str) {
+#ifdef WINDOWS_ENABLED
+	// wchar_t is 16-bit
+	return !(p_str == String::utf16((const char16_t *)p_chr));
+#else
+	// wchar_t is 32-bi
+	return !(p_str == String((const char32_t *)p_chr));
+#endif
+}
+
+bool String::operator!=(const char *p_str) const {
+	return (!(*this == p_str));
+}
+
+bool String::operator!=(const wchar_t *p_str) const {
+	return (!(*this == p_str));
+}
+
+bool String::operator!=(const char32_t *p_str) const {
+	return (!(*this == p_str));
+}
+
+bool String::operator!=(const String &p_str) const {
+	return !((*this == p_str));
+}
+
+bool String::operator<=(const String &p_str) const {
+	return !(p_str < *this);
+}
+
+bool String::operator>(const String &p_str) const {
+	return p_str < *this;
+}
+
+bool String::operator>=(const String &p_str) const {
+	return !(*this < p_str);
+}
+
+bool String::operator<(const char *p_str) const {
+	if (is_empty() && p_str[0] == 0) {
+		return false;
+	}
+	if (is_empty()) {
+		return true;
+	}
+	return is_str_less(get_data(), p_str);
+}
+
+bool String::operator<(const wchar_t *p_str) const {
+	if (is_empty() && p_str[0] == 0) {
+		return false;
+	}
+	if (is_empty()) {
+		return true;
+	}
+
+#ifdef WINDOWS_ENABLED
+	// wchar_t is 16-bit
+	return is_str_less(get_data(), String::utf16((const char16_t *)p_str).get_data());
+#else
+	// wchar_t is 32-bit
+	return is_str_less(get_data(), (const char32_t *)p_str);
+#endif
+}
+
+bool String::operator<(const char32_t *p_str) const {
+	if (is_empty() && p_str[0] == 0) {
+		return false;
+	}
+	if (is_empty()) {
+		return true;
+	}
+
+	return is_str_less(get_data(), p_str);
+}
+
+bool String::operator<(const String &p_str) const {
+	return operator<(p_str.get_data());
+}
+
+signed char String::nocasecmp_to(const String &p_str) const {
+	if (is_empty() && p_str.is_empty()) {
+		return 0;
+	}
+	if (is_empty()) {
+		return -1;
+	}
+	if (p_str.is_empty()) {
+		return 1;
+	}
+
+	const char32_t *that_str = p_str.get_data();
+	const char32_t *this_str = get_data();
+
+	while (true) {
+		if (*that_str == 0 && *this_str == 0) {
+			return 0; //we're equal
+		} else if (*this_str == 0) {
+			return -1; //if this is empty, and the other one is not, then we're less.. I think?
+		} else if (*that_str == 0) {
+			return 1; //otherwise the other one is smaller..
+		} else if (_find_upper(*this_str) < _find_upper(*that_str)) { //more than
+			return -1;
+		} else if (_find_upper(*this_str) > _find_upper(*that_str)) { //less than
+			return 1;
+		}
+
+		this_str++;
+		that_str++;
+	}
+}
+
+signed char String::casecmp_to(const String &p_str) const {
+	if (is_empty() && p_str.is_empty()) {
+		return 0;
+	}
+	if (is_empty()) {
+		return -1;
+	}
+	if (p_str.is_empty()) {
+		return 1;
+	}
+
+	const char32_t *that_str = p_str.get_data();
+	const char32_t *this_str = get_data();
+
+	while (true) {
+		if (*that_str == 0 && *this_str == 0) {
+			return 0; //we're equal
+		} else if (*this_str == 0) {
+			return -1; //if this is empty, and the other one is not, then we're less.. I think?
+		} else if (*that_str == 0) {
+			return 1; //otherwise the other one is smaller..
+		} else if (*this_str < *that_str) { //more than
+			return -1;
+		} else if (*this_str > *that_str) { //less than
+			return 1;
+		}
+
+		this_str++;
+		that_str++;
+	}
+}
+
+signed char String::naturalnocasecmp_to(const String &p_str) const {
+	const char32_t *this_str = get_data();
+	const char32_t *that_str = p_str.get_data();
+
+	if (this_str && that_str) {
+		while (*this_str == '.' || *that_str == '.') {
+			if (*this_str++ != '.') {
+				return 1;
+			}
+			if (*that_str++ != '.') {
+				return -1;
+			}
+			if (!*that_str) {
+				return 1;
+			}
+			if (!*this_str) {
+				return -1;
+			}
+		}
+
+		while (*this_str) {
+			if (!*that_str) {
+				return 1;
+			} else if (is_digit(*this_str)) {
+				if (!is_digit(*that_str)) {
+					return -1;
+				}
+
+				// Keep ptrs to start of numerical sequences
+				const char32_t *this_substr = this_str;
+				const char32_t *that_substr = that_str;
+
+				// Compare lengths of both numerical sequences, ignoring leading zeros
+				while (is_digit(*this_str)) {
+					this_str++;
+				}
+				while (is_digit(*that_str)) {
+					that_str++;
+				}
+				while (*this_substr == '0') {
+					this_substr++;
+				}
+				while (*that_substr == '0') {
+					that_substr++;
+				}
+				int this_len = this_str - this_substr;
+				int that_len = that_str - that_substr;
+
+				if (this_len < that_len) {
+					return -1;
+				} else if (this_len > that_len) {
+					return 1;
+				}
+
+				// If lengths equal, compare lexicographically
+				while (this_substr != this_str && that_substr != that_str) {
+					if (*this_substr < *that_substr) {
+						return -1;
+					} else if (*this_substr > *that_substr) {
+						return 1;
+					}
+					this_substr++;
+					that_substr++;
+				}
+			} else if (is_digit(*that_str)) {
+				return 1;
+			} else {
+				if (_find_upper(*this_str) < _find_upper(*that_str)) { //more than
+					return -1;
+				} else if (_find_upper(*this_str) > _find_upper(*that_str)) { //less than
+					return 1;
+				}
+
+				this_str++;
+				that_str++;
+			}
+		}
+		if (*that_str) {
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+const char32_t *String::get_data() const {
+	static const char32_t zero = 0;
+	return size() ? &operator[](0) : &zero;
+}
+
+String String::_camelcase_to_underscore() const {
+	const char32_t *cstr = get_data();
+	String new_string;
+	int start_index = 0;
+
+	for (int i = 1; i < this->size(); i++) {
+		bool is_prev_upper = is_ascii_upper_case(cstr[i - 1]);
+		bool is_prev_lower = is_ascii_lower_case(cstr[i - 1]);
+		bool is_prev_digit = is_digit(cstr[i - 1]);
+
+		bool is_curr_upper = is_ascii_upper_case(cstr[i]);
+		bool is_curr_lower = is_ascii_lower_case(cstr[i]);
+		bool is_curr_digit = is_digit(cstr[i]);
+
+		bool is_next_lower = false;
+		if (i + 1 < this->size()) {
+			is_next_lower = is_ascii_lower_case(cstr[i + 1]);
+		}
+
+		const bool cond_a = is_prev_lower && is_curr_upper; // aA
+		const bool cond_b = (is_prev_upper || is_prev_digit) && is_curr_upper && is_next_lower; // AAa, 2Aa
+		const bool cond_c = is_prev_digit && is_curr_lower && is_next_lower; // 2aa
+		const bool cond_d = (is_prev_upper || is_prev_lower) && is_curr_digit; // A2, a2
+
+		if (cond_a || cond_b || cond_c || cond_d) {
+			new_string += this->substr(start_index, i - start_index) + "_";
+			start_index = i;
+		}
+	}
+
+	new_string += this->substr(start_index, this->size() - start_index);
+	return new_string.to_lower();
+}
+
+String String::capitalize() const {
+	String aux = this->_camelcase_to_underscore().replace("_", " ").strip_edges();
+	String cap;
+	for (int i = 0; i < aux.get_slice_count(" "); i++) {
+		String slice = aux.get_slicec(' ', i);
+		if (slice.length() > 0) {
+			slice[0] = _find_upper(slice[0]);
+			if (i > 0) {
+				cap += " ";
+			}
+			cap += slice;
+		}
+	}
+
+	return cap;
+}
+
+String String::to_camel_case() const {
+	String s = this->to_pascal_case();
+	if (!s.is_empty()) {
+		s[0] = _find_lower(s[0]);
+	}
+	return s;
+}
+
+String String::to_pascal_case() const {
+	return this->capitalize().replace(" ", "");
+}
+
+String String::to_snake_case() const {
+	return this->_camelcase_to_underscore().replace(" ", "_").strip_edges();
+}
+
+String String::get_with_code_lines() const {
+	const Vector<String> lines = split("\n");
+	String ret;
+	for (int i = 0; i < lines.size(); i++) {
+		if (i > 0) {
+			ret += "\n";
+		}
+		ret += vformat("%4d | %s", i + 1, lines[i]);
+	}
+	return ret;
+}
+
+int String::get_slice_count(String p_splitter) const {
+	if (is_empty()) {
+		return 0;
+	}
+	if (p_splitter.is_empty()) {
+		return 0;
+	}
+
+	int pos = 0;
+	int slices = 1;
+
+	while ((pos = find(p_splitter, pos)) >= 0) {
+		slices++;
+		pos += p_splitter.length();
+	}
+
+	return slices;
+}
+
+String String::get_slice(String p_splitter, int p_slice) const {
+	if (is_empty() || p_splitter.is_empty()) {
+		return "";
+	}
+
+	int pos = 0;
+	int prev_pos = 0;
+	//int slices=1;
+	if (p_slice < 0) {
+		return "";
+	}
+	if (find(p_splitter) == -1) {
+		return *this;
+	}
+
+	int i = 0;
+	while (true) {
+		pos = find(p_splitter, pos);
+		if (pos == -1) {
+			pos = length(); //reached end
+		}
+
+		int from = prev_pos;
+		//int to=pos;
+
+		if (p_slice == i) {
+			return substr(from, pos - from);
+		}
+
+		if (pos == length()) { //reached end and no find
+			break;
+		}
+		pos += p_splitter.length();
+		prev_pos = pos;
+		i++;
+	}
+
+	return ""; //no find!
+}
+
+String String::get_slicec(char32_t p_splitter, int p_slice) const {
+	if (is_empty()) {
+		return String();
+	}
+
+	if (p_slice < 0) {
+		return String();
+	}
+
+	const char32_t *c = this->ptr();
+	int i = 0;
+	int prev = 0;
+	int count = 0;
+	while (true) {
+		if (c[i] == 0 || c[i] == p_splitter) {
+			if (p_slice == count) {
+				return substr(prev, i - prev);
+			} else if (c[i] == 0) {
+				return String();
+			} else {
+				count++;
+				prev = i + 1;
+			}
+		}
+
+		i++;
+	}
+}
+
+Vector<String> String::split_spaces() const {
+	Vector<String> ret;
+	int from = 0;
+	int i = 0;
+	int len = length();
+	if (len == 0) {
+		return ret;
+	}
+
+	bool inside = false;
+
+	while (true) {
+		bool empty = operator[](i) < 33;
+
+		if (i == 0) {
+			inside = !empty;
+		}
+
+		if (!empty && !inside) {
+			inside = true;
+			from = i;
+		}
+
+		if (empty && inside) {
+			ret.push_back(substr(from, i - from));
+			inside = false;
+		}
+
+		if (i == len) {
+			break;
+		}
+		i++;
+	}
+
+	return ret;
+}
+
+Vector<String> String::split(const String &p_splitter, bool p_allow_empty, int p_maxsplit) const {
+	Vector<String> ret;
+
+	if (is_empty()) {
+		if (p_allow_empty) {
+			ret.push_back("");
+		}
+		return ret;
+	}
+
+	int from = 0;
+	int len = length();
+
+	while (true) {
+		int end;
+		if (p_splitter.is_empty()) {
+			end = from + 1;
+		} else {
+			end = find(p_splitter, from);
+			if (end < 0) {
+				end = len;
+			}
+		}
+		if (p_allow_empty || (end > from)) {
+			if (p_maxsplit <= 0) {
+				ret.push_back(substr(from, end - from));
+			} else {
+				// Put rest of the string and leave cycle.
+				if (p_maxsplit == ret.size()) {
+					ret.push_back(substr(from, len));
+					break;
+				}
+
+				// Otherwise, push items until positive limit is reached.
+				ret.push_back(substr(from, end - from));
+			}
+		}
+
+		if (end == len) {
+			break;
+		}
+
+		from = end + p_splitter.length();
+	}
+
+	return ret;
+}
+
+Vector<String> String::rsplit(const String &p_splitter, bool p_allow_empty, int p_maxsplit) const {
+	Vector<String> ret;
+	const int len = length();
+	int remaining_len = len;
+
+	while (true) {
+		if (remaining_len < p_splitter.length() || (p_maxsplit > 0 && p_maxsplit == ret.size())) {
+			// no room for another splitter or hit max splits, push what's left and we're done
+			if (p_allow_empty || remaining_len > 0) {
+				ret.push_back(substr(0, remaining_len));
+			}
+			break;
+		}
+
+		int left_edge;
+		if (p_splitter.is_empty()) {
+			left_edge = remaining_len - 1;
+			if (left_edge == 0) {
+				left_edge--; // Skip to the < 0 condition.
+			}
+		} else {
+			left_edge = rfind(p_splitter, remaining_len - p_splitter.length());
+		}
+
+		if (left_edge < 0) {
+			// no more splitters, we're done
+			ret.push_back(substr(0, remaining_len));
+			break;
+		}
+
+		int substr_start = left_edge + p_splitter.length();
+		if (p_allow_empty || substr_start < remaining_len) {
+			ret.push_back(substr(substr_start, remaining_len - substr_start));
+		}
+
+		remaining_len = left_edge;
+	}
+
+	ret.reverse();
+	return ret;
+}
+
+Vector<double> String::split_floats(const String &p_splitter, bool p_allow_empty) const {
+	Vector<double> ret;
+	int from = 0;
+	int len = length();
+
+	while (true) {
+		int end = find(p_splitter, from);
+		if (end < 0) {
+			end = len;
+		}
+		if (p_allow_empty || (end > from)) {
+			ret.push_back(String::to_float(&get_data()[from]));
+		}
+
+		if (end == len) {
+			break;
+		}
+
+		from = end + p_splitter.length();
+	}
+
+	return ret;
+}
+
+Vector<float> String::split_floats_mk(const Vector<String> &p_splitters, bool p_allow_empty) const {
+	Vector<float> ret;
+	int from = 0;
+	int len = length();
+
+	while (true) {
+		int idx;
+		int end = findmk(p_splitters, from, &idx);
+		int spl_len = 1;
+		if (end < 0) {
+			end = len;
+		} else {
+			spl_len = p_splitters[idx].length();
+		}
+
+		if (p_allow_empty || (end > from)) {
+			ret.push_back(String::to_float(&get_data()[from]));
+		}
+
+		if (end == len) {
+			break;
+		}
+
+		from = end + spl_len;
+	}
+
+	return ret;
+}
+
+Vector<int> String::split_ints(const String &p_splitter, bool p_allow_empty) const {
+	Vector<int> ret;
+	int from = 0;
+	int len = length();
+
+	while (true) {
+		int end = find(p_splitter, from);
+		if (end < 0) {
+			end = len;
+		}
+		if (p_allow_empty || (end > from)) {
+			ret.push_back(String::to_int(&get_data()[from], end - from));
+		}
+
+		if (end == len) {
+			break;
+		}
+
+		from = end + p_splitter.length();
+	}
+
+	return ret;
+}
+
+Vector<int> String::split_ints_mk(const Vector<String> &p_splitters, bool p_allow_empty) const {
+	Vector<int> ret;
+	int from = 0;
+	int len = length();
+
+	while (true) {
+		int idx;
+		int end = findmk(p_splitters, from, &idx);
+		int spl_len = 1;
+		if (end < 0) {
+			end = len;
+		} else {
+			spl_len = p_splitters[idx].length();
+		}
+
+		if (p_allow_empty || (end > from)) {
+			ret.push_back(String::to_int(&get_data()[from], end - from));
+		}
+
+		if (end == len) {
+			break;
+		}
+
+		from = end + spl_len;
+	}
+
+	return ret;
+}
+
+String String::join(Vector<String> parts) const {
+	String ret;
+	for (int i = 0; i < parts.size(); ++i) {
+		if (i > 0) {
+			ret += *this;
+		}
+		ret += parts[i];
+	}
+	return ret;
+}
+
+char32_t String::char_uppercase(char32_t p_char) {
+	return _find_upper(p_char);
+}
+
+char32_t String::char_lowercase(char32_t p_char) {
+	return _find_lower(p_char);
+}
+
+String String::to_upper() const {
+	String upper = *this;
+
+	for (int i = 0; i < upper.size(); i++) {
+		const char32_t s = upper[i];
+		const char32_t t = _find_upper(s);
+		if (s != t) { // avoid copy on write
+			upper[i] = t;
+		}
+	}
+
+	return upper;
+}
+
+String String::to_lower() const {
+	String lower = *this;
+
+	for (int i = 0; i < lower.size(); i++) {
+		const char32_t s = lower[i];
+		const char32_t t = _find_lower(s);
+		if (s != t) { // avoid copy on write
+			lower[i] = t;
+		}
+	}
+
+	return lower;
+}
+
+String String::chr(char32_t p_char) {
+	char32_t c[2] = { p_char, 0 };
+	return String(c);
+}
+
+String String::num(double p_num, int p_decimals) {
+	if (Math::is_nan(p_num)) {
+		return "nan";
+	}
+
+	if (Math::is_inf(p_num)) {
+		if (signbit(p_num)) {
+			return "-inf";
+		} else {
+			return "inf";
+		}
+	}
+
+	if (p_decimals < 0) {
+		p_decimals = 14;
+		const double abs_num = ABS(p_num);
+		if (abs_num > 10) {
+			// We want to align the digits to the above sane default, so we only
+			// need to subtract log10 for numbers with a positive power of ten.
+			p_decimals -= (int)floor(log10(abs_num));
+		}
+	}
+	if (p_decimals > MAX_DECIMALS) {
+		p_decimals = MAX_DECIMALS;
+	}
+
+	char fmt[7];
+	fmt[0] = '%';
+	fmt[1] = '.';
+
+	if (p_decimals < 0) {
+		fmt[1] = 'l';
+		fmt[2] = 'f';
+		fmt[3] = 0;
+	} else if (p_decimals < 10) {
+		fmt[2] = '0' + p_decimals;
+		fmt[3] = 'l';
+		fmt[4] = 'f';
+		fmt[5] = 0;
+	} else {
+		fmt[2] = '0' + (p_decimals / 10);
+		fmt[3] = '0' + (p_decimals % 10);
+		fmt[4] = 'l';
+		fmt[5] = 'f';
+		fmt[6] = 0;
+	}
+	// if we want to convert a double with as much decimal places as as
+	// DBL_MAX or DBL_MIN then we would theoretically need a buffer of at least
+	// DBL_MAX_10_EXP + 2 for DBL_MAX and DBL_MAX_10_EXP + 4 for DBL_MIN.
+	// BUT those values where still giving me exceptions, so I tested from
+	// DBL_MAX_10_EXP + 10 incrementing one by one and DBL_MAX_10_EXP + 17 (325)
+	// was the first buffer size not to throw an exception
+	char buf[325];
+
+#if defined(__GNUC__) || defined(_MSC_VER)
+	// PLEASE NOTE that, albeit vcrt online reference states that snprintf
+	// should safely truncate the output to the given buffer size, we have
+	// found a case where this is not true, so we should create a buffer
+	// as big as needed
+	snprintf(buf, 325, fmt, p_num);
+#else
+	sprintf(buf, fmt, p_num);
+#endif
+
+	buf[324] = 0;
+	//destroy trailing zeroes
+	{
+		bool period = false;
+		int z = 0;
+		while (buf[z]) {
+			if (buf[z] == '.') {
+				period = true;
+			}
+			z++;
+		}
+
+		if (period) {
+			z--;
+			while (z > 0) {
+				if (buf[z] == '0') {
+					buf[z] = 0;
+				} else if (buf[z] == '.') {
+					buf[z] = 0;
+					break;
+				} else {
+					break;
+				}
+
+				z--;
+			}
+		}
+	}
+
+	return buf;
+}
+
+String String::num_int64(int64_t p_num, int base, bool capitalize_hex) {
+	bool sign = p_num < 0;
+
+	int64_t n = p_num;
+
+	int chars = 0;
+	do {
+		n /= base;
+		chars++;
+	} while (n);
+
+	if (sign) {
+		chars++;
+	}
+	String s;
+	s.resize(chars + 1);
+	char32_t *c = s.ptrw();
+	c[chars] = 0;
+	n = p_num;
+	do {
+		int mod = ABS(n % base);
+		if (mod >= 10) {
+			char a = (capitalize_hex ? 'A' : 'a');
+			c[--chars] = a + (mod - 10);
+		} else {
+			c[--chars] = '0' + mod;
+		}
+
+		n /= base;
+	} while (n);
+
+	if (sign) {
+		c[0] = '-';
+	}
+
+	return s;
+}
+
+String String::num_uint64(uint64_t p_num, int base, bool capitalize_hex) {
+	uint64_t n = p_num;
+
+	int chars = 0;
+	do {
+		n /= base;
+		chars++;
+	} while (n);
+
+	String s;
+	s.resize(chars + 1);
+	char32_t *c = s.ptrw();
+	c[chars] = 0;
+	n = p_num;
+	do {
+		int mod = n % base;
+		if (mod >= 10) {
+			char a = (capitalize_hex ? 'A' : 'a');
+			c[--chars] = a + (mod - 10);
+		} else {
+			c[--chars] = '0' + mod;
+		}
+
+		n /= base;
+	} while (n);
+
+	return s;
+}
+
+String String::num_real(double p_num, bool p_trailing) {
+	if (p_num == (double)(int64_t)p_num) {
+		if (p_trailing) {
+			return num_int64((int64_t)p_num) + ".0";
+		} else {
+			return num_int64((int64_t)p_num);
+		}
+	}
+#ifdef REAL_T_IS_DOUBLE
+	int decimals = 14;
+#else
+	int decimals = 6;
+#endif
+	// We want to align the digits to the above sane default, so we only need
+	// to subtract log10 for numbers with a positive power of ten magnitude.
+	double abs_num = Math::abs(p_num);
+	if (abs_num > 10) {
+		decimals -= (int)floor(log10(abs_num));
+	}
+	return num(p_num, decimals);
+}
+
+String String::num_scientific(double p_num) {
+	if (Math::is_nan(p_num)) {
+		return "nan";
+	}
+
+	if (Math::is_inf(p_num)) {
+		if (signbit(p_num)) {
+			return "-inf";
+		} else {
+			return "inf";
+		}
+	}
+
+	char buf[256];
+
+#if defined(__GNUC__) || defined(_MSC_VER)
+
+#if defined(__MINGW32__) && defined(_TWO_DIGIT_EXPONENT) && !defined(_UCRT)
+	// MinGW requires _set_output_format() to conform to C99 output for printf
+	unsigned int old_exponent_format = _set_output_format(_TWO_DIGIT_EXPONENT);
+#endif
+	snprintf(buf, 256, "%lg", p_num);
+
+#if defined(__MINGW32__) && defined(_TWO_DIGIT_EXPONENT) && !defined(_UCRT)
+	_set_output_format(old_exponent_format);
+#endif
+
+#else
+	sprintf(buf, "%.16lg", p_num);
+#endif
+
+	buf[255] = 0;
+
+	return buf;
+}
+
+String String::md5(const uint8_t *p_md5) {
+	return String::hex_encode_buffer(p_md5, 16);
+}
+
+String String::hex_encode_buffer(const uint8_t *p_buffer, int p_len) {
+	static const char hex[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+
+	String ret;
+	char v[2] = { 0, 0 };
+
+	for (int i = 0; i < p_len; i++) {
+		v[0] = hex[p_buffer[i] >> 4];
+		ret += v;
+		v[0] = hex[p_buffer[i] & 0xF];
+		ret += v;
+	}
+
+	return ret;
+}
+
+void String::print_unicode_error(const String &p_message, bool p_critical) const {
+	if (p_critical) {
+		print_error(vformat("Unicode parsing error, some characters were replaced with spaces: %s", p_message));
+	} else {
+		print_error(vformat("Unicode parsing error: %s", p_message));
+	}
+}
+
+CharString String::ascii(bool p_allow_extended) const {
+	if (!length()) {
+		return CharString();
+	}
+
+	CharString cs;
+	cs.resize(size());
+
+	for (int i = 0; i < size(); i++) {
+		char32_t c = operator[](i);
+		if ((c <= 0x7f) || (c <= 0xff && p_allow_extended)) {
+			cs[i] = c;
+		} else {
+			print_unicode_error(vformat("Invalid unicode codepoint (%x), cannot represent as ASCII/Latin-1", (uint32_t)c));
+			cs[i] = 0x20;
+		}
+	}
+
+	return cs;
+}
+
+String String::utf8(const char *p_utf8, int p_len) {
+	String ret;
+	ret.parse_utf8(p_utf8, p_len);
+
+	return ret;
+}
+
+Error String::parse_utf8(const char *p_utf8, int p_len, bool p_skip_cr) {
+	if (!p_utf8) {
+		return ERR_INVALID_DATA;
+	}
+
+	String aux;
+
+	int cstr_size = 0;
+	int str_size = 0;
+
+	/* HANDLE BOM (Byte Order Mark) */
+	if (p_len < 0 || p_len >= 3) {
+		bool has_bom = uint8_t(p_utf8[0]) == 0xef && uint8_t(p_utf8[1]) == 0xbb && uint8_t(p_utf8[2]) == 0xbf;
+		if (has_bom) {
+			//8-bit encoding, byte order has no meaning in UTF-8, just skip it
+			if (p_len >= 0) {
+				p_len -= 3;
+			}
+			p_utf8 += 3;
+		}
+	}
+
+	bool decode_error = false;
+	bool decode_failed = false;
+	{
+		const char *ptrtmp = p_utf8;
+		const char *ptrtmp_limit = &p_utf8[p_len];
+		int skip = 0;
+		uint8_t c_start = 0;
+		while (ptrtmp != ptrtmp_limit && *ptrtmp) {
+			uint8_t c = *ptrtmp >= 0 ? *ptrtmp : uint8_t(256 + *ptrtmp);
+
+			if (skip == 0) {
+				if (p_skip_cr && c == '\r') {
+					ptrtmp++;
+					continue;
+				}
+				/* Determine the number of characters in sequence */
+				if ((c & 0x80) == 0) {
+					skip = 0;
+				} else if ((c & 0xe0) == 0xc0) {
+					skip = 1;
+				} else if ((c & 0xf0) == 0xe0) {
+					skip = 2;
+				} else if ((c & 0xf8) == 0xf0) {
+					skip = 3;
+				} else if ((c & 0xfc) == 0xf8) {
+					skip = 4;
+				} else if ((c & 0xfe) == 0xfc) {
+					skip = 5;
+				} else {
+					skip = 0;
+					print_unicode_error(vformat("Invalid UTF-8 leading byte (%x)", c), true);
+					decode_failed = true;
+				}
+				c_start = c;
+
+				if (skip == 1 && (c & 0x1e) == 0) {
+					print_unicode_error(vformat("Overlong encoding (%x ...)", c));
+					decode_error = true;
+				}
+				str_size++;
+			} else {
+				if ((c_start == 0xe0 && skip == 2 && c < 0xa0) || (c_start == 0xf0 && skip == 3 && c < 0x90) || (c_start == 0xf8 && skip == 4 && c < 0x88) || (c_start == 0xfc && skip == 5 && c < 0x84)) {
+					print_unicode_error(vformat("Overlong encoding (%x %x ...)", c_start, c));
+					decode_error = true;
+				}
+				if (c < 0x80 || c > 0xbf) {
+					print_unicode_error(vformat("Invalid UTF-8 continuation byte (%x ... %x ...)", c_start, c), true);
+					decode_failed = true;
+					skip = 0;
+				} else {
+					--skip;
+				}
+			}
+
+			cstr_size++;
+			ptrtmp++;
+		}
+
+		if (skip) {
+			print_unicode_error(vformat("Missing %d UTF-8 continuation byte(s)", skip), true);
+			decode_failed = true;
+		}
+	}
+
+	if (str_size == 0) {
+		clear();
+		return OK; // empty string
+	}
+
+	resize(str_size + 1);
+	char32_t *dst = ptrw();
+	dst[str_size] = 0;
+
+	int skip = 0;
+	uint32_t unichar = 0;
+	while (cstr_size) {
+		uint8_t c = *p_utf8 >= 0 ? *p_utf8 : uint8_t(256 + *p_utf8);
+
+		if (skip == 0) {
+			if (p_skip_cr && c == '\r') {
+				p_utf8++;
+				continue;
+			}
+			/* Determine the number of characters in sequence */
+			if ((c & 0x80) == 0) {
+				*(dst++) = c;
+				unichar = 0;
+				skip = 0;
+			} else if ((c & 0xe0) == 0xc0) {
+				unichar = (0xff >> 3) & c;
+				skip = 1;
+			} else if ((c & 0xf0) == 0xe0) {
+				unichar = (0xff >> 4) & c;
+				skip = 2;
+			} else if ((c & 0xf8) == 0xf0) {
+				unichar = (0xff >> 5) & c;
+				skip = 3;
+			} else if ((c & 0xfc) == 0xf8) {
+				unichar = (0xff >> 6) & c;
+				skip = 4;
+			} else if ((c & 0xfe) == 0xfc) {
+				unichar = (0xff >> 7) & c;
+				skip = 5;
+			} else {
+				*(dst++) = 0x20;
+				unichar = 0;
+				skip = 0;
+			}
+		} else {
+			if (c < 0x80 || c > 0xbf) {
+				*(dst++) = 0x20;
+				skip = 0;
+			} else {
+				unichar = (unichar << 6) | (c & 0x3f);
+				--skip;
+				if (skip == 0) {
+					if (unichar == 0) {
+						print_unicode_error("NUL character", true);
+						decode_failed = true;
+						unichar = 0x20;
+					}
+					if ((unichar & 0xfffff800) == 0xd800) {
+						print_unicode_error(vformat("Unpaired surrogate (%x)", unichar));
+						//decode_error = true;
+						unichar = 0x20;
+					}
+					if (unichar > 0x10ffff) {
+						print_unicode_error(vformat("Invalid unicode codepoint (%x)", unichar));
+						//decode_error = true;
+						unichar = 0x20;
+					}
+					*(dst++) = unichar;
+				}
+			}
+		}
+
+		cstr_size--;
+		p_utf8++;
+	}
+	if (skip) {
+		*(dst++) = 0x20;
+	}
+
+	if (decode_failed) {
+		return ERR_INVALID_DATA;
+	} else if (decode_error) {
+		return ERR_PARSE_ERROR;
+	} else {
+		return OK;
+	}
+}
+
+CharString String::utf8() const {
+	int l = length();
+	if (!l) {
+		return CharString();
+	}
+
+	const char32_t *d = &operator[](0);
+	int fl = 0;
+	for (int i = 0; i < l; i++) {
+		uint32_t c = d[i];
+		if (c <= 0x7f) { // 7 bits.
+			fl += 1;
+		} else if (c <= 0x7ff) { // 11 bits
+			fl += 2;
+		} else if (c <= 0xffff) { // 16 bits
+			fl += 3;
+		} else if (c <= 0x001fffff) { // 21 bits
+			fl += 4;
+		} else if (c <= 0x03ffffff) { // 26 bits
+			fl += 5;
+			print_unicode_error(vformat("Invalid unicode codepoint (%x)", c));
+		} else if (c <= 0x7fffffff) { // 31 bits
+			fl += 6;
+			print_unicode_error(vformat("Invalid unicode codepoint (%x)", c));
+		} else {
+			fl += 1;
+			print_unicode_error(vformat("Invalid unicode codepoint (%x), cannot represent as UTF-8", c), true);
+		}
+	}
+
+	CharString utf8s;
+	if (fl == 0) {
+		return utf8s;
+	}
+
+	utf8s.resize(fl + 1);
+	uint8_t *cdst = (uint8_t *)utf8s.get_data();
+
+#define APPEND_CHAR(m_c) *(cdst++) = m_c
+
+	for (int i = 0; i < l; i++) {
+		uint32_t c = d[i];
+
+		if (c <= 0x7f) { // 7 bits.
+			APPEND_CHAR(c);
+		} else if (c <= 0x7ff) { // 11 bits
+			APPEND_CHAR(uint32_t(0xc0 | ((c >> 6) & 0x1f))); // Top 5 bits.
+			APPEND_CHAR(uint32_t(0x80 | (c & 0x3f))); // Bottom 6 bits.
+		} else if (c <= 0xffff) { // 16 bits
+			APPEND_CHAR(uint32_t(0xe0 | ((c >> 12) & 0x0f))); // Top 4 bits.
+			APPEND_CHAR(uint32_t(0x80 | ((c >> 6) & 0x3f))); // Middle 6 bits.
+			APPEND_CHAR(uint32_t(0x80 | (c & 0x3f))); // Bottom 6 bits.
+		} else if (c <= 0x001fffff) { // 21 bits
+			APPEND_CHAR(uint32_t(0xf0 | ((c >> 18) & 0x07))); // Top 3 bits.
+			APPEND_CHAR(uint32_t(0x80 | ((c >> 12) & 0x3f))); // Upper middle 6 bits.
+			APPEND_CHAR(uint32_t(0x80 | ((c >> 6) & 0x3f))); // Lower middle 6 bits.
+			APPEND_CHAR(uint32_t(0x80 | (c & 0x3f))); // Bottom 6 bits.
+		} else if (c <= 0x03ffffff) { // 26 bits
+			APPEND_CHAR(uint32_t(0xf8 | ((c >> 24) & 0x03))); // Top 2 bits.
+			APPEND_CHAR(uint32_t(0x80 | ((c >> 18) & 0x3f))); // Upper middle 6 bits.
+			APPEND_CHAR(uint32_t(0x80 | ((c >> 12) & 0x3f))); // middle 6 bits.
+			APPEND_CHAR(uint32_t(0x80 | ((c >> 6) & 0x3f))); // Lower middle 6 bits.
+			APPEND_CHAR(uint32_t(0x80 | (c & 0x3f))); // Bottom 6 bits.
+		} else if (c <= 0x7fffffff) { // 31 bits
+			APPEND_CHAR(uint32_t(0xfc | ((c >> 30) & 0x01))); // Top 1 bit.
+			APPEND_CHAR(uint32_t(0x80 | ((c >> 24) & 0x3f))); // Upper upper middle 6 bits.
+			APPEND_CHAR(uint32_t(0x80 | ((c >> 18) & 0x3f))); // Lower upper middle 6 bits.
+			APPEND_CHAR(uint32_t(0x80 | ((c >> 12) & 0x3f))); // Upper lower middle 6 bits.
+			APPEND_CHAR(uint32_t(0x80 | ((c >> 6) & 0x3f))); // Lower lower middle 6 bits.
+			APPEND_CHAR(uint32_t(0x80 | (c & 0x3f))); // Bottom 6 bits.
+		} else {
+			APPEND_CHAR(0x20);
+		}
+	}
+#undef APPEND_CHAR
+	*cdst = 0; //trailing zero
+
+	return utf8s;
+}
+
+String String::utf16(const char16_t *p_utf16, int p_len) {
+	String ret;
+	ret.parse_utf16(p_utf16, p_len);
+
+	return ret;
+}
+
+Error String::parse_utf16(const char16_t *p_utf16, int p_len) {
+	if (!p_utf16) {
+		return ERR_INVALID_DATA;
+	}
+
+	String aux;
+
+	int cstr_size = 0;
+	int str_size = 0;
+
+	/* HANDLE BOM (Byte Order Mark) */
+	bool byteswap = false; // assume correct endianness if no BOM found
+	if (p_len < 0 || p_len >= 1) {
+		bool has_bom = false;
+		if (uint16_t(p_utf16[0]) == 0xfeff) { // correct BOM, read as is
+			has_bom = true;
+			byteswap = false;
+		} else if (uint16_t(p_utf16[0]) == 0xfffe) { // backwards BOM, swap bytes
+			has_bom = true;
+			byteswap = true;
+		}
+		if (has_bom) {
+			if (p_len >= 0) {
+				p_len -= 1;
+			}
+			p_utf16 += 1;
+		}
+	}
+
+	bool decode_error = false;
+	{
+		const char16_t *ptrtmp = p_utf16;
+		const char16_t *ptrtmp_limit = &p_utf16[p_len];
+		uint32_t c_prev = 0;
+		bool skip = false;
+		while (ptrtmp != ptrtmp_limit && *ptrtmp) {
+			uint32_t c = (byteswap) ? BSWAP16(*ptrtmp) : *ptrtmp;
+
+			if ((c & 0xfffffc00) == 0xd800) { // lead surrogate
+				if (skip) {
+					print_unicode_error(vformat("Unpaired lead surrogate (%x [trail?] %x)", c_prev, c));
+					decode_error = true;
+				}
+				skip = true;
+			} else if ((c & 0xfffffc00) == 0xdc00) { // trail surrogate
+				if (skip) {
+					str_size--;
+				} else {
+					print_unicode_error(vformat("Unpaired trail surrogate (%x [lead?] %x)", c_prev, c));
+					decode_error = true;
+				}
+				skip = false;
+			} else {
+				skip = false;
+			}
+
+			c_prev = c;
+			str_size++;
+			cstr_size++;
+			ptrtmp++;
+		}
+
+		if (skip) {
+			print_unicode_error(vformat("Unpaired lead surrogate (%x [eol])", c_prev));
+			decode_error = true;
+		}
+	}
+
+	if (str_size == 0) {
+		clear();
+		return OK; // empty string
+	}
+
+	resize(str_size + 1);
+	char32_t *dst = ptrw();
+	dst[str_size] = 0;
+
+	bool skip = false;
+	uint32_t c_prev = 0;
+	while (cstr_size) {
+		uint32_t c = (byteswap) ? BSWAP16(*p_utf16) : *p_utf16;
+
+		if ((c & 0xfffffc00) == 0xd800) { // lead surrogate
+			if (skip) {
+				*(dst++) = c_prev; // unpaired, store as is
+			}
+			skip = true;
+		} else if ((c & 0xfffffc00) == 0xdc00) { // trail surrogate
+			if (skip) {
+				*(dst++) = (c_prev << 10UL) + c - ((0xd800 << 10UL) + 0xdc00 - 0x10000); // decode pair
+			} else {
+				*(dst++) = c; // unpaired, store as is
+			}
+			skip = false;
+		} else {
+			*(dst++) = c;
+			skip = false;
+		}
+
+		cstr_size--;
+		p_utf16++;
+		c_prev = c;
+	}
+
+	if (skip) {
+		*(dst++) = c_prev;
+	}
+
+	if (decode_error) {
+		return ERR_PARSE_ERROR;
+	} else {
+		return OK;
+	}
+}
+
+Char16String String::utf16() const {
+	int l = length();
+	if (!l) {
+		return Char16String();
+	}
+
+	const char32_t *d = &operator[](0);
+	int fl = 0;
+	for (int i = 0; i < l; i++) {
+		uint32_t c = d[i];
+		if (c <= 0xffff) { // 16 bits.
+			fl += 1;
+			if ((c & 0xfffff800) == 0xd800) {
+				print_unicode_error(vformat("Unpaired surrogate (%x)", c));
+			}
+		} else if (c <= 0x10ffff) { // 32 bits.
+			fl += 2;
+		} else {
+			print_unicode_error(vformat("Invalid unicode codepoint (%x), cannot represent as UTF-16", c), true);
+			fl += 1;
+		}
+	}
+
+	Char16String utf16s;
+	if (fl == 0) {
+		return utf16s;
+	}
+
+	utf16s.resize(fl + 1);
+	uint16_t *cdst = (uint16_t *)utf16s.get_data();
+
+#define APPEND_CHAR(m_c) *(cdst++) = m_c
+
+	for (int i = 0; i < l; i++) {
+		uint32_t c = d[i];
+
+		if (c <= 0xffff) { // 16 bits.
+			APPEND_CHAR(c);
+		} else if (c <= 0x10ffff) { // 32 bits.
+			APPEND_CHAR(uint32_t((c >> 10) + 0xd7c0)); // lead surrogate.
+			APPEND_CHAR(uint32_t((c & 0x3ff) | 0xdc00)); // trail surrogate.
+		} else {
+			APPEND_CHAR(0x20);
+		}
+	}
+#undef APPEND_CHAR
+	*cdst = 0; //trailing zero
+
+	return utf16s;
+}
+
+String::String(const char *p_str) {
+	copy_from(p_str);
+}
+
+String::String(const wchar_t *p_str) {
+	copy_from(p_str);
+}
+
+String::String(const char32_t *p_str) {
+	copy_from(p_str);
+}
+
+String::String(const char *p_str, int p_clip_to_len) {
+	copy_from(p_str, p_clip_to_len);
+}
+
+String::String(const wchar_t *p_str, int p_clip_to_len) {
+	copy_from(p_str, p_clip_to_len);
+}
+
+String::String(const char32_t *p_str, int p_clip_to_len) {
+	copy_from(p_str, p_clip_to_len);
+}
+
+String::String(const StrRange &p_range) {
+	if (!p_range.c_str) {
+		return;
+	}
+	copy_from(p_range.c_str, p_range.len);
+}
+
+int64_t String::hex_to_int() const {
+	int len = length();
+	if (len == 0) {
+		return 0;
+	}
+
+	const char32_t *s = ptr();
+
+	int64_t sign = s[0] == '-' ? -1 : 1;
+
+	if (sign < 0) {
+		s++;
+	}
+
+	if (len > 2 && s[0] == '0' && lower_case(s[1]) == 'x') {
+		s += 2;
+	}
+
+	int64_t hex = 0;
+
+	while (*s) {
+		char32_t c = lower_case(*s);
+		int64_t n;
+		if (is_digit(c)) {
+			n = c - '0';
+		} else if (c >= 'a' && c <= 'f') {
+			n = (c - 'a') + 10;
+		} else {
+			ERR_FAIL_COND_V_MSG(true, 0, "Invalid hexadecimal notation character \"" + chr(*s) + "\" in string \"" + *this + "\".");
+		}
+		// Check for overflow/underflow, with special case to ensure INT64_MIN does not result in error
+		bool overflow = ((hex > INT64_MAX / 16) && (sign == 1 || (sign == -1 && hex != (INT64_MAX >> 4) + 1))) || (sign == -1 && hex == (INT64_MAX >> 4) + 1 && c > '0');
+		ERR_FAIL_COND_V_MSG(overflow, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + *this + " as a 64-bit signed integer, since the value is " + (sign == 1 ? "too large." : "too small."));
+		hex *= 16;
+		hex += n;
+		s++;
+	}
+
+	return hex * sign;
+}
+
+int64_t String::bin_to_int() const {
+	int len = length();
+	if (len == 0) {
+		return 0;
+	}
+
+	const char32_t *s = ptr();
+
+	int64_t sign = s[0] == '-' ? -1 : 1;
+
+	if (sign < 0) {
+		s++;
+	}
+
+	if (len > 2 && s[0] == '0' && lower_case(s[1]) == 'b') {
+		s += 2;
+	}
+
+	int64_t binary = 0;
+
+	while (*s) {
+		char32_t c = lower_case(*s);
+		int64_t n;
+		if (c == '0' || c == '1') {
+			n = c - '0';
+		} else {
+			return 0;
+		}
+		// Check for overflow/underflow, with special case to ensure INT64_MIN does not result in error
+		bool overflow = ((binary > INT64_MAX / 2) && (sign == 1 || (sign == -1 && binary != (INT64_MAX >> 1) + 1))) || (sign == -1 && binary == (INT64_MAX >> 1) + 1 && c > '0');
+		ERR_FAIL_COND_V_MSG(overflow, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + *this + " as a 64-bit signed integer, since the value is " + (sign == 1 ? "too large." : "too small."));
+		binary *= 2;
+		binary += n;
+		s++;
+	}
+
+	return binary * sign;
+}
+
+int64_t String::to_int() const {
+	if (length() == 0) {
+		return 0;
+	}
+
+	int to = (find(".") >= 0) ? find(".") : length();
+
+	int64_t integer = 0;
+	int64_t sign = 1;
+
+	for (int i = 0; i < to; i++) {
+		char32_t c = operator[](i);
+		if (is_digit(c)) {
+			bool overflow = (integer > INT64_MAX / 10) || (integer == INT64_MAX / 10 && ((sign == 1 && c > '7') || (sign == -1 && c > '8')));
+			ERR_FAIL_COND_V_MSG(overflow, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + *this + " as a 64-bit signed integer, since the value is " + (sign == 1 ? "too large." : "too small."));
+			integer *= 10;
+			integer += c - '0';
+
+		} else if (integer == 0 && c == '-') {
+			sign = -sign;
+		}
+	}
+
+	return integer * sign;
+}
+
+int64_t String::to_int(const char *p_str, int p_len) {
+	int to = 0;
+	if (p_len >= 0) {
+		to = p_len;
+	} else {
+		while (p_str[to] != 0 && p_str[to] != '.') {
+			to++;
+		}
+	}
+
+	int64_t integer = 0;
+	int64_t sign = 1;
+
+	for (int i = 0; i < to; i++) {
+		char c = p_str[i];
+		if (is_digit(c)) {
+			bool overflow = (integer > INT64_MAX / 10) || (integer == INT64_MAX / 10 && ((sign == 1 && c > '7') || (sign == -1 && c > '8')));
+			ERR_FAIL_COND_V_MSG(overflow, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + String(p_str).substr(0, to) + " as a 64-bit signed integer, since the value is " + (sign == 1 ? "too large." : "too small."));
+			integer *= 10;
+			integer += c - '0';
+
+		} else if (c == '-' && integer == 0) {
+			sign = -sign;
+		} else if (c != ' ') {
+			break;
+		}
+	}
+
+	return integer * sign;
+}
+
+int64_t String::to_int(const wchar_t *p_str, int p_len) {
+	int to = 0;
+	if (p_len >= 0) {
+		to = p_len;
+	} else {
+		while (p_str[to] != 0 && p_str[to] != '.') {
+			to++;
+		}
+	}
+
+	int64_t integer = 0;
+	int64_t sign = 1;
+
+	for (int i = 0; i < to; i++) {
+		wchar_t c = p_str[i];
+		if (is_digit(c)) {
+			bool overflow = (integer > INT64_MAX / 10) || (integer == INT64_MAX / 10 && ((sign == 1 && c > '7') || (sign == -1 && c > '8')));
+			ERR_FAIL_COND_V_MSG(overflow, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + String(p_str).substr(0, to) + " as a 64-bit signed integer, since the value is " + (sign == 1 ? "too large." : "too small."));
+			integer *= 10;
+			integer += c - '0';
+
+		} else if (c == '-' && integer == 0) {
+			sign = -sign;
+		} else if (c != ' ') {
+			break;
+		}
+	}
+
+	return integer * sign;
+}
+
+bool String::is_numeric() const {
+	if (length() == 0) {
+		return false;
+	}
+
+	int s = 0;
+	if (operator[](0) == '-') {
+		++s;
+	}
+	bool dot = false;
+	for (int i = s; i < length(); i++) {
+		char32_t c = operator[](i);
+		if (c == '.') {
+			if (dot) {
+				return false;
+			}
+			dot = true;
+		} else if (!is_digit(c)) {
+			return false;
+		}
+	}
+
+	return true; // TODO: Use the parser below for this instead
+}
+
+template <class C>
+static double built_in_strtod(
+		/* A decimal ASCII floating-point number,
+		 * optionally preceded by white space. Must
+		 * have form "-I.FE-X", where I is the integer
+		 * part of the mantissa, F is the fractional
+		 * part of the mantissa, and X is the
+		 * exponent. Either of the signs may be "+",
+		 * "-", or omitted. Either I or F may be
+		 * omitted, or both. The decimal point isn't
+		 * necessary unless F is present. The "E" may
+		 * actually be an "e". E and X may both be
+		 * omitted (but not just one). */
+		const C *string,
+		/* If non-nullptr, store terminating Cacter's
+		 * address here. */
+		C **endPtr = nullptr) {
+	/* Largest possible base 10 exponent. Any
+	 * exponent larger than this will already
+	 * produce underflow or overflow, so there's
+	 * no need to worry about additional digits. */
+	static const int maxExponent = 511;
+	/* Table giving binary powers of 10. Entry
+	 * is 10^2^i. Used to convert decimal
+	 * exponents into floating-point numbers. */
+	static const double powersOf10[] = {
+		10.,
+		100.,
+		1.0e4,
+		1.0e8,
+		1.0e16,
+		1.0e32,
+		1.0e64,
+		1.0e128,
+		1.0e256
+	};
+
+	bool sign, expSign = false;
+	double fraction, dblExp;
+	const double *d;
+	const C *p;
+	int c;
+	/* Exponent read from "EX" field. */
+	int exp = 0;
+	/* Exponent that derives from the fractional
+	 * part. Under normal circumstances, it is
+	 * the negative of the number of digits in F.
+	 * However, if I is very long, the last digits
+	 * of I get dropped (otherwise a long I with a
+	 * large negative exponent could cause an
+	 * unnecessary overflow on I alone). In this
+	 * case, fracExp is incremented one for each
+	 * dropped digit. */
+	int fracExp = 0;
+	/* Number of digits in mantissa. */
+	int mantSize;
+	/* Number of mantissa digits BEFORE decimal point. */
+	int decPt;
+	/* Temporarily holds location of exponent in string. */
+	const C *pExp;
+
+	/*
+	 * Strip off leading blanks and check for a sign.
+	 */
+
+	p = string;
+	while (*p == ' ' || *p == '\t' || *p == '\n') {
+		p += 1;
+	}
+	if (*p == '-') {
+		sign = true;
+		p += 1;
+	} else {
+		if (*p == '+') {
+			p += 1;
+		}
+		sign = false;
+	}
+
+	/*
+	 * Count the number of digits in the mantissa (including the decimal
+	 * point), and also locate the decimal point.
+	 */
+
+	decPt = -1;
+	for (mantSize = 0;; mantSize += 1) {
+		c = *p;
+		if (!is_digit(c)) {
+			if ((c != '.') || (decPt >= 0)) {
+				break;
+			}
+			decPt = mantSize;
+		}
+		p += 1;
+	}
+
+	/*
+	 * Now suck up the digits in the mantissa. Use two integers to collect 9
+	 * digits each (this is faster than using floating-point). If the mantissa
+	 * has more than 18 digits, ignore the extras, since they can't affect the
+	 * value anyway.
+	 */
+
+	pExp = p;
+	p -= mantSize;
+	if (decPt < 0) {
+		decPt = mantSize;
+	} else {
+		mantSize -= 1; /* One of the digits was the point. */
+	}
+	if (mantSize > 18) {
+		fracExp = decPt - 18;
+		mantSize = 18;
+	} else {
+		fracExp = decPt - mantSize;
+	}
+	if (mantSize == 0) {
+		fraction = 0.0;
+		p = string;
+		goto done;
+	} else {
+		int frac1, frac2;
+
+		frac1 = 0;
+		for (; mantSize > 9; mantSize -= 1) {
+			c = *p;
+			p += 1;
+			if (c == '.') {
+				c = *p;
+				p += 1;
+			}
+			frac1 = 10 * frac1 + (c - '0');
+		}
+		frac2 = 0;
+		for (; mantSize > 0; mantSize -= 1) {
+			c = *p;
+			p += 1;
+			if (c == '.') {
+				c = *p;
+				p += 1;
+			}
+			frac2 = 10 * frac2 + (c - '0');
+		}
+		fraction = (1.0e9 * frac1) + frac2;
+	}
+
+	/*
+	 * Skim off the exponent.
+	 */
+
+	p = pExp;
+	if ((*p == 'E') || (*p == 'e')) {
+		p += 1;
+		if (*p == '-') {
+			expSign = true;
+			p += 1;
+		} else {
+			if (*p == '+') {
+				p += 1;
+			}
+			expSign = false;
+		}
+		if (!is_digit(char32_t(*p))) {
+			p = pExp;
+			goto done;
+		}
+		while (is_digit(char32_t(*p))) {
+			exp = exp * 10 + (*p - '0');
+			p += 1;
+		}
+	}
+	if (expSign) {
+		exp = fracExp - exp;
+	} else {
+		exp = fracExp + exp;
+	}
+
+	/*
+	 * Generate a floating-point number that represents the exponent. Do this
+	 * by processing the exponent one bit at a time to combine many powers of
+	 * 2 of 10. Then combine the exponent with the fraction.
+	 */
+
+	if (exp < 0) {
+		expSign = true;
+		exp = -exp;
+	} else {
+		expSign = false;
+	}
+
+	if (exp > maxExponent) {
+		exp = maxExponent;
+		WARN_PRINT("Exponent too high");
+	}
+	dblExp = 1.0;
+	for (d = powersOf10; exp != 0; exp >>= 1, ++d) {
+		if (exp & 01) {
+			dblExp *= *d;
+		}
+	}
+	if (expSign) {
+		fraction /= dblExp;
+	} else {
+		fraction *= dblExp;
+	}
+
+done:
+	if (endPtr != nullptr) {
+		*endPtr = (C *)p;
+	}
+
+	if (sign) {
+		return -fraction;
+	}
+	return fraction;
+}
+
+#define READING_SIGN 0
+#define READING_INT 1
+#define READING_DEC 2
+#define READING_EXP 3
+#define READING_DONE 4
+
+double String::to_float(const char *p_str) {
+	return built_in_strtod<char>(p_str);
+}
+
+double String::to_float(const char32_t *p_str, const char32_t **r_end) {
+	return built_in_strtod<char32_t>(p_str, (char32_t **)r_end);
+}
+
+double String::to_float(const wchar_t *p_str, const wchar_t **r_end) {
+	return built_in_strtod<wchar_t>(p_str, (wchar_t **)r_end);
+}
+
+int64_t String::to_int(const char32_t *p_str, int p_len, bool p_clamp) {
+	if (p_len == 0 || !p_str[0]) {
+		return 0;
+	}
+	///@todo make more exact so saving and loading does not lose precision
+
+	int64_t integer = 0;
+	int64_t sign = 1;
+	int reading = READING_SIGN;
+
+	const char32_t *str = p_str;
+	const char32_t *limit = &p_str[p_len];
+
+	while (*str && reading != READING_DONE && str != limit) {
+		char32_t c = *(str++);
+		switch (reading) {
+			case READING_SIGN: {
+				if (is_digit(c)) {
+					reading = READING_INT;
+					// let it fallthrough
+				} else if (c == '-') {
+					sign = -1;
+					reading = READING_INT;
+					break;
+				} else if (c == '+') {
+					sign = 1;
+					reading = READING_INT;
+					break;
+				} else {
+					break;
+				}
+				[[fallthrough]];
+			}
+			case READING_INT: {
+				if (is_digit(c)) {
+					if (integer > INT64_MAX / 10) {
+						String number("");
+						str = p_str;
+						while (*str && str != limit) {
+							number += *(str++);
+						}
+						if (p_clamp) {
+							if (sign == 1) {
+								return INT64_MAX;
+							} else {
+								return INT64_MIN;
+							}
+						} else {
+							ERR_FAIL_V_MSG(sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + number + " as a 64-bit signed integer, since the value is " + (sign == 1 ? "too large." : "too small."));
+						}
+					}
+					integer *= 10;
+					integer += c - '0';
+				} else {
+					reading = READING_DONE;
+				}
+
+			} break;
+		}
+	}
+
+	return sign * integer;
+}
+
+double String::to_float() const {
+	if (is_empty()) {
+		return 0;
+	}
+	return built_in_strtod<char32_t>(get_data());
+}
+
+uint32_t String::hash(const char *p_cstr) {
+	uint32_t hashv = 5381;
+	uint32_t c = *p_cstr++;
+
+	while (c) {
+		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
+		c = *p_cstr++;
+	}
+
+	return hashv;
+}
+
+uint32_t String::hash(const char *p_cstr, int p_len) {
+	uint32_t hashv = 5381;
+	for (int i = 0; i < p_len; i++) {
+		hashv = ((hashv << 5) + hashv) + p_cstr[i]; /* hash * 33 + c */
+	}
+
+	return hashv;
+}
+
+uint32_t String::hash(const wchar_t *p_cstr, int p_len) {
+	uint32_t hashv = 5381;
+	for (int i = 0; i < p_len; i++) {
+		hashv = ((hashv << 5) + hashv) + p_cstr[i]; /* hash * 33 + c */
+	}
+
+	return hashv;
+}
+
+uint32_t String::hash(const wchar_t *p_cstr) {
+	uint32_t hashv = 5381;
+	uint32_t c = *p_cstr++;
+
+	while (c) {
+		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
+		c = *p_cstr++;
+	}
+
+	return hashv;
+}
+
+uint32_t String::hash(const char32_t *p_cstr, int p_len) {
+	uint32_t hashv = 5381;
+	for (int i = 0; i < p_len; i++) {
+		hashv = ((hashv << 5) + hashv) + p_cstr[i]; /* hash * 33 + c */
+	}
+
+	return hashv;
+}
+
+uint32_t String::hash(const char32_t *p_cstr) {
+	uint32_t hashv = 5381;
+	uint32_t c = *p_cstr++;
+
+	while (c) {
+		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
+		c = *p_cstr++;
+	}
+
+	return hashv;
+}
+
+uint32_t String::hash() const {
+	/* simple djb2 hashing */
+
+	const char32_t *chr = get_data();
+	uint32_t hashv = 5381;
+	uint32_t c = *chr++;
+
+	while (c) {
+		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
+		c = *chr++;
+	}
+
+	return hashv;
+}
+
+uint64_t String::hash64() const {
+	/* simple djb2 hashing */
+
+	const char32_t *chr = get_data();
+	uint64_t hashv = 5381;
+	uint64_t c = *chr++;
+
+	while (c) {
+		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
+		c = *chr++;
+	}
+
+	return hashv;
+}
+
+String String::md5_text() const {
+	CharString cs = utf8();
+	unsigned char hash[16];
+	CryptoCore::md5((unsigned char *)cs.ptr(), cs.length(), hash);
+	return String::hex_encode_buffer(hash, 16);
+}
+
+String String::sha1_text() const {
+	CharString cs = utf8();
+	unsigned char hash[20];
+	CryptoCore::sha1((unsigned char *)cs.ptr(), cs.length(), hash);
+	return String::hex_encode_buffer(hash, 20);
+}
+
+String String::sha256_text() const {
+	CharString cs = utf8();
+	unsigned char hash[32];
+	CryptoCore::sha256((unsigned char *)cs.ptr(), cs.length(), hash);
+	return String::hex_encode_buffer(hash, 32);
+}
+
+Vector<uint8_t> String::md5_buffer() const {
+	CharString cs = utf8();
+	unsigned char hash[16];
+	CryptoCore::md5((unsigned char *)cs.ptr(), cs.length(), hash);
+
+	Vector<uint8_t> ret;
+	ret.resize(16);
+	for (int i = 0; i < 16; i++) {
+		ret.write[i] = hash[i];
+	}
+	return ret;
+}
+
+Vector<uint8_t> String::sha1_buffer() const {
+	CharString cs = utf8();
+	unsigned char hash[20];
+	CryptoCore::sha1((unsigned char *)cs.ptr(), cs.length(), hash);
+
+	Vector<uint8_t> ret;
+	ret.resize(20);
+	for (int i = 0; i < 20; i++) {
+		ret.write[i] = hash[i];
+	}
+
+	return ret;
+}
+
+Vector<uint8_t> String::sha256_buffer() const {
+	CharString cs = utf8();
+	unsigned char hash[32];
+	CryptoCore::sha256((unsigned char *)cs.ptr(), cs.length(), hash);
+
+	Vector<uint8_t> ret;
+	ret.resize(32);
+	for (int i = 0; i < 32; i++) {
+		ret.write[i] = hash[i];
+	}
+	return ret;
+}
+
+String String::insert(int p_at_pos, const String &p_string) const {
+	if (p_at_pos < 0) {
+		return *this;
+	}
+
+	if (p_at_pos > length()) {
+		p_at_pos = length();
+	}
+
+	String pre;
+	if (p_at_pos > 0) {
+		pre = substr(0, p_at_pos);
+	}
+
+	String post;
+	if (p_at_pos < length()) {
+		post = substr(p_at_pos, length() - p_at_pos);
+	}
+
+	return pre + p_string + post;
+}
+
+String String::substr(int p_from, int p_chars) const {
+	if (p_chars == -1) {
+		p_chars = length() - p_from;
+	}
+
+	if (is_empty() || p_from < 0 || p_from >= length() || p_chars <= 0) {
+		return "";
+	}
+
+	if ((p_from + p_chars) > length()) {
+		p_chars = length() - p_from;
+	}
+
+	if (p_from == 0 && p_chars >= length()) {
+		return String(*this);
+	}
+
+	String s;
+	s.copy_from_unchecked(&get_data()[p_from], p_chars);
+	return s;
+}
+
+int String::find(const String &p_str, int p_from) const {
+	if (p_from < 0) {
+		return -1;
+	}
+
+	const int src_len = p_str.length();
+
+	const int len = length();
+
+	if (src_len == 0 || len == 0) {
+		return -1; // won't find anything!
+	}
+
+	const char32_t *src = get_data();
+	const char32_t *str = p_str.get_data();
+
+	for (int i = p_from; i <= (len - src_len); i++) {
+		bool found = true;
+		for (int j = 0; j < src_len; j++) {
+			int read_pos = i + j;
+
+			if (read_pos >= len) {
+				ERR_PRINT("read_pos>=len");
+				return -1;
+			}
+
+			if (src[read_pos] != str[j]) {
+				found = false;
+				break;
+			}
+		}
+
+		if (found) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+int String::find(const char *p_str, int p_from) const {
+	if (p_from < 0) {
+		return -1;
+	}
+
+	const int len = length();
+
+	if (len == 0) {
+		return -1; // won't find anything!
+	}
+
+	const char32_t *src = get_data();
+
+	int src_len = 0;
+	while (p_str[src_len] != '\0') {
+		src_len++;
+	}
+
+	if (src_len == 1) {
+		const char32_t needle = p_str[0];
+
+		for (int i = p_from; i < len; i++) {
+			if (src[i] == needle) {
+				return i;
+			}
+		}
+
+	} else {
+		for (int i = p_from; i <= (len - src_len); i++) {
+			bool found = true;
+			for (int j = 0; j < src_len; j++) {
+				int read_pos = i + j;
+
+				if (read_pos >= len) {
+					ERR_PRINT("read_pos>=len");
+					return -1;
+				}
+
+				if (src[read_pos] != (char32_t)p_str[j]) {
+					found = false;
+					break;
+				}
+			}
+
+			if (found) {
+				return i;
+			}
+		}
+	}
+
+	return -1;
+}
+
+int String::find_char(const char32_t &p_char, int p_from) const {
+	return _cowdata.find(p_char, p_from);
+}
+
+int String::findmk(const Vector<String> &p_keys, int p_from, int *r_key) const {
+	if (p_from < 0) {
+		return -1;
+	}
+	if (p_keys.size() == 0) {
+		return -1;
+	}
+
+	//int src_len=p_str.length();
+	const String *keys = &p_keys[0];
+	int key_count = p_keys.size();
+	int len = length();
+
+	if (len == 0) {
+		return -1; // won't find anything!
+	}
+
+	const char32_t *src = get_data();
+
+	for (int i = p_from; i < len; i++) {
+		bool found = true;
+		for (int k = 0; k < key_count; k++) {
+			found = true;
+			if (r_key) {
+				*r_key = k;
+			}
+			const char32_t *cmp = keys[k].get_data();
+			int l = keys[k].length();
+
+			for (int j = 0; j < l; j++) {
+				int read_pos = i + j;
+
+				if (read_pos >= len) {
+					found = false;
+					break;
+				}
+
+				if (src[read_pos] != cmp[j]) {
+					found = false;
+					break;
+				}
+			}
+			if (found) {
+				break;
+			}
+		}
+
+		if (found) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+int String::findn(const String &p_str, int p_from) const {
+	if (p_from < 0) {
+		return -1;
+	}
+
+	int src_len = p_str.length();
+
+	if (src_len == 0 || length() == 0) {
+		return -1; // won't find anything!
+	}
+
+	const char32_t *srcd = get_data();
+
+	for (int i = p_from; i <= (length() - src_len); i++) {
+		bool found = true;
+		for (int j = 0; j < src_len; j++) {
+			int read_pos = i + j;
+
+			if (read_pos >= length()) {
+				ERR_PRINT("read_pos>=length()");
+				return -1;
+			}
+
+			char32_t src = _find_lower(srcd[read_pos]);
+			char32_t dst = _find_lower(p_str[j]);
+
+			if (src != dst) {
+				found = false;
+				break;
+			}
+		}
+
+		if (found) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+int String::rfind(const String &p_str, int p_from) const {
+	// establish a limit
+	int limit = length() - p_str.length();
+	if (limit < 0) {
+		return -1;
+	}
+
+	// establish a starting point
+	if (p_from < 0) {
+		p_from = limit;
+	} else if (p_from > limit) {
+		p_from = limit;
+	}
+
+	int src_len = p_str.length();
+	int len = length();
+
+	if (src_len == 0 || len == 0) {
+		return -1; // won't find anything!
+	}
+
+	const char32_t *src = get_data();
+
+	for (int i = p_from; i >= 0; i--) {
+		bool found = true;
+		for (int j = 0; j < src_len; j++) {
+			int read_pos = i + j;
+
+			if (read_pos >= len) {
+				ERR_PRINT("read_pos>=len");
+				return -1;
+			}
+
+			if (src[read_pos] != p_str[j]) {
+				found = false;
+				break;
+			}
+		}
+
+		if (found) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+int String::rfindn(const String &p_str, int p_from) const {
+	// establish a limit
+	int limit = length() - p_str.length();
+	if (limit < 0) {
+		return -1;
+	}
+
+	// establish a starting point
+	if (p_from < 0) {
+		p_from = limit;
+	} else if (p_from > limit) {
+		p_from = limit;
+	}
+
+	int src_len = p_str.length();
+	int len = length();
+
+	if (src_len == 0 || len == 0) {
+		return -1; // won't find anything!
+	}
+
+	const char32_t *src = get_data();
+
+	for (int i = p_from; i >= 0; i--) {
+		bool found = true;
+		for (int j = 0; j < src_len; j++) {
+			int read_pos = i + j;
+
+			if (read_pos >= len) {
+				ERR_PRINT("read_pos>=len");
+				return -1;
+			}
+
+			char32_t srcc = _find_lower(src[read_pos]);
+			char32_t dstc = _find_lower(p_str[j]);
+
+			if (srcc != dstc) {
+				found = false;
+				break;
+			}
+		}
+
+		if (found) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+bool String::ends_with(const String &p_string) const {
+	int l = p_string.length();
+	if (l > length()) {
+		return false;
+	}
+
+	if (l == 0) {
+		return true;
+	}
+
+	const char32_t *p = &p_string[0];
+	const char32_t *s = &operator[](length() - l);
+
+	for (int i = 0; i < l; i++) {
+		if (p[i] != s[i]) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool String::begins_with(const String &p_string) const {
+	int l = p_string.length();
+	if (l > length()) {
+		return false;
+	}
+
+	if (l == 0) {
+		return true;
+	}
+
+	const char32_t *p = &p_string[0];
+	const char32_t *s = &operator[](0);
+
+	for (int i = 0; i < l; i++) {
+		if (p[i] != s[i]) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool String::begins_with(const char *p_string) const {
+	int l = length();
+	if (l == 0 || !p_string) {
+		return false;
+	}
+
+	const char32_t *str = &operator[](0);
+	int i = 0;
+
+	while (*p_string && i < l) {
+		if ((char32_t)*p_string != str[i]) {
+			return false;
+		}
+		i++;
+		p_string++;
+	}
+
+	return *p_string == 0;
+}
+
+bool String::is_enclosed_in(const String &p_string) const {
+	return begins_with(p_string) && ends_with(p_string);
+}
+
+bool String::is_subsequence_of(const String &p_string) const {
+	return _base_is_subsequence_of(p_string, false);
+}
+
+bool String::is_subsequence_ofn(const String &p_string) const {
+	return _base_is_subsequence_of(p_string, true);
+}
+
+bool String::is_quoted() const {
+	return is_enclosed_in("\"") || is_enclosed_in("'");
+}
+
+int String::_count(const String &p_string, int p_from, int p_to, bool p_case_insensitive) const {
+	if (p_string.is_empty()) {
+		return 0;
+	}
+	int len = length();
+	int slen = p_string.length();
+	if (len < slen) {
+		return 0;
+	}
+	String str;
+	if (p_from >= 0 && p_to >= 0) {
+		if (p_to == 0) {
+			p_to = len;
+		} else if (p_from >= p_to) {
+			return 0;
+		}
+		if (p_from == 0 && p_to == len) {
+			str = String();
+			str.copy_from_unchecked(&get_data()[0], len);
+		} else {
+			str = substr(p_from, p_to - p_from);
+		}
+	} else {
+		return 0;
+	}
+	int c = 0;
+	int idx = -1;
+	do {
+		idx = p_case_insensitive ? str.findn(p_string) : str.find(p_string);
+		if (idx != -1) {
+			str = str.substr(idx + slen, str.length() - slen);
+			++c;
+		}
+	} while (idx != -1);
+	return c;
+}
+
+int String::count(const String &p_string, int p_from, int p_to) const {
+	return _count(p_string, p_from, p_to, false);
+}
+
+int String::countn(const String &p_string, int p_from, int p_to) const {
+	return _count(p_string, p_from, p_to, true);
+}
+
+bool String::_base_is_subsequence_of(const String &p_string, bool case_insensitive) const {
+	int len = length();
+	if (len == 0) {
+		// Technically an empty string is subsequence of any string
+		return true;
+	}
+
+	if (len > p_string.length()) {
+		return false;
+	}
+
+	const char32_t *src = &operator[](0);
+	const char32_t *tgt = &p_string[0];
+
+	for (; *src && *tgt; tgt++) {
+		bool match = false;
+		if (case_insensitive) {
+			char32_t srcc = _find_lower(*src);
+			char32_t tgtc = _find_lower(*tgt);
+			match = srcc == tgtc;
+		} else {
+			match = *src == *tgt;
+		}
+		if (match) {
+			src++;
+			if (!*src) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+Vector<String> String::bigrams() const {
+	int n_pairs = length() - 1;
+	Vector<String> b;
+	if (n_pairs <= 0) {
+		return b;
+	}
+	b.resize(n_pairs);
+	for (int i = 0; i < n_pairs; i++) {
+		b.write[i] = substr(i, 2);
+	}
+	return b;
+}
+
+// Similarity according to Sorensen-Dice coefficient
+float String::similarity(const String &p_string) const {
+	if (operator==(p_string)) {
+		// Equal strings are totally similar
+		return 1.0f;
+	}
+	if (length() < 2 || p_string.length() < 2) {
+		// No way to calculate similarity without a single bigram
+		return 0.0f;
+	}
+
+	Vector<String> src_bigrams = bigrams();
+	Vector<String> tgt_bigrams = p_string.bigrams();
+
+	int src_size = src_bigrams.size();
+	int tgt_size = tgt_bigrams.size();
+
+	int sum = src_size + tgt_size;
+	int inter = 0;
+	for (int i = 0; i < src_size; i++) {
+		for (int j = 0; j < tgt_size; j++) {
+			if (src_bigrams[i] == tgt_bigrams[j]) {
+				inter++;
+				break;
+			}
+		}
+	}
+
+	return (2.0f * inter) / sum;
+}
+
+static bool _wildcard_match(const char32_t *p_pattern, const char32_t *p_string, bool p_case_sensitive) {
+	switch (*p_pattern) {
+		case '\0':
+			return !*p_string;
+		case '*':
+			return _wildcard_match(p_pattern + 1, p_string, p_case_sensitive) || (*p_string && _wildcard_match(p_pattern, p_string + 1, p_case_sensitive));
+		case '?':
+			return *p_string && (*p_string != '.') && _wildcard_match(p_pattern + 1, p_string + 1, p_case_sensitive);
+		default:
+
+			return (p_case_sensitive ? (*p_string == *p_pattern) : (_find_upper(*p_string) == _find_upper(*p_pattern))) && _wildcard_match(p_pattern + 1, p_string + 1, p_case_sensitive);
+	}
+}
+
+bool String::match(const String &p_wildcard) const {
+	if (!p_wildcard.length() || !length()) {
+		return false;
+	}
+
+	return _wildcard_match(p_wildcard.get_data(), get_data(), true);
+}
+
+bool String::matchn(const String &p_wildcard) const {
+	if (!p_wildcard.length() || !length()) {
+		return false;
+	}
+	return _wildcard_match(p_wildcard.get_data(), get_data(), false);
+}
+
+String String::format(const Variant &values, String placeholder) const {
+	String new_string = String(this->ptr());
+
+	if (values.get_type() == Variant::ARRAY) {
+		Array values_arr = values;
+
+		for (int i = 0; i < values_arr.size(); i++) {
+			String i_as_str = String::num_int64(i);
+
+			if (values_arr[i].get_type() == Variant::ARRAY) { //Array in Array structure [["name","RobotGuy"],[0,"godot"],["strength",9000.91]]
+				Array value_arr = values_arr[i];
+
+				if (value_arr.size() == 2) {
+					Variant v_key = value_arr[0];
+					String key = v_key;
+
+					Variant v_val = value_arr[1];
+					String val = v_val;
+
+					new_string = new_string.replace(placeholder.replace("_", key), val);
+				} else {
+					ERR_PRINT(String("STRING.format Inner Array size != 2 ").ascii().get_data());
+				}
+			} else { //Array structure ["RobotGuy","Logis","rookie"]
+				Variant v_val = values_arr[i];
+				String val = v_val;
+
+				if (placeholder.find("_") > -1) {
+					new_string = new_string.replace(placeholder.replace("_", i_as_str), val);
+				} else {
+					new_string = new_string.replace_first(placeholder, val);
+				}
+			}
+		}
+	} else if (values.get_type() == Variant::DICTIONARY) {
+		Dictionary d = values;
+		List<Variant> keys;
+		d.get_key_list(&keys);
+
+		for (const Variant &key : keys) {
+			new_string = new_string.replace(placeholder.replace("_", key), d[key]);
+		}
+	} else {
+		ERR_PRINT(String("Invalid type: use Array or Dictionary.").ascii().get_data());
+	}
+
+	return new_string;
+}
+
+String String::replace(const String &p_key, const String &p_with) const {
+	String new_string;
+	int search_from = 0;
+	int result = 0;
+
+	while ((result = find(p_key, search_from)) >= 0) {
+		new_string += substr(search_from, result - search_from);
+		new_string += p_with;
+		search_from = result + p_key.length();
+	}
+
+	if (search_from == 0) {
+		return *this;
+	}
+
+	new_string += substr(search_from, length() - search_from);
+
+	return new_string;
+}
+
+String String::replace(const char *p_key, const char *p_with) const {
+	String new_string;
+	int search_from = 0;
+	int result = 0;
+
+	while ((result = find(p_key, search_from)) >= 0) {
+		new_string += substr(search_from, result - search_from);
+		new_string += p_with;
+		int k = 0;
+		while (p_key[k] != '\0') {
+			k++;
+		}
+		search_from = result + k;
+	}
+
+	if (search_from == 0) {
+		return *this;
+	}
+
+	new_string += substr(search_from, length() - search_from);
+
+	return new_string;
+}
+
+String String::replace_first(const String &p_key, const String &p_with) const {
+	int pos = find(p_key);
+	if (pos >= 0) {
+		return substr(0, pos) + p_with + substr(pos + p_key.length(), length());
+	}
+
+	return *this;
+}
+
+String String::replacen(const String &p_key, const String &p_with) const {
+	String new_string;
+	int search_from = 0;
+	int result = 0;
+
+	while ((result = findn(p_key, search_from)) >= 0) {
+		new_string += substr(search_from, result - search_from);
+		new_string += p_with;
+		search_from = result + p_key.length();
+	}
+
+	if (search_from == 0) {
+		return *this;
+	}
+
+	new_string += substr(search_from, length() - search_from);
+	return new_string;
+}
+
+String String::repeat(int p_count) const {
+	ERR_FAIL_COND_V_MSG(p_count < 0, "", "Parameter count should be a positive number.");
+
+	int len = length();
+	String new_string = *this;
+	new_string.resize(p_count * len + 1);
+
+	char32_t *dst = new_string.ptrw();
+	int offset = 1;
+	int stride = 1;
+	while (offset < p_count) {
+		memcpy(dst + offset * len, dst, stride * len * sizeof(char32_t));
+		offset += stride;
+		stride = MIN(stride * 2, p_count - offset);
+	}
+	dst[p_count * len] = _null;
+	return new_string;
+}
+
+String String::left(int p_len) const {
+	if (p_len < 0) {
+		p_len = length() + p_len;
+	}
+
+	if (p_len <= 0) {
+		return "";
+	}
+
+	if (p_len >= length()) {
+		return *this;
+	}
+
+	return substr(0, p_len);
+}
+
+String String::right(int p_len) const {
+	if (p_len < 0) {
+		p_len = length() + p_len;
+	}
+
+	if (p_len <= 0) {
+		return "";
+	}
+
+	if (p_len >= length()) {
+		return *this;
+	}
+
+	return substr(length() - p_len);
+}
+
+char32_t String::unicode_at(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, length(), 0);
+	return operator[](p_idx);
+}
+
+String String::indent(const String &p_prefix) const {
+	String new_string;
+	int line_start = 0;
+
+	for (int i = 0; i < length(); i++) {
+		const char32_t c = operator[](i);
+		if (c == '\n') {
+			if (i == line_start) {
+				new_string += c; // Leave empty lines empty.
+			} else {
+				new_string += p_prefix + substr(line_start, i - line_start + 1);
+			}
+			line_start = i + 1;
+		}
+	}
+	if (line_start != length()) {
+		new_string += p_prefix + substr(line_start);
+	}
+	return new_string;
+}
+
+String String::dedent() const {
+	String new_string;
+	String indent;
+	bool has_indent = false;
+	bool has_text = false;
+	int line_start = 0;
+	int indent_stop = -1;
+
+	for (int i = 0; i < length(); i++) {
+		char32_t c = operator[](i);
+		if (c == '\n') {
+			if (has_text) {
+				new_string += substr(indent_stop, i - indent_stop);
+			}
+			new_string += "\n";
+			has_text = false;
+			line_start = i + 1;
+			indent_stop = -1;
+		} else if (!has_text) {
+			if (c > 32) {
+				has_text = true;
+				if (!has_indent) {
+					has_indent = true;
+					indent = substr(line_start, i - line_start);
+					indent_stop = i;
+				}
+			}
+			if (has_indent && indent_stop < 0) {
+				int j = i - line_start;
+				if (j >= indent.length() || c != indent[j]) {
+					indent_stop = i;
+				}
+			}
+		}
+	}
+
+	if (has_text) {
+		new_string += substr(indent_stop, length() - indent_stop);
+	}
+
+	return new_string;
+}
+
+String String::strip_edges(bool left, bool right) const {
+	int len = length();
+	int beg = 0, end = len;
+
+	if (left) {
+		for (int i = 0; i < len; i++) {
+			if (operator[](i) <= 32) {
+				beg++;
+			} else {
+				break;
+			}
+		}
+	}
+
+	if (right) {
+		for (int i = len - 1; i >= 0; i--) {
+			if (operator[](i) <= 32) {
+				end--;
+			} else {
+				break;
+			}
+		}
+	}
+
+	if (beg == 0 && end == len) {
+		return *this;
+	}
+
+	return substr(beg, end - beg);
+}
+
+String String::strip_escapes() const {
+	String new_string;
+	for (int i = 0; i < length(); i++) {
+		// Escape characters on first page of the ASCII table, before 32 (Space).
+		if (operator[](i) < 32) {
+			continue;
+		}
+		new_string += operator[](i);
+	}
+
+	return new_string;
+}
+
+String String::lstrip(const String &p_chars) const {
+	int len = length();
+	int beg;
+
+	for (beg = 0; beg < len; beg++) {
+		if (p_chars.find_char(get(beg)) == -1) {
+			break;
+		}
+	}
+
+	if (beg == 0) {
+		return *this;
+	}
+
+	return substr(beg, len - beg);
+}
+
+String String::rstrip(const String &p_chars) const {
+	int len = length();
+	int end;
+
+	for (end = len - 1; end >= 0; end--) {
+		if (p_chars.find_char(get(end)) == -1) {
+			break;
+		}
+	}
+
+	if (end == len - 1) {
+		return *this;
+	}
+
+	return substr(0, end + 1);
+}
+
+bool String::is_network_share_path() const {
+	return begins_with("//") || begins_with("\\\\");
+}
+
+String String::simplify_path() const {
+	String s = *this;
+	String drive;
+
+	// Check if we have a special path (like res://) or a protocol identifier.
+	int p = s.find("://");
+	bool found = false;
+	if (p > 0) {
+		bool only_chars = true;
+		for (int i = 0; i < p; i++) {
+			if (!is_ascii_alphanumeric_char(s[i])) {
+				only_chars = false;
+				break;
+			}
+		}
+		if (only_chars) {
+			found = true;
+			drive = s.substr(0, p + 3);
+			s = s.substr(p + 3);
+		}
+	}
+	if (!found) {
+		if (is_network_share_path()) {
+			// Network path, beginning with // or \\.
+			drive = s.substr(0, 2);
+			s = s.substr(2);
+		} else if (s.begins_with("/") || s.begins_with("\\")) {
+			// Absolute path.
+			drive = s.substr(0, 1);
+			s = s.substr(1);
+		} else {
+			// Windows-style drive path, like C:/ or C:\.
+			p = s.find(":/");
+			if (p == -1) {
+				p = s.find(":\\");
+			}
+			if (p != -1 && p < s.find("/")) {
+				drive = s.substr(0, p + 2);
+				s = s.substr(p + 2);
+			}
+		}
+	}
+
+	s = s.replace("\\", "/");
+	while (true) { // in case of using 2 or more slash
+		String compare = s.replace("//", "/");
+		if (s == compare) {
+			break;
+		} else {
+			s = compare;
+		}
+	}
+	Vector<String> dirs = s.split("/", false);
+
+	for (int i = 0; i < dirs.size(); i++) {
+		String d = dirs[i];
+		if (d == ".") {
+			dirs.remove_at(i);
+			i--;
+		} else if (d == "..") {
+			if (i == 0) {
+				dirs.remove_at(i);
+				i--;
+			} else {
+				dirs.remove_at(i);
+				dirs.remove_at(i - 1);
+				i -= 2;
+			}
+		}
+	}
+
+	s = "";
+
+	for (int i = 0; i < dirs.size(); i++) {
+		if (i > 0) {
+			s += "/";
+		}
+		s += dirs[i];
+	}
+
+	return drive + s;
+}
+
+static int _humanize_digits(int p_num) {
+	if (p_num < 100) {
+		return 2;
+	} else if (p_num < 1024) {
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
+String String::humanize_size(uint64_t p_size) {
+	uint64_t _div = 1;
+	Vector<String> prefixes;
+	prefixes.push_back(RTR("B"));
+	prefixes.push_back(RTR("KiB"));
+	prefixes.push_back(RTR("MiB"));
+	prefixes.push_back(RTR("GiB"));
+	prefixes.push_back(RTR("TiB"));
+	prefixes.push_back(RTR("PiB"));
+	prefixes.push_back(RTR("EiB"));
+
+	int prefix_idx = 0;
+
+	while (prefix_idx < prefixes.size() - 1 && p_size > (_div * 1024)) {
+		_div *= 1024;
+		prefix_idx++;
+	}
+
+	const int digits = prefix_idx > 0 ? _humanize_digits(p_size / _div) : 0;
+	const double divisor = prefix_idx > 0 ? _div : 1;
+
+	return String::num(p_size / divisor).pad_decimals(digits) + " " + prefixes[prefix_idx];
+}
+
+bool String::is_absolute_path() const {
+	if (length() > 1) {
+		return (operator[](0) == '/' || operator[](0) == '\\' || find(":/") != -1 || find(":\\") != -1);
+	} else if ((length()) == 1) {
+		return (operator[](0) == '/' || operator[](0) == '\\');
+	} else {
+		return false;
+	}
+}
+
+static _FORCE_INLINE_ bool _is_valid_identifier_bit(int p_index, char32_t p_char) {
+	if (p_index == 0 && is_digit(p_char)) {
+		return false; // No start with number plz.
+	}
+	return is_ascii_identifier_char(p_char);
+}
+
+String String::validate_identifier() const {
+	if (is_empty()) {
+		return "_"; // Empty string is not a valid identifier;
+	}
+
+	String result = *this;
+	int len = result.length();
+	char32_t *buffer = result.ptrw();
+
+	for (int i = 0; i < len; i++) {
+		if (!_is_valid_identifier_bit(i, buffer[i])) {
+			buffer[i] = '_';
+		}
+	}
+
+	return result;
+}
+
+bool String::is_valid_identifier() const {
+	int len = length();
+
+	if (len == 0) {
+		return false;
+	}
+
+	const char32_t *str = &operator[](0);
+
+	for (int i = 0; i < len; i++) {
+		if (!_is_valid_identifier_bit(i, str[i])) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool String::is_valid_string() const {
+	int l = length();
+	const char32_t *src = get_data();
+	bool valid = true;
+	for (int i = 0; i < l; i++) {
+		valid = valid && (src[i] < 0xd800 || (src[i] > 0xdfff && src[i] <= 0x10ffff));
+	}
+	return valid;
+}
+
+String String::uri_encode() const {
+	const CharString temp = utf8();
+	String res;
+	for (int i = 0; i < temp.length(); ++i) {
+		uint8_t ord = temp[i];
+		if (ord == '.' || ord == '-' || ord == '~' || is_ascii_identifier_char(ord)) {
+			res += ord;
+		} else {
+			char p[4] = { '%', 0, 0, 0 };
+			static const char hex[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
+			p[1] = hex[ord >> 4];
+			p[2] = hex[ord & 0xF];
+			res += p;
+		}
+	}
+	return res;
+}
+
+String String::uri_decode() const {
+	CharString src = utf8();
+	CharString res;
+	for (int i = 0; i < src.length(); ++i) {
+		if (src[i] == '%' && i + 2 < src.length()) {
+			char ord1 = src[i + 1];
+			if (is_digit(ord1) || is_ascii_upper_case(ord1)) {
+				char ord2 = src[i + 2];
+				if (is_digit(ord2) || is_ascii_upper_case(ord2)) {
+					char bytes[3] = { (char)ord1, (char)ord2, 0 };
+					res += (char)strtol(bytes, nullptr, 16);
+					i += 2;
+				}
+			} else {
+				res += src[i];
+			}
+		} else if (src[i] == '+') {
+			res += ' ';
+		} else {
+			res += src[i];
+		}
+	}
+	return String::utf8(res);
+}
+
+String String::c_unescape() const {
+	String escaped = *this;
+	escaped = escaped.replace("\\a", "\a");
+	escaped = escaped.replace("\\b", "\b");
+	escaped = escaped.replace("\\f", "\f");
+	escaped = escaped.replace("\\n", "\n");
+	escaped = escaped.replace("\\r", "\r");
+	escaped = escaped.replace("\\t", "\t");
+	escaped = escaped.replace("\\v", "\v");
+	escaped = escaped.replace("\\'", "\'");
+	escaped = escaped.replace("\\\"", "\"");
+	escaped = escaped.replace("\\\\", "\\");
+
+	return escaped;
+}
+
+String String::c_escape() const {
+	String escaped = *this;
+	escaped = escaped.replace("\\", "\\\\");
+	escaped = escaped.replace("\a", "\\a");
+	escaped = escaped.replace("\b", "\\b");
+	escaped = escaped.replace("\f", "\\f");
+	escaped = escaped.replace("\n", "\\n");
+	escaped = escaped.replace("\r", "\\r");
+	escaped = escaped.replace("\t", "\\t");
+	escaped = escaped.replace("\v", "\\v");
+	escaped = escaped.replace("\'", "\\'");
+	escaped = escaped.replace("\"", "\\\"");
+
+	return escaped;
+}
+
+String String::c_escape_multiline() const {
+	String escaped = *this;
+	escaped = escaped.replace("\\", "\\\\");
+	escaped = escaped.replace("\"", "\\\"");
+
+	return escaped;
+}
+
+String String::json_escape() const {
+	String escaped = *this;
+	escaped = escaped.replace("\\", "\\\\");
+	escaped = escaped.replace("\b", "\\b");
+	escaped = escaped.replace("\f", "\\f");
+	escaped = escaped.replace("\n", "\\n");
+	escaped = escaped.replace("\r", "\\r");
+	escaped = escaped.replace("\t", "\\t");
+	escaped = escaped.replace("\v", "\\v");
+	escaped = escaped.replace("\"", "\\\"");
+
+	return escaped;
+}
+
+String String::xml_escape(bool p_escape_quotes) const {
+	String str = *this;
+	str = str.replace("&", "&amp;");
+	str = str.replace("<", "&lt;");
+	str = str.replace(">", "&gt;");
+	if (p_escape_quotes) {
+		str = str.replace("'", "&apos;");
+		str = str.replace("\"", "&quot;");
+	}
+	/*
+for (int i=1;i<32;i++) {
+	char chr[2]={i,0};
+	str=str.replace(chr,"&#"+String::num(i)+";");
+}*/
+	return str;
+}
+
+static _FORCE_INLINE_ int _xml_unescape(const char32_t *p_src, int p_src_len, char32_t *p_dst) {
+	int len = 0;
+	while (p_src_len) {
+		if (*p_src == '&') {
+			int eat = 0;
+
+			if (p_src_len >= 4 && p_src[1] == '#') {
+				char32_t c = 0;
+				bool overflow = false;
+				if (p_src[2] == 'x') {
+					// Hex entity &#x<num>;
+					for (int i = 3; i < p_src_len; i++) {
+						eat = i + 1;
+						char32_t ct = p_src[i];
+						if (ct == ';') {
+							break;
+						} else if (is_digit(ct)) {
+							ct = ct - '0';
+						} else if (ct >= 'a' && ct <= 'f') {
+							ct = (ct - 'a') + 10;
+						} else if (ct >= 'A' && ct <= 'F') {
+							ct = (ct - 'A') + 10;
+						} else {
+							break;
+						}
+						if (c > (UINT32_MAX >> 4)) {
+							overflow = true;
+							break;
+						}
+						c <<= 4;
+						c |= ct;
+					}
+				} else {
+					// Decimal entity &#<num>;
+					for (int i = 2; i < p_src_len; i++) {
+						eat = i + 1;
+						char32_t ct = p_src[i];
+						if (ct == ';' || !is_digit(ct)) {
+							break;
+						}
+					}
+					if (p_src[eat - 1] == ';') {
+						int64_t val = String::to_int(p_src + 2, eat - 3);
+						if (val > 0 && val <= UINT32_MAX) {
+							c = (char32_t)val;
+						} else {
+							overflow = true;
+						}
+					}
+				}
+
+				// Value must be non-zero, in the range of char32_t,
+				// actually end with ';'. If invalid, leave the entity as-is
+				if (c == '\0' || overflow || p_src[eat - 1] != ';') {
+					eat = 1;
+					c = *p_src;
+				}
+				if (p_dst) {
+					*p_dst = c;
+				}
+
+			} else if (p_src_len >= 4 && p_src[1] == 'g' && p_src[2] == 't' && p_src[3] == ';') {
+				if (p_dst) {
+					*p_dst = '>';
+				}
+				eat = 4;
+			} else if (p_src_len >= 4 && p_src[1] == 'l' && p_src[2] == 't' && p_src[3] == ';') {
+				if (p_dst) {
+					*p_dst = '<';
+				}
+				eat = 4;
+			} else if (p_src_len >= 5 && p_src[1] == 'a' && p_src[2] == 'm' && p_src[3] == 'p' && p_src[4] == ';') {
+				if (p_dst) {
+					*p_dst = '&';
+				}
+				eat = 5;
+			} else if (p_src_len >= 6 && p_src[1] == 'q' && p_src[2] == 'u' && p_src[3] == 'o' && p_src[4] == 't' && p_src[5] == ';') {
+				if (p_dst) {
+					*p_dst = '"';
+				}
+				eat = 6;
+			} else if (p_src_len >= 6 && p_src[1] == 'a' && p_src[2] == 'p' && p_src[3] == 'o' && p_src[4] == 's' && p_src[5] == ';') {
+				if (p_dst) {
+					*p_dst = '\'';
+				}
+				eat = 6;
+			} else {
+				if (p_dst) {
+					*p_dst = *p_src;
+				}
+				eat = 1;
+			}
+
+			if (p_dst) {
+				p_dst++;
+			}
+
+			len++;
+			p_src += eat;
+			p_src_len -= eat;
+		} else {
+			if (p_dst) {
+				*p_dst = *p_src;
+				p_dst++;
+			}
+			len++;
+			p_src++;
+			p_src_len--;
+		}
+	}
+
+	return len;
+}
+
+String String::xml_unescape() const {
+	String str;
+	int l = length();
+	int len = _xml_unescape(get_data(), l, nullptr);
+	if (len == 0) {
+		return String();
+	}
+	str.resize(len + 1);
+	_xml_unescape(get_data(), l, str.ptrw());
+	str[len] = 0;
+	return str;
+}
+
+String String::pad_decimals(int p_digits) const {
+	String s = *this;
+	int c = s.find(".");
+
+	if (c == -1) {
+		if (p_digits <= 0) {
+			return s;
+		}
+		s += ".";
+		c = s.length() - 1;
+	} else {
+		if (p_digits <= 0) {
+			return s.substr(0, c);
+		}
+	}
+
+	if (s.length() - (c + 1) > p_digits) {
+		s = s.substr(0, c + p_digits + 1);
+	} else {
+		while (s.length() - (c + 1) < p_digits) {
+			s += "0";
+		}
+	}
+	return s;
+}
+
+String String::pad_zeros(int p_digits) const {
+	String s = *this;
+	int end = s.find(".");
+
+	if (end == -1) {
+		end = s.length();
+	}
+
+	if (end == 0) {
+		return s;
+	}
+
+	int begin = 0;
+
+	while (begin < end && !is_digit(s[begin])) {
+		begin++;
+	}
+
+	if (begin >= end) {
+		return s;
+	}
+
+	while (end - begin < p_digits) {
+		s = s.insert(begin, "0");
+		end++;
+	}
+
+	return s;
+}
+
+String String::trim_prefix(const String &p_prefix) const {
+	String s = *this;
+	if (s.begins_with(p_prefix)) {
+		return s.substr(p_prefix.length(), s.length() - p_prefix.length());
+	}
+	return s;
+}
+
+String String::trim_suffix(const String &p_suffix) const {
+	String s = *this;
+	if (s.ends_with(p_suffix)) {
+		return s.substr(0, s.length() - p_suffix.length());
+	}
+	return s;
+}
+
+bool String::is_valid_int() const {
+	int len = length();
+
+	if (len == 0) {
+		return false;
+	}
+
+	int from = 0;
+	if (len != 1 && (operator[](0) == '+' || operator[](0) == '-')) {
+		from++;
+	}
+
+	for (int i = from; i < len; i++) {
+		if (!is_digit(operator[](i))) {
+			return false; // no start with number plz
+		}
+	}
+
+	return true;
+}
+
+bool String::is_valid_hex_number(bool p_with_prefix) const {
+	int len = length();
+
+	if (len == 0) {
+		return false;
+	}
+
+	int from = 0;
+	if (len != 1 && (operator[](0) == '+' || operator[](0) == '-')) {
+		from++;
+	}
+
+	if (p_with_prefix) {
+		if (len < 3) {
+			return false;
+		}
+		if (operator[](from) != '0' || operator[](from + 1) != 'x') {
+			return false;
+		}
+		from += 2;
+	}
+
+	for (int i = from; i < len; i++) {
+		char32_t c = operator[](i);
+		if (is_hex_digit(c)) {
+			continue;
+		}
+		return false;
+	}
+
+	return true;
+}
+
+bool String::is_valid_float() const {
+	int len = length();
+
+	if (len == 0) {
+		return false;
+	}
+
+	int from = 0;
+	if (operator[](0) == '+' || operator[](0) == '-') {
+		from++;
+	}
+
+	bool exponent_found = false;
+	bool period_found = false;
+	bool sign_found = false;
+	bool exponent_values_found = false;
+	bool numbers_found = false;
+
+	for (int i = from; i < len; i++) {
+		if (is_digit(operator[](i))) {
+			if (exponent_found) {
+				exponent_values_found = true;
+			} else {
+				numbers_found = true;
+			}
+		} else if (numbers_found && !exponent_found && operator[](i) == 'e') {
+			exponent_found = true;
+		} else if (!period_found && !exponent_found && operator[](i) == '.') {
+			period_found = true;
+		} else if ((operator[](i) == '-' || operator[](i) == '+') && exponent_found && !exponent_values_found && !sign_found) {
+			sign_found = true;
+		} else {
+			return false; // no start with number plz
+		}
+	}
+
+	return numbers_found;
+}
+
+String String::path_to_file(const String &p_path) const {
+	// Don't get base dir for src, this is expected to be a dir already.
+	String src = this->replace("\\", "/");
+	String dst = p_path.replace("\\", "/").get_base_dir();
+	String rel = src.path_to(dst);
+	if (rel == dst) { // failed
+		return p_path;
+	} else {
+		return rel + p_path.get_file();
+	}
+}
+
+String String::path_to(const String &p_path) const {
+	String src = this->replace("\\", "/");
+	String dst = p_path.replace("\\", "/");
+	if (!src.ends_with("/")) {
+		src += "/";
+	}
+	if (!dst.ends_with("/")) {
+		dst += "/";
+	}
+
+	if (src.begins_with("res://") && dst.begins_with("res://")) {
+		src = src.replace("res://", "/");
+		dst = dst.replace("res://", "/");
+
+	} else if (src.begins_with("user://") && dst.begins_with("user://")) {
+		src = src.replace("user://", "/");
+		dst = dst.replace("user://", "/");
+
+	} else if (src.begins_with("/") && dst.begins_with("/")) {
+		//nothing
+	} else {
+		//dos style
+		String src_begin = src.get_slicec('/', 0);
+		String dst_begin = dst.get_slicec('/', 0);
+
+		if (src_begin != dst_begin) {
+			return p_path; //impossible to do this
+		}
+
+		src = src.substr(src_begin.length(), src.length());
+		dst = dst.substr(dst_begin.length(), dst.length());
+	}
+
+	//remove leading and trailing slash and split
+	Vector<String> src_dirs = src.substr(1, src.length() - 2).split("/");
+	Vector<String> dst_dirs = dst.substr(1, dst.length() - 2).split("/");
+
+	//find common parent
+	int common_parent = 0;
+
+	while (true) {
+		if (src_dirs.size() == common_parent) {
+			break;
+		}
+		if (dst_dirs.size() == common_parent) {
+			break;
+		}
+		if (src_dirs[common_parent] != dst_dirs[common_parent]) {
+			break;
+		}
+		common_parent++;
+	}
+
+	common_parent--;
+
+	String dir;
+
+	for (int i = src_dirs.size() - 1; i > common_parent; i--) {
+		dir += "../";
+	}
+
+	for (int i = common_parent + 1; i < dst_dirs.size(); i++) {
+		dir += dst_dirs[i] + "/";
+	}
+
+	if (dir.length() == 0) {
+		dir = "./";
+	}
+	return dir;
+}
+
+bool String::is_valid_html_color() const {
+	return Color::html_is_valid(*this);
+}
+
+// Changes made to the set of invalid filename characters must also be reflected in the String documentation for is_valid_filename.
+static const char *invalid_filename_characters = ": / \\ ? * \" | % < >";
+
+bool String::is_valid_filename() const {
+	String stripped = strip_edges();
+	if (*this != stripped) {
+		return false;
+	}
+
+	if (stripped.is_empty()) {
+		return false;
+	}
+
+	Vector<String> chars = String(invalid_filename_characters).split(" ");
+	for (const String &ch : chars) {
+		if (contains(ch)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+String String::validate_filename() const {
+	Vector<String> chars = String(invalid_filename_characters).split(" ");
+	String name = strip_edges();
+	for (int i = 0; i < chars.size(); i++) {
+		name = name.replace(chars[i], "_");
+	}
+	return name;
+}
+
+bool String::is_valid_ip_address() const {
+	if (find(":") >= 0) {
+		Vector<String> ip = split(":");
+		for (int i = 0; i < ip.size(); i++) {
+			String n = ip[i];
+			if (n.is_empty()) {
+				continue;
+			}
+			if (n.is_valid_hex_number(false)) {
+				int64_t nint = n.hex_to_int();
+				if (nint < 0 || nint > 0xffff) {
+					return false;
+				}
+				continue;
+			}
+			if (!n.is_valid_ip_address()) {
+				return false;
+			}
+		}
+
+	} else {
+		Vector<String> ip = split(".");
+		if (ip.size() != 4) {
+			return false;
+		}
+		for (int i = 0; i < ip.size(); i++) {
+			String n = ip[i];
+			if (!n.is_valid_int()) {
+				return false;
+			}
+			int val = n.to_int();
+			if (val < 0 || val > 255) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+bool String::is_resource_file() const {
+	return begins_with("res://") && find("::") == -1;
+}
+
+bool String::is_relative_path() const {
+	return !is_absolute_path();
+}
+
+String String::get_base_dir() const {
+	int end = 0;
+
+	// URL scheme style base.
+	int basepos = find("://");
+	if (basepos != -1) {
+		end = basepos + 3;
+	}
+
+	// Windows top level directory base.
+	if (end == 0) {
+		basepos = find(":/");
+		if (basepos == -1) {
+			basepos = find(":\\");
+		}
+		if (basepos != -1) {
+			end = basepos + 2;
+		}
+	}
+
+	// Windows UNC network share path.
+	if (end == 0) {
+		if (is_network_share_path()) {
+			basepos = find("/", 2);
+			if (basepos == -1) {
+				basepos = find("\\", 2);
+			}
+			int servpos = find("/", basepos + 1);
+			if (servpos == -1) {
+				servpos = find("\\", basepos + 1);
+			}
+			if (servpos != -1) {
+				end = servpos + 1;
+			}
+		}
+	}
+
+	// Unix root directory base.
+	if (end == 0) {
+		if (begins_with("/")) {
+			end = 1;
+		}
+	}
+
+	String rs;
+	String base;
+	if (end != 0) {
+		rs = substr(end, length());
+		base = substr(0, end);
+	} else {
+		rs = *this;
+	}
+
+	int sep = MAX(rs.rfind("/"), rs.rfind("\\"));
+	if (sep == -1) {
+		return base;
+	}
+
+	return base + rs.substr(0, sep);
+}
+
+String String::get_file() const {
+	int sep = MAX(rfind("/"), rfind("\\"));
+	if (sep == -1) {
+		return *this;
+	}
+
+	return substr(sep + 1, length());
+}
+
+String String::get_extension() const {
+	int pos = rfind(".");
+	if (pos < 0 || pos < MAX(rfind("/"), rfind("\\"))) {
+		return "";
+	}
+
+	return substr(pos + 1, length());
+}
+
+String String::path_join(const String &p_file) const {
+	if (is_empty()) {
+		return p_file;
+	}
+	if (operator[](length() - 1) == '/' || (p_file.size() > 0 && p_file.operator[](0) == '/')) {
+		return *this + p_file;
+	}
+	return *this + "/" + p_file;
+}
+
+String String::property_name_encode() const {
+	// Escape and quote strings with extended ASCII or further Unicode characters
+	// as well as '"', '=' or ' ' (32)
+	const char32_t *cstr = get_data();
+	for (int i = 0; cstr[i]; i++) {
+		if (cstr[i] == '=' || cstr[i] == '"' || cstr[i] == ';' || cstr[i] == '[' || cstr[i] == ']' || cstr[i] < 33 || cstr[i] > 126) {
+			return "\"" + c_escape_multiline() + "\"";
+		}
+	}
+	// Keep as is
+	return *this;
+}
+
+// Changes made to the set of invalid characters must also be reflected in the String documentation.
+const String String::invalid_node_name_characters = ". : @ / \" " UNIQUE_NODE_PREFIX;
+
+String String::validate_node_name() const {
+	Vector<String> chars = String::invalid_node_name_characters.split(" ");
+	String name = this->replace(chars[0], "");
+	for (int i = 1; i < chars.size(); i++) {
+		name = name.replace(chars[i], "");
+	}
+	return name;
+}
+
+String String::get_basename() const {
+	int pos = rfind(".");
+	if (pos < 0 || pos < MAX(rfind("/"), rfind("\\"))) {
+		return *this;
+	}
+
+	return substr(0, pos);
+}
+
+String itos(int64_t p_val) {
+	return String::num_int64(p_val);
+}
+
+String uitos(uint64_t p_val) {
+	return String::num_uint64(p_val);
+}
+
+String rtos(double p_val) {
+	return String::num(p_val);
+}
+
+String rtoss(double p_val) {
+	return String::num_scientific(p_val);
+}
+
+// Right-pad with a character.
+String String::rpad(int min_length, const String &character) const {
+	String s = *this;
+	int padding = min_length - s.length();
+	if (padding > 0) {
+		for (int i = 0; i < padding; i++) {
+			s = s + character;
+		}
+	}
+
+	return s;
+}
+
+// Left-pad with a character.
+String String::lpad(int min_length, const String &character) const {
+	String s = *this;
+	int padding = min_length - s.length();
+	if (padding > 0) {
+		for (int i = 0; i < padding; i++) {
+			s = character + s;
+		}
+	}
+
+	return s;
+}
+
+// sprintf is implemented in GDScript via:
+//   "fish %s pie" % "frog"
+//   "fish %s %d pie" % ["frog", 12]
+// In case of an error, the string returned is the error description and "error" is true.
+String String::sprintf(const Array &values, bool *error) const {
+	String formatted;
+	char32_t *self = (char32_t *)get_data();
+	bool in_format = false;
+	int value_index = 0;
+	int min_chars = 0;
+	int min_decimals = 0;
+	bool in_decimals = false;
+	bool pad_with_zeros = false;
+	bool left_justified = false;
+	bool show_sign = false;
+
+	if (error) {
+		*error = true;
+	}
+
+	for (; *self; self++) {
+		const char32_t c = *self;
+
+		if (in_format) { // We have % - let's see what else we get.
+			switch (c) {
+				case '%': { // Replace %% with %
+					formatted += chr(c);
+					in_format = false;
+					break;
+				}
+				case 'd': // Integer (signed)
+				case 'o': // Octal
+				case 'x': // Hexadecimal (lowercase)
+				case 'X': { // Hexadecimal (uppercase)
+					if (value_index >= values.size()) {
+						return "not enough arguments for format string";
+					}
+
+					if (!values[value_index].is_num()) {
+						return "a number is required";
+					}
+
+					int64_t value = values[value_index];
+					int base = 16;
+					bool capitalize = false;
+					switch (c) {
+						case 'd':
+							base = 10;
+							break;
+						case 'o':
+							base = 8;
+							break;
+						case 'x':
+							break;
+						case 'X':
+							base = 16;
+							capitalize = true;
+							break;
+					}
+					// Get basic number.
+					String str = String::num_int64(ABS(value), base, capitalize);
+					int number_len = str.length();
+
+					// Padding.
+					int pad_chars_count = (value < 0 || show_sign) ? min_chars - 1 : min_chars;
+					String pad_char = pad_with_zeros ? String("0") : String(" ");
+					if (left_justified) {
+						str = str.rpad(pad_chars_count, pad_char);
+					} else {
+						str = str.lpad(pad_chars_count, pad_char);
+					}
+
+					// Sign.
+					if (show_sign || value < 0) {
+						String sign_char = value < 0 ? "-" : "+";
+						if (left_justified) {
+							str = str.insert(0, sign_char);
+						} else {
+							str = str.insert(pad_with_zeros ? 0 : str.length() - number_len, sign_char);
+						}
+					}
+
+					formatted += str;
+					++value_index;
+					in_format = false;
+
+					break;
+				}
+				case 'f': { // Float
+					if (value_index >= values.size()) {
+						return "not enough arguments for format string";
+					}
+
+					if (!values[value_index].is_num()) {
+						return "a number is required";
+					}
+
+					double value = values[value_index];
+					bool is_negative = (value < 0);
+					String str = String::num(ABS(value), min_decimals);
+					const bool is_finite = Math::is_finite(value);
+
+					// Pad decimals out.
+					if (is_finite) {
+						str = str.pad_decimals(min_decimals);
+					}
+
+					int initial_len = str.length();
+
+					// Padding. Leave room for sign later if required.
+					int pad_chars_count = (is_negative || show_sign) ? min_chars - 1 : min_chars;
+					String pad_char = (pad_with_zeros && is_finite) ? String("0") : String(" "); // Never pad NaN or inf with zeros
+					if (left_justified) {
+						str = str.rpad(pad_chars_count, pad_char);
+					} else {
+						str = str.lpad(pad_chars_count, pad_char);
+					}
+
+					// Add sign if needed.
+					if (show_sign || is_negative) {
+						String sign_char = is_negative ? "-" : "+";
+						if (left_justified) {
+							str = str.insert(0, sign_char);
+						} else {
+							str = str.insert(pad_with_zeros ? 0 : str.length() - initial_len, sign_char);
+						}
+					}
+
+					formatted += str;
+					++value_index;
+					in_format = false;
+					break;
+				}
+				case 'v': { // Vector2/3/4/2i/3i/4i
+					if (value_index >= values.size()) {
+						return "not enough arguments for format string";
+					}
+
+					int count;
+					switch (values[value_index].get_type()) {
+						case Variant::VECTOR2:
+						case Variant::VECTOR2I: {
+							count = 2;
+						} break;
+						case Variant::VECTOR3:
+						case Variant::VECTOR3I: {
+							count = 3;
+						} break;
+						case Variant::VECTOR4:
+						case Variant::VECTOR4I: {
+							count = 4;
+						} break;
+						default: {
+							return "%v requires a vector type (Vector2/3/4/2i/3i/4i)";
+						}
+					}
+
+					Vector4 vec = values[value_index];
+					String str = "(";
+					for (int i = 0; i < count; i++) {
+						double val = vec[i];
+						String number_str = String::num(ABS(val), min_decimals);
+						const bool is_finite = Math::is_finite(val);
+
+						// Pad decimals out.
+						if (is_finite) {
+							number_str = number_str.pad_decimals(min_decimals);
+						}
+
+						int initial_len = number_str.length();
+
+						// Padding. Leave room for sign later if required.
+						int pad_chars_count = val < 0 ? min_chars - 1 : min_chars;
+						String pad_char = (pad_with_zeros && is_finite) ? String("0") : String(" "); // Never pad NaN or inf with zeros
+						if (left_justified) {
+							number_str = number_str.rpad(pad_chars_count, pad_char);
+						} else {
+							number_str = number_str.lpad(pad_chars_count, pad_char);
+						}
+
+						// Add sign if needed.
+						if (val < 0) {
+							if (left_justified) {
+								number_str = number_str.insert(0, "-");
+							} else {
+								number_str = number_str.insert(pad_with_zeros ? 0 : number_str.length() - initial_len, "-");
+							}
+						}
+
+						// Add number to combined string
+						str += number_str;
+
+						if (i < count - 1) {
+							str += ", ";
+						}
+					}
+					str += ")";
+
+					formatted += str;
+					++value_index;
+					in_format = false;
+					break;
+				}
+				case 's': { // String
+					if (value_index >= values.size()) {
+						return "not enough arguments for format string";
+					}
+
+					String str = values[value_index];
+					// Padding.
+					if (left_justified) {
+						str = str.rpad(min_chars);
+					} else {
+						str = str.lpad(min_chars);
+					}
+
+					formatted += str;
+					++value_index;
+					in_format = false;
+					break;
+				}
+				case 'c': {
+					if (value_index >= values.size()) {
+						return "not enough arguments for format string";
+					}
+
+					// Convert to character.
+					String str;
+					if (values[value_index].is_num()) {
+						int value = values[value_index];
+						if (value < 0) {
+							return "unsigned integer is lower than minimum";
+						} else if (value >= 0xd800 && value <= 0xdfff) {
+							return "unsigned integer is invalid Unicode character";
+						} else if (value > 0x10ffff) {
+							return "unsigned integer is greater than maximum";
+						}
+						str = chr(values[value_index]);
+					} else if (values[value_index].get_type() == Variant::STRING) {
+						str = values[value_index];
+						if (str.length() != 1) {
+							return "%c requires number or single-character string";
+						}
+					} else {
+						return "%c requires number or single-character string";
+					}
+
+					// Padding.
+					if (left_justified) {
+						str = str.rpad(min_chars);
+					} else {
+						str = str.lpad(min_chars);
+					}
+
+					formatted += str;
+					++value_index;
+					in_format = false;
+					break;
+				}
+				case '-': { // Left justify
+					left_justified = true;
+					break;
+				}
+				case '+': { // Show + if positive.
+					show_sign = true;
+					break;
+				}
+				case '0':
+				case '1':
+				case '2':
+				case '3':
+				case '4':
+				case '5':
+				case '6':
+				case '7':
+				case '8':
+				case '9': {
+					int n = c - '0';
+					if (in_decimals) {
+						min_decimals *= 10;
+						min_decimals += n;
+					} else {
+						if (c == '0' && min_chars == 0) {
+							if (left_justified) {
+								WARN_PRINT("'0' flag ignored with '-' flag in string format");
+							} else {
+								pad_with_zeros = true;
+							}
+						} else {
+							min_chars *= 10;
+							min_chars += n;
+						}
+					}
+					break;
+				}
+				case '.': { // Float/Vector separator.
+					if (in_decimals) {
+						return "too many decimal points in format";
+					}
+					in_decimals = true;
+					min_decimals = 0; // We want to add the value manually.
+					break;
+				}
+
+				case '*': { // Dynamic width, based on value.
+					if (value_index >= values.size()) {
+						return "not enough arguments for format string";
+					}
+
+					Variant::Type value_type = values[value_index].get_type();
+					if (!values[value_index].is_num() &&
+							value_type != Variant::VECTOR2 && value_type != Variant::VECTOR2I &&
+							value_type != Variant::VECTOR3 && value_type != Variant::VECTOR3I &&
+							value_type != Variant::VECTOR4 && value_type != Variant::VECTOR4I) {
+						return "* wants number or vector";
+					}
+
+					int size = values[value_index];
+
+					if (in_decimals) {
+						min_decimals = size;
+					} else {
+						min_chars = size;
+					}
+
+					++value_index;
+					break;
+				}
+
+				default: {
+					return "unsupported format character";
+				}
+			}
+		} else { // Not in format string.
+			switch (c) {
+				case '%':
+					in_format = true;
+					// Back to defaults:
+					min_chars = 0;
+					min_decimals = 6;
+					pad_with_zeros = false;
+					left_justified = false;
+					show_sign = false;
+					in_decimals = false;
+					break;
+				default:
+					formatted += chr(c);
+			}
+		}
+	}
+
+	if (in_format) {
+		return "incomplete format";
+	}
+
+	if (value_index != values.size()) {
+		return "not all arguments converted during string formatting";
+	}
+
+	if (error) {
+		*error = false;
+	}
+	return formatted;
+}
+
+String String::quote(String quotechar) const {
+	return quotechar + *this + quotechar;
+}
+
+String String::unquote() const {
+	if (!is_quoted()) {
+		return *this;
+	}
+
+	return substr(1, length() - 2);
+}
+
+Vector<uint8_t> String::to_ascii_buffer() const {
+	const String *s = this;
+	if (s->is_empty()) {
+		return Vector<uint8_t>();
+	}
+	CharString charstr = s->ascii();
+
+	Vector<uint8_t> retval;
+	size_t len = charstr.length();
+	retval.resize(len);
+	uint8_t *w = retval.ptrw();
+	memcpy(w, charstr.ptr(), len);
+
+	return retval;
+}
+
+Vector<uint8_t> String::to_utf8_buffer() const {
+	const String *s = this;
+	if (s->is_empty()) {
+		return Vector<uint8_t>();
+	}
+	CharString charstr = s->utf8();
+
+	Vector<uint8_t> retval;
+	size_t len = charstr.length();
+	retval.resize(len);
+	uint8_t *w = retval.ptrw();
+	memcpy(w, charstr.ptr(), len);
+
+	return retval;
+}
+
+Vector<uint8_t> String::to_utf16_buffer() const {
+	const String *s = this;
+	if (s->is_empty()) {
+		return Vector<uint8_t>();
+	}
+	Char16String charstr = s->utf16();
+
+	Vector<uint8_t> retval;
+	size_t len = charstr.length() * sizeof(char16_t);
+	retval.resize(len);
+	uint8_t *w = retval.ptrw();
+	memcpy(w, (const void *)charstr.ptr(), len);
+
+	return retval;
+}
+
+Vector<uint8_t> String::to_utf32_buffer() const {
+	const String *s = this;
+	if (s->is_empty()) {
+		return Vector<uint8_t>();
+	}
+
+	Vector<uint8_t> retval;
+	size_t len = s->length() * sizeof(char32_t);
+	retval.resize(len);
+	uint8_t *w = retval.ptrw();
+	memcpy(w, (const void *)s->ptr(), len);
+
+	return retval;
+}
+
+#ifdef TOOLS_ENABLED
+/**
+ * "Tools TRanslate". Performs string replacement for internationalization
+ * within the editor. A translation context can optionally be specified to
+ * disambiguate between identical source strings in translations. When
+ * placeholders are desired, use `vformat(TTR("Example: %s"), some_string)`.
+ * If a string mentions a quantity (and may therefore need a dynamic plural form),
+ * use `TTRN()` instead of `TTR()`.
+ *
+ * NOTE: Only use `TTR()` in editor-only code (typically within the `editor/` folder).
+ * For translations that can be supplied by exported projects, use `RTR()` instead.
+ */
+String TTR(const String &p_text, const String &p_context) {
+	if (TranslationServer::get_singleton()) {
+		return TranslationServer::get_singleton()->tool_translate(p_text, p_context);
+	}
+
+	return p_text;
+}
+
+/**
+ * "Tools TRanslate for N items". Performs string replacement for
+ * internationalization within the editor. A translation context can optionally
+ * be specified to disambiguate between identical source strings in
+ * translations. Use `TTR()` if the string doesn't need dynamic plural form.
+ * When placeholders are desired, use
+ * `vformat(TTRN("%d item", "%d items", some_integer), some_integer)`.
+ * The placeholder must be present in both strings to avoid run-time warnings in `vformat()`.
+ *
+ * NOTE: Only use `TTRN()` in editor-only code (typically within the `editor/` folder).
+ * For translations that can be supplied by exported projects, use `RTRN()` instead.
+ */
+String TTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context) {
+	if (TranslationServer::get_singleton()) {
+		return TranslationServer::get_singleton()->tool_translate_plural(p_text, p_text_plural, p_n, p_context);
+	}
+
+	// Return message based on English plural rule if translation is not possible.
+	if (p_n == 1) {
+		return p_text;
+	}
+	return p_text_plural;
+}
+
+/**
+ * "Docs TRanslate". Used for the editor class reference documentation,
+ * handling descriptions extracted from the XML.
+ * It also replaces `$DOCS_URL` with the actual URL to the documentation's branch,
+ * to allow dehardcoding it in the XML and doing proper substitutions everywhere.
+ */
+String DTR(const String &p_text, const String &p_context) {
+	// Comes straight from the XML, so remove indentation and any trailing whitespace.
+	const String text = p_text.dedent().strip_edges();
+
+	if (TranslationServer::get_singleton()) {
+		return String(TranslationServer::get_singleton()->doc_translate(text, p_context)).replace("$DOCS_URL", VERSION_DOCS_URL);
+	}
+
+	return text.replace("$DOCS_URL", VERSION_DOCS_URL);
+}
+
+/**
+ * "Docs TRanslate for N items". Used for the editor class reference documentation
+ * (with support for plurals), handling descriptions extracted from the XML.
+ * It also replaces `$DOCS_URL` with the actual URL to the documentation's branch,
+ * to allow dehardcoding it in the XML and doing proper substitutions everywhere.
+ */
+String DTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context) {
+	const String text = p_text.dedent().strip_edges();
+	const String text_plural = p_text_plural.dedent().strip_edges();
+
+	if (TranslationServer::get_singleton()) {
+		return String(TranslationServer::get_singleton()->doc_translate_plural(text, text_plural, p_n, p_context)).replace("$DOCS_URL", VERSION_DOCS_URL);
+	}
+
+	// Return message based on English plural rule if translation is not possible.
+	if (p_n == 1) {
+		return text.replace("$DOCS_URL", VERSION_DOCS_URL);
+	}
+	return text_plural.replace("$DOCS_URL", VERSION_DOCS_URL);
+}
+#endif
+
+/**
+ * "Run-time TRanslate". Performs string replacement for internationalization
+ * within a running project. The translation string must be supplied by the
+ * project, as Godot does not provide built-in translations for `RTR()` strings
+ * to keep binary size low. A translation context can optionally be specified to
+ * disambiguate between identical source strings in translations. When
+ * placeholders are desired, use `vformat(RTR("Example: %s"), some_string)`.
+ * If a string mentions a quantity (and may therefore need a dynamic plural form),
+ * use `RTRN()` instead of `RTR()`.
+ *
+ * NOTE: Do not use `RTR()` in editor-only code (typically within the `editor/`
+ * folder). For editor translations, use `TTR()` instead.
+ */
+String RTR(const String &p_text, const String &p_context) {
+	if (TranslationServer::get_singleton()) {
+		String rtr = TranslationServer::get_singleton()->tool_translate(p_text, p_context);
+		if (rtr.is_empty() || rtr == p_text) {
+			return TranslationServer::get_singleton()->translate(p_text, p_context);
+		} else {
+			return rtr;
+		}
+	}
+
+	return p_text;
+}
+
+/**
+ * "Run-time TRanslate for N items". Performs string replacement for
+ * internationalization within a running project. The translation string must be
+ * supplied by the project, as Godot does not provide built-in translations for
+ * `RTRN()` strings to keep binary size low. A translation context can
+ * optionally be specified to disambiguate between identical source strings in
+ * translations. Use `RTR()` if the string doesn't need dynamic plural form.
+ * When placeholders are desired, use
+ * `vformat(RTRN("%d item", "%d items", some_integer), some_integer)`.
+ * The placeholder must be present in both strings to avoid run-time warnings in `vformat()`.
+ *
+ * NOTE: Do not use `RTRN()` in editor-only code (typically within the `editor/`
+ * folder). For editor translations, use `TTRN()` instead.
+ */
+String RTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context) {
+	if (TranslationServer::get_singleton()) {
+		String rtr = TranslationServer::get_singleton()->tool_translate_plural(p_text, p_text_plural, p_n, p_context);
+		if (rtr.is_empty() || rtr == p_text || rtr == p_text_plural) {
+			return TranslationServer::get_singleton()->translate_plural(p_text, p_text_plural, p_n, p_context);
+		} else {
+			return rtr;
+		}
+	}
+
+	// Return message based on English plural rule if translation is not possible.
+	if (p_n == 1) {
+		return p_text;
+	}
+	return p_text_plural;
+}

--- a/patches/ustring.h.patched
+++ b/patches/ustring.h.patched
@@ -1,0 +1,550 @@
+/**************************************************************************/
+/*  ustring.h                                                             */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/**************************************************************************/
+
+#ifndef USTRING_GODOT_H
+#define USTRING_GODOT_H
+
+// Note: _GODOT suffix added to header guard to avoid conflict with ICU header.
+
+#include "core/string/char_utils.h"
+#include "core/templates/cowdata.h"
+#include "core/templates/vector.h"
+#include "core/typedefs.h"
+#include "core/variant/array.h"
+
+/*************************************************************************/
+/*  CharProxy                                                            */
+/*************************************************************************/
+
+template <class T>
+class CharProxy {
+	friend class Char16String;
+	friend class CharString;
+	friend class String;
+
+	const int _index;
+	CowData<T> &_cowdata;
+	static const T _null = 0;
+
+	_FORCE_INLINE_ CharProxy(const int &p_index, CowData<T> &p_cowdata) :
+			_index(p_index),
+			_cowdata(p_cowdata) {}
+
+public:
+	_FORCE_INLINE_ CharProxy(const CharProxy<T> &p_other) :
+			_index(p_other._index),
+			_cowdata(p_other._cowdata) {}
+
+	_FORCE_INLINE_ operator T() const {
+		if (unlikely(_index == _cowdata.size())) {
+			return _null;
+		}
+
+		return _cowdata.get(_index);
+	}
+
+	_FORCE_INLINE_ const T *operator&() const {
+		return _cowdata.ptr() + _index;
+	}
+
+	_FORCE_INLINE_ void operator=(const T &p_other) const {
+		_cowdata.set(_index, p_other);
+	}
+
+	_FORCE_INLINE_ void operator=(const CharProxy<T> &p_other) const {
+		_cowdata.set(_index, p_other.operator T());
+	}
+};
+
+/*************************************************************************/
+/*  Char16String                                                         */
+/*************************************************************************/
+
+class Char16String {
+	CowData<char16_t> _cowdata;
+	static const char16_t _null;
+
+public:
+	_FORCE_INLINE_ char16_t *ptrw() { return _cowdata.ptrw(); }
+	_FORCE_INLINE_ const char16_t *ptr() const { return _cowdata.ptr(); }
+	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
+	Error resize(int p_size) { return _cowdata.resize(p_size); }
+
+	_FORCE_INLINE_ char16_t get(int p_index) const { return _cowdata.get(p_index); }
+	_FORCE_INLINE_ void set(int p_index, const char16_t &p_elem) { _cowdata.set(p_index, p_elem); }
+	_FORCE_INLINE_ const char16_t &operator[](int p_index) const {
+		if (unlikely(p_index == _cowdata.size())) {
+			return _null;
+		}
+
+		return _cowdata.get(p_index);
+	}
+	_FORCE_INLINE_ CharProxy<char16_t> operator[](int p_index) { return CharProxy<char16_t>(p_index, _cowdata); }
+
+	_FORCE_INLINE_ Char16String() {}
+	_FORCE_INLINE_ Char16String(const Char16String &p_str) { _cowdata._ref(p_str._cowdata); }
+	_FORCE_INLINE_ void operator=(const Char16String &p_str) { _cowdata._ref(p_str._cowdata); }
+	_FORCE_INLINE_ Char16String(const char16_t *p_cstr) { copy_from(p_cstr); }
+
+	void operator=(const char16_t *p_cstr);
+	bool operator<(const Char16String &p_right) const;
+	Char16String &operator+=(char16_t p_char);
+	int length() const { return size() ? size() - 1 : 0; }
+	const char16_t *get_data() const;
+	operator const char16_t *() const { return get_data(); };
+
+protected:
+	void copy_from(const char16_t *p_cstr);
+};
+
+/*************************************************************************/
+/*  CharString                                                           */
+/*************************************************************************/
+
+class CharString {
+	CowData<char> _cowdata;
+	static const char _null;
+
+public:
+	_FORCE_INLINE_ char *ptrw() { return _cowdata.ptrw(); }
+	_FORCE_INLINE_ const char *ptr() const { return _cowdata.ptr(); }
+	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
+	Error resize(int p_size) { return _cowdata.resize(p_size); }
+
+	_FORCE_INLINE_ char get(int p_index) const { return _cowdata.get(p_index); }
+	_FORCE_INLINE_ void set(int p_index, const char &p_elem) { _cowdata.set(p_index, p_elem); }
+	_FORCE_INLINE_ const char &operator[](int p_index) const {
+		if (unlikely(p_index == _cowdata.size())) {
+			return _null;
+		}
+
+		return _cowdata.get(p_index);
+	}
+	_FORCE_INLINE_ CharProxy<char> operator[](int p_index) { return CharProxy<char>(p_index, _cowdata); }
+
+	_FORCE_INLINE_ CharString() {}
+	_FORCE_INLINE_ CharString(const CharString &p_str) { _cowdata._ref(p_str._cowdata); }
+	_FORCE_INLINE_ void operator=(const CharString &p_str) { _cowdata._ref(p_str._cowdata); }
+	_FORCE_INLINE_ CharString(const char *p_cstr) { copy_from(p_cstr); }
+
+	void operator=(const char *p_cstr);
+	bool operator<(const CharString &p_right) const;
+	bool operator==(const CharString &p_right) const;
+	CharString &operator+=(char p_char);
+	int length() const { return size() ? size() - 1 : 0; }
+	const char *get_data() const;
+	operator const char *() const { return get_data(); };
+
+protected:
+	void copy_from(const char *p_cstr);
+};
+
+/*************************************************************************/
+/*  String                                                               */
+/*************************************************************************/
+
+struct StrRange {
+	const char32_t *c_str;
+	int len;
+
+	StrRange(const char32_t *p_c_str = nullptr, int p_len = 0) {
+		c_str = p_c_str;
+		len = p_len;
+	}
+};
+
+class String {
+	CowData<char32_t> _cowdata;
+	static const char32_t _null;
+
+	void copy_from(const char *p_cstr);
+	void copy_from(const char *p_cstr, const int p_clip_to);
+	void copy_from(const wchar_t *p_cstr);
+	void copy_from(const wchar_t *p_cstr, const int p_clip_to);
+	void copy_from(const char32_t *p_cstr);
+	void copy_from(const char32_t *p_cstr, const int p_clip_to);
+
+	void copy_from(const char32_t &p_char);
+
+	void copy_from_unchecked(const char32_t *p_char, const int p_length);
+
+	bool _base_is_subsequence_of(const String &p_string, bool case_insensitive) const;
+	int _count(const String &p_string, int p_from, int p_to, bool p_case_insensitive) const;
+	String _camelcase_to_underscore() const;
+
+public:
+	enum {
+		npos = -1 ///<for "some" compatibility with std::string (npos is a huge value in std::string)
+	};
+
+	_FORCE_INLINE_ char32_t *ptrw() { return _cowdata.ptrw(); }
+	_FORCE_INLINE_ const char32_t *ptr() const { return _cowdata.ptr(); }
+
+	void remove_at(int p_index) { _cowdata.remove_at(p_index); }
+
+	_FORCE_INLINE_ void clear() { resize(0); }
+
+	_FORCE_INLINE_ char32_t get(int p_index) const { return _cowdata.get(p_index); }
+	_FORCE_INLINE_ void set(int p_index, const char32_t &p_elem) { _cowdata.set(p_index, p_elem); }
+	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
+	Error resize(int p_size) { return _cowdata.resize(p_size); }
+
+	_FORCE_INLINE_ const char32_t &operator[](int p_index) const {
+		if (unlikely(p_index == _cowdata.size())) {
+			return _null;
+		}
+
+		return _cowdata.get(p_index);
+	}
+	_FORCE_INLINE_ CharProxy<char32_t> operator[](int p_index) { return CharProxy<char32_t>(p_index, _cowdata); }
+
+	bool operator==(const String &p_str) const;
+	bool operator!=(const String &p_str) const;
+	String operator+(const String &p_str) const;
+	String operator+(char32_t p_char) const;
+
+	String &operator+=(const String &);
+	String &operator+=(char32_t p_char);
+	String &operator+=(const char *p_str);
+	String &operator+=(const wchar_t *p_str);
+	String &operator+=(const char32_t *p_str);
+
+	/* Compatibility Operators */
+
+	void operator=(const char *p_str);
+	void operator=(const wchar_t *p_str);
+	void operator=(const char32_t *p_str);
+
+	bool operator==(const char *p_str) const;
+	bool operator==(const wchar_t *p_str) const;
+	bool operator==(const char32_t *p_str) const;
+	bool operator==(const StrRange &p_str_range) const;
+
+	bool operator!=(const char *p_str) const;
+	bool operator!=(const wchar_t *p_str) const;
+	bool operator!=(const char32_t *p_str) const;
+
+	bool operator<(const char32_t *p_str) const;
+	bool operator<(const char *p_str) const;
+	bool operator<(const wchar_t *p_str) const;
+
+	bool operator<(const String &p_str) const;
+	bool operator<=(const String &p_str) const;
+	bool operator>(const String &p_str) const;
+	bool operator>=(const String &p_str) const;
+
+	signed char casecmp_to(const String &p_str) const;
+	signed char nocasecmp_to(const String &p_str) const;
+	signed char naturalnocasecmp_to(const String &p_str) const;
+
+	const char32_t *get_data() const;
+	/* standard size stuff */
+
+	_FORCE_INLINE_ int length() const {
+		int s = size();
+		return s ? (s - 1) : 0; // length does not include zero
+	}
+
+	bool is_valid_string() const;
+
+	/* debug, error messages */
+	void print_unicode_error(const String &p_message, bool p_critical = false) const;
+
+	/* complex helpers */
+	String substr(int p_from, int p_chars = -1) const;
+	int find(const String &p_str, int p_from = 0) const; ///< return <0 if failed
+	int find(const char *p_str, int p_from = 0) const; ///< return <0 if failed
+	int find_char(const char32_t &p_char, int p_from = 0) const; ///< return <0 if failed
+	int findn(const String &p_str, int p_from = 0) const; ///< return <0 if failed, case insensitive
+	int rfind(const String &p_str, int p_from = -1) const; ///< return <0 if failed
+	int rfindn(const String &p_str, int p_from = -1) const; ///< return <0 if failed, case insensitive
+	int findmk(const Vector<String> &p_keys, int p_from = 0, int *r_key = nullptr) const; ///< return <0 if failed
+	bool match(const String &p_wildcard) const;
+	bool matchn(const String &p_wildcard) const;
+	bool begins_with(const String &p_string) const;
+	bool begins_with(const char *p_string) const;
+	bool ends_with(const String &p_string) const;
+	bool is_enclosed_in(const String &p_string) const;
+	bool is_subsequence_of(const String &p_string) const;
+	bool is_subsequence_ofn(const String &p_string) const;
+	bool is_quoted() const;
+	Vector<String> bigrams() const;
+	float similarity(const String &p_string) const;
+	String format(const Variant &values, String placeholder = "{_}") const;
+	String replace_first(const String &p_key, const String &p_with) const;
+	String replace(const String &p_key, const String &p_with) const;
+	String replace(const char *p_key, const char *p_with) const;
+	String replacen(const String &p_key, const String &p_with) const;
+	String repeat(int p_count) const;
+	String insert(int p_at_pos, const String &p_string) const;
+	String pad_decimals(int p_digits) const;
+	String pad_zeros(int p_digits) const;
+	String trim_prefix(const String &p_prefix) const;
+	String trim_suffix(const String &p_suffix) const;
+	String lpad(int min_length, const String &character = " ") const;
+	String rpad(int min_length, const String &character = " ") const;
+	String sprintf(const Array &values, bool *error) const;
+	String quote(String quotechar = "\"") const;
+	String unquote() const;
+	static String num(double p_num, int p_decimals = -1);
+	static String num_scientific(double p_num);
+	static String num_real(double p_num, bool p_trailing = true);
+	static String num_int64(int64_t p_num, int base = 10, bool capitalize_hex = false);
+	static String num_uint64(uint64_t p_num, int base = 10, bool capitalize_hex = false);
+	static String chr(char32_t p_char);
+	static String md5(const uint8_t *p_md5);
+	static String hex_encode_buffer(const uint8_t *p_buffer, int p_len);
+	bool is_numeric() const;
+
+	double to_float() const;
+	int64_t hex_to_int() const;
+	int64_t bin_to_int() const;
+	int64_t to_int() const;
+
+	static int64_t to_int(const char *p_str, int p_len = -1);
+	static int64_t to_int(const wchar_t *p_str, int p_len = -1);
+	static int64_t to_int(const char32_t *p_str, int p_len = -1, bool p_clamp = false);
+
+	static double to_float(const char *p_str);
+	static double to_float(const wchar_t *p_str, const wchar_t **r_end = nullptr);
+	static double to_float(const char32_t *p_str, const char32_t **r_end = nullptr);
+
+	String capitalize() const;
+	String to_camel_case() const;
+	String to_pascal_case() const;
+	String to_snake_case() const;
+
+	String get_with_code_lines() const;
+	int get_slice_count(String p_splitter) const;
+	String get_slice(String p_splitter, int p_slice) const;
+	String get_slicec(char32_t p_splitter, int p_slice) const;
+
+	Vector<String> split(const String &p_splitter = "", bool p_allow_empty = true, int p_maxsplit = 0) const;
+	Vector<String> rsplit(const String &p_splitter = "", bool p_allow_empty = true, int p_maxsplit = 0) const;
+	Vector<String> split_spaces() const;
+	Vector<double> split_floats(const String &p_splitter, bool p_allow_empty = true) const;
+	Vector<float> split_floats_mk(const Vector<String> &p_splitters, bool p_allow_empty = true) const;
+	Vector<int> split_ints(const String &p_splitter, bool p_allow_empty = true) const;
+	Vector<int> split_ints_mk(const Vector<String> &p_splitters, bool p_allow_empty = true) const;
+
+	String join(Vector<String> parts) const;
+
+	static char32_t char_uppercase(char32_t p_char);
+	static char32_t char_lowercase(char32_t p_char);
+	String to_upper() const;
+	String to_lower() const;
+
+	int count(const String &p_string, int p_from = 0, int p_to = 0) const;
+	int countn(const String &p_string, int p_from = 0, int p_to = 0) const;
+
+	String left(int p_len) const;
+	String right(int p_len) const;
+	String indent(const String &p_prefix) const;
+	String dedent() const;
+	String strip_edges(bool left = true, bool right = true) const;
+	String strip_escapes() const;
+	String lstrip(const String &p_chars) const;
+	String rstrip(const String &p_chars) const;
+	String get_extension() const;
+	String get_basename() const;
+	String path_join(const String &p_file) const;
+	char32_t unicode_at(int p_idx) const;
+
+	CharString ascii(bool p_allow_extended = false) const;
+	CharString utf8() const;
+	Error parse_utf8(const char *p_utf8, int p_len = -1, bool p_skip_cr = false);
+	static String utf8(const char *p_utf8, int p_len = -1);
+
+	Char16String utf16() const;
+	Error parse_utf16(const char16_t *p_utf16, int p_len = -1);
+	static String utf16(const char16_t *p_utf16, int p_len = -1);
+
+	static uint32_t hash(const char32_t *p_cstr, int p_len); /* hash the string */
+	static uint32_t hash(const char32_t *p_cstr); /* hash the string */
+	static uint32_t hash(const wchar_t *p_cstr, int p_len); /* hash the string */
+	static uint32_t hash(const wchar_t *p_cstr); /* hash the string */
+	static uint32_t hash(const char *p_cstr, int p_len); /* hash the string */
+	static uint32_t hash(const char *p_cstr); /* hash the string */
+	uint32_t hash() const; /* hash the string */
+	uint64_t hash64() const; /* hash the string */
+	String md5_text() const;
+	String sha1_text() const;
+	String sha256_text() const;
+	Vector<uint8_t> md5_buffer() const;
+	Vector<uint8_t> sha1_buffer() const;
+	Vector<uint8_t> sha256_buffer() const;
+
+	_FORCE_INLINE_ bool is_empty() const { return length() == 0; }
+	_FORCE_INLINE_ bool contains(const char *p_str) const { return find(p_str) != -1; }
+	_FORCE_INLINE_ bool contains(const String &p_str) const { return find(p_str) != -1; }
+
+	// path functions
+	bool is_absolute_path() const;
+	bool is_relative_path() const;
+	bool is_resource_file() const;
+	String path_to(const String &p_path) const;
+	String path_to_file(const String &p_path) const;
+	String get_base_dir() const;
+	String get_file() const;
+	static String humanize_size(uint64_t p_size);
+	String simplify_path() const;
+	bool is_network_share_path() const;
+
+	String xml_escape(bool p_escape_quotes = false) const;
+	String xml_unescape() const;
+	String uri_encode() const;
+	String uri_decode() const;
+	String c_escape() const;
+	String c_escape_multiline() const;
+	String c_unescape() const;
+	String json_escape() const;
+	Error parse_url(String &r_scheme, String &r_host, int &r_port, String &r_path) const;
+
+	String property_name_encode() const;
+
+	// node functions
+	static const String invalid_node_name_characters;
+	String validate_node_name() const;
+	String validate_identifier() const;
+	String validate_filename() const;
+
+	bool is_valid_identifier() const;
+	bool is_valid_int() const;
+	bool is_valid_float() const;
+	bool is_valid_hex_number(bool p_with_prefix) const;
+	bool is_valid_html_color() const;
+	bool is_valid_ip_address() const;
+	bool is_valid_filename() const;
+
+	/**
+	 * The constructors must not depend on other overloads
+	 */
+
+	_FORCE_INLINE_ String() {}
+	_FORCE_INLINE_ String(const String &p_str) { _cowdata._ref(p_str._cowdata); }
+	_FORCE_INLINE_ void operator=(const String &p_str) { _cowdata._ref(p_str._cowdata); }
+
+	Vector<uint8_t> to_ascii_buffer() const;
+	Vector<uint8_t> to_utf8_buffer() const;
+	Vector<uint8_t> to_utf16_buffer() const;
+	Vector<uint8_t> to_utf32_buffer() const;
+
+	String(const char *p_str);
+	String(const wchar_t *p_str);
+	String(const char32_t *p_str);
+	String(const char *p_str, int p_clip_to_len);
+	String(const wchar_t *p_str, int p_clip_to_len);
+	String(const char32_t *p_str, int p_clip_to_len);
+	String(const StrRange &p_range);
+};
+
+bool operator==(const char *p_chr, const String &p_str);
+bool operator==(const wchar_t *p_chr, const String &p_str);
+bool operator!=(const char *p_chr, const String &p_str);
+bool operator!=(const wchar_t *p_chr, const String &p_str);
+
+String operator+(const char *p_chr, const String &p_str);
+String operator+(const wchar_t *p_chr, const String &p_str);
+String operator+(char32_t p_chr, const String &p_str);
+
+String itos(int64_t p_val);
+String uitos(uint64_t p_val);
+String rtos(double p_val);
+String rtoss(double p_val); //scientific version
+
+struct NoCaseComparator {
+	bool operator()(const String &p_a, const String &p_b) const {
+		return p_a.nocasecmp_to(p_b) < 0;
+	}
+};
+
+struct NaturalNoCaseComparator {
+	bool operator()(const String &p_a, const String &p_b) const {
+		return p_a.naturalnocasecmp_to(p_b) < 0;
+	}
+};
+
+template <typename L, typename R>
+_FORCE_INLINE_ bool is_str_less(const L *l_ptr, const R *r_ptr) {
+	while (true) {
+		const char32_t l = *l_ptr;
+		const char32_t r = *r_ptr;
+
+		if (l == 0 && r == 0) {
+			return false;
+		} else if (l == 0) {
+			return true;
+		} else if (r == 0) {
+			return false;
+		} else if (l < r) {
+			return true;
+		} else if (l > r) {
+			return false;
+		}
+
+		l_ptr++;
+		r_ptr++;
+	}
+}
+
+/* end of namespace */
+
+// Tool translate (TTR and variants) for the editor UI,
+// and doc translate for the class reference (DTR).
+#ifdef TOOLS_ENABLED
+// Gets parsed.
+String TTR(const String &p_text, const String &p_context = "");
+String TTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
+String DTR(const String &p_text, const String &p_context = "");
+String DTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
+// Use for C strings.
+#define TTRC(m_value) (m_value)
+// Use to avoid parsing (for use later with C strings).
+#define TTRGET(m_value) TTR(m_value)
+
+#else
+#define TTRC(m_value) (m_value)
+#define TTRGET(m_value) (m_value)
+#endif
+
+// Use this to mark property names for editor translation.
+// Often for dynamic properties defined in _get_property_list().
+// Property names defined directly inside EDITOR_DEF, GLOBAL_DEF, and ADD_PROPERTY macros don't need this.
+#define PNAME(m_value) (m_value)
+
+// Similar to PNAME, but to mark groups, i.e. properties with PROPERTY_USAGE_GROUP.
+// Groups defined directly inside ADD_GROUP macros don't need this.
+// The arguments are the same as ADD_GROUP. m_prefix is only used for extraction.
+#define GNAME(m_value, m_prefix) (m_value)
+
+// Runtime translate for the public node API.
+String RTR(const String &p_text, const String &p_context = "");
+String RTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
+
+bool select_word(const String &p_s, int p_col, int &r_beg, int &r_end);
+
+_FORCE_INLINE_ void sarray_add_str(Vector<String> &arr) {
+}
+
+_FORCE_INLINE_ void sarray_add_str(Vector<String> &arr, const String &p_str) {
+	arr.push_back(p_str);
+}
+
+template <class... P>
+_FORCE_INLINE_ void sarray_add_str(Vector<String> &arr, const String &p_str, P... p_args) {
+	arr.push_back(p_str);
+	sarray_add_str(arr, p_args...);
+}
+
+template <class... P>
+_FORCE_INLINE_ Vector<String> sarray(P... p_args) {
+	Vector<String> arr;
+	sarray_add_str(arr, p_args...);
+	return arr;
+}
+
+#endif // USTRING_GODOT_H


### PR DESCRIPTION
It needs patched `ustring.cpp` and `ustring.h` on [a7d0e1](/godotengine/godot/commit/a7d0e1). I put modded versions to the patches folder. This seems to work in general but I saw unexplained 1 byte defference that modifies `Dictionary` to explicit type when recompiled. IDK what causes that, I'm not that well versed in Godot. It'd be nice if someone who knows their GDScript checks it later.

This also ignores non-critical utf-8 errors during decompilation. There were games before that had unpaired surrogate error while properly decompiling if it's ignored.