### PR TITLE
Fix incorrect file offsets when exporting PCK

### DIFF
--- a/editor/gdre_editor.cpp
+++ b/editor/gdre_editor.cpp
@@ -1291,7 +1291,7 @@ uint64_t GodotREEditor::_pck_create_process_folder(EditorProgressGDDC *p_pr, con
 			finfo.instantiate();
 
 			String name = p_rel.path_join(f);
-			finfo->init(p_path, name, p_offset, file->get_length(), hash, nullptr, flags == (1 << 0));
+			finfo->init(p_path, name, offset, file->get_length(), hash, nullptr, flags == (1 << 0));
 
 			pck_save_files.push_back(finfo);
 


### PR DESCRIPTION
rn it uses the argument thats passed to the function instead of the local thats actually updated  lol
ive tested this change with one game im REing and can confirm that it has fixed my issue