### PR TITLE
fix: specify UTF-8 encoding when reading .csproj file on Windows

### DIFF
--- a/build/mono_decomp.py
+++ b/build/mono_decomp.py
@@ -49,7 +49,7 @@ def get_godot_mono_decomp_lib_dir(godot_mono_decomp_dir, target_platform, target
     triplet = get_godot_mono_triplet(target_platform, target_arch)
     target_framework = "net9.0"
     csproj_path = os.path.join(godot_mono_decomp_dir, "GodotMonoDecompNativeAOT.csproj")
-    with open(csproj_path, "r") as csproj_file:
+    with open(csproj_path, "r", encoding="utf-8") as csproj_file:
         for line in csproj_file:
             if "TargetFramework" in line:
                 target_framework = line.split(">")[1].split("<")[0].strip()


### PR DESCRIPTION
## Problem
On Windows systems with non-UTF-8 locale (e.g. Simplified Chinese using GBK),
building with `scons platform=windows` fails with:
```bash
UnicodeDecodeError: 'gbk' codec can't decode byte 0xbf in position 2: illegal multibyte sequence:
  File "modules/gdsdecomp/build/mono_decomp.py", line 53:
    for line in csproj_file:
```
This happens because `open()` without an explicit encoding falls back to the
system default (GBK on Chinese Windows), but the .csproj file is UTF-8 encoded.

## Fix
Explicitly set `encoding="utf-8"` in the `open()` call for .csproj files.